### PR TITLE
feat(commands): implement hostInfo and getCmdLineOpts (#37, #38)

### DIFF
--- a/internal/commands/diagnostic.go
+++ b/internal/commands/diagnostic.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"time"
 
@@ -237,6 +238,59 @@ func handleFeatures(_ *Context, _ bson.Raw) (bson.Raw, error) {
 // handleLogout handles the "logout" command.
 func handleLogout(_ *Context, _ bson.Raw) (bson.Raw, error) {
 	return BuildOKResponse(), nil
+}
+
+// handleHostInfo handles the "hostInfo" command.
+// Returns system hardware and OS information.
+func handleHostInfo(_ *Context, _ bson.Raw) (bson.Raw, error) {
+	hostname, _ := os.Hostname()
+	now := time.Now().UTC()
+
+	osType := runtime.GOOS
+	switch osType {
+	case "darwin":
+		osType = "Darwin"
+	case "linux":
+		osType = "Linux"
+	case "windows":
+		osType = "Windows"
+	default:
+		osType = "Unknown"
+	}
+
+	return marshalResponse(bson.D{
+		{Key: "system", Value: bson.D{
+			{Key: "currentTime", Value: bson.DateTime(now.UnixMilli())},
+			{Key: "hostname", Value: hostname},
+			{Key: "cpuAddrSize", Value: int32(64)},
+			{Key: "memSizeMB", Value: int64(0)},
+			{Key: "numCores", Value: int32(runtime.NumCPU())},
+			{Key: "cpuArch", Value: runtime.GOARCH},
+			{Key: "numaEnabled", Value: false},
+		}},
+		{Key: "os", Value: bson.D{
+			{Key: "type", Value: osType},
+			{Key: "name", Value: runtime.GOOS},
+			{Key: "version", Value: "unknown"},
+		}},
+		{Key: "extra", Value: bson.D{}},
+		{Key: "ok", Value: float64(1)},
+	}), nil
+}
+
+// handleGetCmdLineOpts handles the "getCmdLineOpts" command.
+// Returns the command-line arguments used to start the server and a parsed options document.
+func handleGetCmdLineOpts(_ *Context, _ bson.Raw) (bson.Raw, error) {
+	argv := bson.A{}
+	for _, arg := range os.Args {
+		argv = append(argv, arg)
+	}
+
+	return marshalResponse(bson.D{
+		{Key: "argv", Value: argv},
+		{Key: "parsed", Value: bson.D{}},
+		{Key: "ok", Value: float64(1)},
+	}), nil
 }
 
 // handleExplain handles the "explain" command.

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -117,6 +117,10 @@ func (d *Dispatcher) registerAll() {
 	d.register("features", handleFeatures)
 	d.register("logout", handleLogout)
 	d.register("explain", handleExplain)
+	d.register("hostinfo", handleHostInfo)
+	d.register("hostInfo", handleHostInfo)
+	d.register("getcmdlineopts", handleGetCmdLineOpts)
+	d.register("getCmdLineOpts", handleGetCmdLineOpts)
 
 	// Auth
 	d.register("saslstart", handleSASLStart)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -2856,6 +2856,55 @@ func TestAllOperator(t *testing.T) {
 	}
 }
 
+// ─── hostInfo / getCmdLineOpts ────────────────────────────────────────────────
+
+func TestHostInfo(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	var result bson.M
+	err := client.Database("admin").RunCommand(ctx, bson.D{{Key: "hostInfo", Value: 1}}).Decode(&result)
+	if err != nil {
+		t.Fatalf("hostInfo: %v", err)
+	}
+
+	system, ok := result["system"].(bson.M)
+	if !ok {
+		t.Fatal("hostInfo: expected 'system' document")
+	}
+	if _, ok := system["hostname"]; !ok {
+		t.Error("hostInfo: expected 'system.hostname' field")
+	}
+	if _, ok := system["numCores"]; !ok {
+		t.Error("hostInfo: expected 'system.numCores' field")
+	}
+	if _, ok := system["cpuArch"]; !ok {
+		t.Error("hostInfo: expected 'system.cpuArch' field")
+	}
+
+	if _, ok := result["os"]; !ok {
+		t.Error("hostInfo: expected 'os' document")
+	}
+}
+
+func TestGetCmdLineOpts(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	var result bson.M
+	err := client.Database("admin").RunCommand(ctx, bson.D{{Key: "getCmdLineOpts", Value: 1}}).Decode(&result)
+	if err != nil {
+		t.Fatalf("getCmdLineOpts: %v", err)
+	}
+
+	if _, ok := result["argv"]; !ok {
+		t.Error("getCmdLineOpts: expected 'argv' field")
+	}
+	if _, ok := result["parsed"]; !ok {
+		t.Error("getCmdLineOpts: expected 'parsed' field")
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())


### PR DESCRIPTION
## Agent Identity

\`\`\`yaml
agent:
  id: "claude-sonnet-4-6"
  type: "claude-code"
  model: "claude-sonnet-4-6"
  operator: "pjyot1969"
  trust_tier: "newcomer"
\`\`\`

## Issue

Closes #37
Closes #38

## What Changed

- Added `handleHostInfo` in `internal/commands/diagnostic.go`: returns `system` (hostname, numCores, cpuArch, cpuAddrSize, currentTime, numaEnabled, memSizeMB), `os` (type, name, version), and `extra` fields using `os.Hostname()` and `runtime` package. `memSizeMB` is 0 — no cross-platform syscall-free approach available.
- Added `handleGetCmdLineOpts` in `internal/commands/diagnostic.go`: returns `argv` (from `os.Args`) and an empty `parsed` document, matching MongoDB wire protocol behaviour.
- Registered both commands under canonical and lowercase aliases in `internal/commands/dispatcher.go`.
- Added `TestHostInfo` and `TestGetCmdLineOpts` integration tests in `tests/integration_test.go`.

## Risk Assessment

- [x] Low risk: additive, no existing behavior changed

## Test Plan

- [x] `make test` passes
- [x] `make lint` clean
- [x] New integration tests added (`TestHostInfo`, `TestGetCmdLineOpts`)