### PR TITLE
fix(query): reject fractional $size args; add unit+integration tests for $size and $all (#17, #20)

### DIFF
--- a/internal/query/filter.go
+++ b/internal/query/filter.go
@@ -603,10 +603,14 @@ func evalElemMatch(doc bson.Raw, fieldVal bson.RawValue, opVal bson.RawValue) (b
 }
 
 // evalSize checks the array field's length matches opVal.
+// MongoDB requires the argument to be a whole number; fractional values are an error.
 func evalSize(fieldVal bson.RawValue, opVal bson.RawValue) (bool, error) {
 	size, ok := toFloat64(opVal)
 	if !ok {
 		return false, fmt.Errorf("$size requires numeric argument")
+	}
+	if size != math.Trunc(size) || size < 0 {
+		return false, fmt.Errorf("$size must be a non-negative integer, got %v", size)
 	}
 	if fieldVal.Type != bson.TypeArray {
 		return false, nil
@@ -615,7 +619,7 @@ func evalSize(fieldVal bson.RawValue, opVal bson.RawValue) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return float64(len(vals)) == size, nil
+	return int64(len(vals)) == int64(size), nil
 }
 
 // evalBits handles bitwise operators on integer fields.

--- a/internal/query/filter_test.go
+++ b/internal/query/filter_test.go
@@ -1,0 +1,201 @@
+package query
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// mustMarshal marshals a bson.D to bson.Raw, panicking on failure.
+func mustMarshal(d bson.D) bson.Raw {
+	raw, err := bson.Marshal(d)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
+// ─── $size ────────────────────────────────────────────────────────────────────
+
+func TestEvalSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		doc       bson.D
+		filter    bson.D
+		wantMatch bool
+		wantErr   bool
+	}{
+		{
+			name:      "exact match 3 elements",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"a", "b", "c"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$size", Value: 3}}}},
+			wantMatch: true,
+		},
+		{
+			name:      "wrong count",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"a", "b"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$size", Value: 3}}}},
+			wantMatch: false,
+		},
+		{
+			name:      "empty array matches $size 0",
+			doc:       bson.D{{Key: "tags", Value: bson.A{}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$size", Value: 0}}}},
+			wantMatch: true,
+		},
+		{
+			name:      "empty array does not match $size 1",
+			doc:       bson.D{{Key: "tags", Value: bson.A{}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$size", Value: 1}}}},
+			wantMatch: false,
+		},
+		{
+			name:      "non-array field never matches",
+			doc:       bson.D{{Key: "name", Value: "alice"}},
+			filter:    bson.D{{Key: "name", Value: bson.D{{Key: "$size", Value: 1}}}},
+			wantMatch: false,
+		},
+		{
+			name:      "missing field never matches",
+			doc:       bson.D{{Key: "other", Value: 1}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$size", Value: 0}}}},
+			wantMatch: false,
+		},
+		{
+			name:      "float with fractional part is rejected",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"a", "b"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$size", Value: 2.5}}}},
+			wantMatch: false,
+			wantErr:   true,
+		},
+		{
+			name:      "negative integer is rejected",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"a"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$size", Value: int32(-1)}}}},
+			wantMatch: false,
+			wantErr:   true,
+		},
+		{
+			name:      "whole-number float is accepted",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"a", "b"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$size", Value: 2.0}}}},
+			wantMatch: true,
+		},
+		{
+			name:      "int64 argument accepted",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"x"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$size", Value: int64(1)}}}},
+			wantMatch: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			match, err := Filter(mustMarshal(tc.doc), mustMarshal(tc.filter))
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if match != tc.wantMatch {
+				t.Errorf("got match=%v, want %v", match, tc.wantMatch)
+			}
+		})
+	}
+}
+
+// ─── $all ─────────────────────────────────────────────────────────────────────
+
+func TestEvalAll(t *testing.T) {
+	tests := []struct {
+		name      string
+		doc       bson.D
+		filter    bson.D
+		wantMatch bool
+		wantErr   bool
+	}{
+		{
+			name:      "all elements present",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"ssl", "security", "network"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$all", Value: bson.A{"ssl", "security"}}}}},
+			wantMatch: true,
+		},
+		{
+			name:      "one element missing",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"ssl", "network"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$all", Value: bson.A{"ssl", "security"}}}}},
+			wantMatch: false,
+		},
+		{
+			name:      "exact single-element match on scalar",
+			doc:       bson.D{{Key: "status", Value: "active"}},
+			filter:    bson.D{{Key: "status", Value: bson.D{{Key: "$all", Value: bson.A{"active"}}}}},
+			wantMatch: true,
+		},
+		{
+			name:      "scalar field, multiple required values — no match",
+			doc:       bson.D{{Key: "status", Value: "active"}},
+			filter:    bson.D{{Key: "status", Value: bson.D{{Key: "$all", Value: bson.A{"active", "other"}}}}},
+			wantMatch: false,
+		},
+		{
+			name:      "empty $all array never matches",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"a", "b"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$all", Value: bson.A{}}}}},
+			wantMatch: false,
+		},
+		{
+			name:      "missing field does not match",
+			doc:       bson.D{{Key: "other", Value: 1}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$all", Value: bson.A{"a"}}}}},
+			wantMatch: false,
+		},
+		{
+			name:      "order of required elements does not matter",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"c", "a", "b"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$all", Value: bson.A{"b", "a"}}}}},
+			wantMatch: true,
+		},
+		{
+			name:      "$all requires array operand",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"a"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$all", Value: "a"}}}},
+			wantMatch: false,
+			wantErr:   true,
+		},
+		{
+			name:      "numeric values",
+			doc:       bson.D{{Key: "scores", Value: bson.A{int32(1), int32(2), int32(3)}}},
+			filter:    bson.D{{Key: "scores", Value: bson.D{{Key: "$all", Value: bson.A{int32(1), int32(3)}}}}},
+			wantMatch: true,
+		},
+		{
+			name:      "all elements required including extra",
+			doc:       bson.D{{Key: "tags", Value: bson.A{"a", "b"}}},
+			filter:    bson.D{{Key: "tags", Value: bson.D{{Key: "$all", Value: bson.A{"a", "b", "c"}}}}},
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			match, err := Filter(mustMarshal(tc.doc), mustMarshal(tc.filter))
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if match != tc.wantMatch {
+				t.Errorf("got match=%v, want %v", match, tc.wantMatch)
+			}
+		})
+	}
+}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -2766,6 +2766,96 @@ func TestTypeFilter(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// $size query operator
+// ---------------------------------------------------------------------------
+
+func TestSizeOperator(t *testing.T) {
+	ctx := context.Background()
+	client := newClient(t)
+	coll := client.Database(testDB(t)).Collection("docs")
+
+	coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "_id", Value: 1}, {Key: "tags", Value: bson.A{}}},
+		bson.D{{Key: "_id", Value: 2}, {Key: "tags", Value: bson.A{"a"}}},
+		bson.D{{Key: "_id", Value: 3}, {Key: "tags", Value: bson.A{"a", "b"}}},
+		bson.D{{Key: "_id", Value: 4}, {Key: "tags", Value: bson.A{"a", "b", "c"}}},
+		bson.D{{Key: "_id", Value: 5}, {Key: "name", Value: "no-tags"}},
+	})
+
+	cases := []struct {
+		label string
+		size  interface{}
+		want  int
+	}{
+		{"size 0", 0, 1},
+		{"size 1", 1, 1},
+		{"size 2", int32(2), 1},
+		{"size 3", int64(3), 1},
+		{"size 4", 4, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			n, err := coll.CountDocuments(ctx, bson.D{{Key: "tags", Value: bson.D{{Key: "$size", Value: tc.size}}}})
+			if err != nil {
+				t.Fatalf("$size %v: %v", tc.size, err)
+			}
+			if int(n) != tc.want {
+				t.Errorf("$size %v: expected %d docs, got %d", tc.size, tc.want, n)
+			}
+		})
+	}
+
+	// Fractional argument must return an error.
+	_, err := coll.CountDocuments(ctx, bson.D{{Key: "tags", Value: bson.D{{Key: "$size", Value: 2.5}}}})
+	if err == nil {
+		t.Error("$size 2.5: expected error for fractional argument, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// $all query operator
+// ---------------------------------------------------------------------------
+
+func TestAllOperator(t *testing.T) {
+	ctx := context.Background()
+	client := newClient(t)
+	coll := client.Database(testDB(t)).Collection("docs")
+
+	coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "_id", Value: 1}, {Key: "tags", Value: bson.A{"ssl", "security", "network"}}},
+		bson.D{{Key: "_id", Value: 2}, {Key: "tags", Value: bson.A{"ssl", "network"}}},
+		bson.D{{Key: "_id", Value: 3}, {Key: "tags", Value: bson.A{"security"}}},
+		bson.D{{Key: "_id", Value: 4}, {Key: "tags", Value: bson.A{}}},
+	})
+
+	cases := []struct {
+		label string
+		all   bson.A
+		want  int
+	}{
+		{"ssl+security", bson.A{"ssl", "security"}, 1},
+		{"ssl only", bson.A{"ssl"}, 2},
+		{"all three", bson.A{"ssl", "security", "network"}, 1},
+		{"missing element", bson.A{"missing"}, 0},
+		{"empty $all", bson.A{}, 0},
+		{"reversed order", bson.A{"network", "ssl"}, 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			n, err := coll.CountDocuments(ctx, bson.D{{Key: "tags", Value: bson.D{{Key: "$all", Value: tc.all}}}})
+			if err != nil {
+				t.Fatalf("$all %v: %v", tc.all, err)
+			}
+			if int(n) != tc.want {
+				t.Errorf("$all %v: expected %d docs, got %d", tc.all, tc.want, n)
+			}
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())


### PR DESCRIPTION
## Agent Identity

\`\`\`yaml
agent:
  id: "cursor-duoman"
  type: "cursor"
  model: "claude-4.6-sonnet-medium-thinking"
  operator: "manuduo"
  trust_tier: "newcomer"
  capabilities:
    - "go-development"
    - "test-writing"
\`\`\`

## Issue

Closes #17
Closes #20

## What Changed

**`internal/query/filter.go` — bug fix**
- `evalSize`: added validation that rejects fractional (e.g. `2.5`) and negative arguments with an error, matching MongoDB's behaviour: *"$size must be a non-negative integer"*. Previously any numeric value was silently accepted, meaning `{$size: 2.5}` would never match (2.5 ≠ len(arr)) but would not error. Changed the final comparison from `float64` to `int64` to avoid floating-point precision edge cases.

**`internal/query/filter_test.go` — new file (first unit tests for the query package)**
- `TestEvalSize`: 10 table-driven cases — exact match, wrong count, empty array, non-array field, missing field, fractional arg (error), negative arg (error), whole-number float, int64 arg, int32 arg.
- `TestEvalAll`: 10 table-driven cases — subset match, missing element, empty `$all` (no match), order independence, scalar field single/multi required, numeric values, extra required element, non-array operand (error).

**`tests/integration_test.go` — new integration tests**
- `TestSizeOperator`: inserts 5 docs with 0–3-element `tags` arrays + one without `tags`; verifies counts for sizes 0–4; asserts fractional arg returns an error.
- `TestAllOperator`: 6 table-driven cases exercising subset, full set, missing element, empty `$all`, and order independence.

## Why

- `$size` was silently accepting fractional arguments instead of erroring per MongoDB spec — a correctness bug.
- Neither `$size` nor `$all` had dedicated unit or integration tests despite being fully implemented. This PR completes the acceptance criteria for both issues.

## Risk Assessment

- [x] Low risk: one-line logic fix in `evalSize` (adds a guard before the existing comparison); all other changes are additive tests

## Test Plan

- [x] `make build` passes
- [x] `make test` passes — `ok github.com/inder/salvobase/internal/query` (20 new unit tests)
- [x] Unit tests added: `TestEvalSize` (10 cases), `TestEvalAll` (10 cases)
- [x] Integration tests added: `TestSizeOperator`, `TestAllOperator`