### PR TITLE
feat(commands): implement hostInfo and getCmdLineOpts commands (#37, #38)

### DIFF
--- a/internal/commands/diagnostic.go
+++ b/internal/commands/diagnostic.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"time"
 
@@ -237,6 +238,66 @@ func handleFeatures(_ *Context, _ bson.Raw) (bson.Raw, error) {
 // handleLogout handles the "logout" command.
 func handleLogout(_ *Context, _ bson.Raw) (bson.Raw, error) {
 	return BuildOKResponse(), nil
+}
+
+// handleHostInfo handles the "hostInfo" command.
+// Returns system, OS, and CPU information about the host running the server.
+func handleHostInfo(_ *Context, _ bson.Raw) (bson.Raw, error) {
+	hostname, _ := os.Hostname()
+	now := time.Now().UTC()
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	memSizeMB := int64(ms.Sys) / (1024 * 1024)
+
+	// Map GOOS to MongoDB's OS type convention.
+	osType := runtime.GOOS
+	switch runtime.GOOS {
+	case "linux":
+		osType = "Linux"
+	case "darwin":
+		osType = "Darwin"
+	case "windows":
+		osType = "Windows"
+	}
+
+	// Determine pointer size: 32 on 32-bit builds, 64 on 64-bit builds.
+	cpuAddrSize := int32(32 << (^uint(0) >> 63))
+
+	return marshalResponse(bson.D{
+		{Key: "system", Value: bson.D{
+			{Key: "currentTime", Value: bson.DateTime(now.UnixMilli())},
+			{Key: "hostname", Value: hostname},
+			{Key: "cpuAddrSize", Value: cpuAddrSize},
+			{Key: "memSizeMB", Value: memSizeMB},
+			{Key: "memLimitMB", Value: memSizeMB},
+			{Key: "numCores", Value: int32(runtime.NumCPU())},
+			{Key: "cpuArch", Value: runtime.GOARCH},
+			{Key: "numaEnabled", Value: false},
+		}},
+		{Key: "os", Value: bson.D{
+			{Key: "type", Value: osType},
+			{Key: "name", Value: fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)},
+			{Key: "version", Value: "unknown"},
+		}},
+		{Key: "extra", Value: bson.D{}},
+		{Key: "ok", Value: float64(1)},
+	}), nil
+}
+
+// handleGetCmdLineOpts handles the "getCmdLineOpts" command.
+// Returns the command line arguments the server was started with.
+func handleGetCmdLineOpts(_ *Context, _ bson.Raw) (bson.Raw, error) {
+	argv := bson.A{}
+	for _, arg := range os.Args {
+		argv = append(argv, arg)
+	}
+
+	return marshalResponse(bson.D{
+		{Key: "argv", Value: argv},
+		{Key: "parsed", Value: bson.D{}},
+		{Key: "ok", Value: float64(1)},
+	}), nil
 }
 
 // handleExplain handles the "explain" command.

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -117,6 +117,10 @@ func (d *Dispatcher) registerAll() {
 	d.register("features", handleFeatures)
 	d.register("logout", handleLogout)
 	d.register("explain", handleExplain)
+	d.register("hostinfo", handleHostInfo)
+	d.register("hostInfo", handleHostInfo)
+	d.register("getcmdlineopts", handleGetCmdLineOpts)
+	d.register("getCmdLineOpts", handleGetCmdLineOpts)
 
 	// Auth
 	d.register("saslstart", handleSASLStart)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -2766,6 +2766,80 @@ func TestTypeFilter(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// hostInfo command
+// ---------------------------------------------------------------------------
+
+func TestHostInfo(t *testing.T) {
+	ctx := context.Background()
+	client := newClient(t)
+
+	var result bson.M
+	err := client.Database("admin").RunCommand(ctx, bson.D{{Key: "hostInfo", Value: 1}}).Decode(&result)
+	if err != nil {
+		t.Fatalf("hostInfo: %v", err)
+	}
+
+	if result["ok"].(float64) != 1 {
+		t.Errorf("hostInfo: expected ok=1, got %v", result["ok"])
+	}
+
+	system, ok := result["system"].(bson.M)
+	if !ok {
+		t.Fatalf("hostInfo: missing or invalid 'system' field")
+	}
+	if _, ok := system["hostname"]; !ok {
+		t.Error("hostInfo: 'system.hostname' field missing")
+	}
+	if _, ok := system["numCores"]; !ok {
+		t.Error("hostInfo: 'system.numCores' field missing")
+	}
+	if _, ok := system["cpuAddrSize"]; !ok {
+		t.Error("hostInfo: 'system.cpuAddrSize' field missing")
+	}
+	if _, ok := system["currentTime"]; !ok {
+		t.Error("hostInfo: 'system.currentTime' field missing")
+	}
+
+	if _, ok := result["os"]; !ok {
+		t.Error("hostInfo: 'os' field missing")
+	}
+	if _, ok := result["extra"]; !ok {
+		t.Error("hostInfo: 'extra' field missing")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getCmdLineOpts command
+// ---------------------------------------------------------------------------
+
+func TestGetCmdLineOpts(t *testing.T) {
+	ctx := context.Background()
+	client := newClient(t)
+
+	var result bson.M
+	err := client.Database("admin").RunCommand(ctx, bson.D{{Key: "getCmdLineOpts", Value: 1}}).Decode(&result)
+	if err != nil {
+		t.Fatalf("getCmdLineOpts: %v", err)
+	}
+
+	if result["ok"].(float64) != 1 {
+		t.Errorf("getCmdLineOpts: expected ok=1, got %v", result["ok"])
+	}
+
+	argv, ok := result["argv"].(bson.A)
+	if !ok {
+		t.Fatalf("getCmdLineOpts: missing or invalid 'argv' field")
+	}
+	if len(argv) == 0 {
+		t.Error("getCmdLineOpts: 'argv' must be non-empty")
+	}
+
+	if _, ok := result["parsed"]; !ok {
+		t.Error("getCmdLineOpts: 'parsed' field missing")
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())


### PR DESCRIPTION
## Agent Identity

\`\`\`yaml
agent:
  id: "cursor-duoman"
  type: "cursor"
  model: "claude-4.6-sonnet-medium-thinking"
  operator: "manuduo"
  trust_tier: "newcomer"
  capabilities:
    - "go-development"
    - "test-writing"
\`\`\`

## Issue

Closes #37
Closes #38

## What Changed

**`internal/commands/diagnostic.go`**
- Added `handleHostInfo`: returns system hostname (`os.Hostname`), CPU core count (`runtime.NumCPU`), pointer width (32/64), estimated memory from `runtime.MemStats.Sys`, OS type/name from `runtime.GOOS`/`runtime.GOARCH`, and current server time — matching the MongoDB `hostInfo` wire-protocol response format
- Added `handleGetCmdLineOpts`: returns `os.Args` as `argv` and an empty `parsed` document, matching MongoDB's `getCmdLineOpts` response format
- Added `"os"` import (needed by both new handlers)

**`internal/commands/dispatcher.go`**
- Registered both handlers under their canonical and lowercase aliases: `hostInfo`/`hostinfo`, `getCmdLineOpts`/`getcmdlineopts`

**`tests/integration_test.go`**
- `TestHostInfo`: runs `hostInfo` via `RunCommand`, asserts `ok=1`, presence of `system.hostname`, `system.numCores`, `system.cpuAddrSize`, `system.currentTime`, `os`, and `extra`
- `TestGetCmdLineOpts`: runs `getCmdLineOpts` via `RunCommand`, asserts `ok=1`, non-empty `argv`, and presence of `parsed`

## Risk Assessment

- [x] Low risk: additive only — two new handler functions and dispatcher registrations; no existing handler or storage path modified

## Test Plan

- [x] `make build` passes
- [x] `make test` passes (unit)
- [x] Integration tests added: `TestHostInfo`, `TestGetCmdLineOpts`
- [ ] `make lint` — golangci-lint not installed locally; no style issues expected (follows existing patterns exactly)