### PR TITLE
tests(compat): array ops, update ops, aggregation, findAndModify edge cases (#21 #22 #23 #24)

### DIFF
--- a/tests/compat_edge_cases_test.go
+++ b/tests/compat_edge_cases_test.go
@@ -659,3 +659,681 @@ func getFieldValue(doc bson.D, key string) interface{} {
 	}
 	return nil
 }
+
+// ─── Array Query Operator Edge Cases (#21) ────────────────────────────────────
+
+// TestCompatInWithEmptyArray verifies that $in:[] matches no documents.
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/query/in/
+func TestCompatInWithEmptyArray(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_in_empty")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "x", Value: 1}},
+		bson.D{{Key: "x", Value: 2}},
+	})
+
+	cursor, err := coll.Find(ctx, bson.D{{Key: "x", Value: bson.D{{Key: "$in", Value: bson.A{}}}}})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("$in:[] should match nothing, got %d document(s)", len(results))
+	}
+}
+
+// TestCompatNinWithEmptyArray verifies that $nin:[] matches all documents.
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/query/nin/
+func TestCompatNinWithEmptyArray(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_nin_empty")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "x", Value: 1}},
+		bson.D{{Key: "x", Value: 2}},
+		bson.D{{Key: "x", Value: 3}},
+	})
+
+	cursor, err := coll.Find(ctx, bson.D{{Key: "x", Value: bson.D{{Key: "$nin", Value: bson.A{}}}}})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 3 {
+		t.Errorf("$nin:[] should match all 3 documents, got %d", len(results))
+	}
+}
+
+// TestCompatArrayFieldMatchesScalar verifies that querying a scalar value
+// against an array field matches if the value is an element of the array.
+// Ref: https://www.mongodb.com/docs/manual/tutorial/query-arrays/
+func TestCompatArrayFieldMatchesScalar(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_arr_scalar")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "tags", Value: bson.A{"admin", "user"}}},
+		bson.D{{Key: "tags", Value: bson.A{"user"}}},
+		bson.D{{Key: "tags", Value: bson.A{"moderator"}}},
+	})
+
+	cursor, err := coll.Find(ctx, bson.D{{Key: "tags", Value: "admin"}})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 document with 'admin' tag, got %d", len(results))
+	}
+}
+
+// TestCompatInWithNull verifies that $in with null matches documents where
+// the field is null or missing.
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/query/in/
+func TestCompatInWithNull(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_in_null")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "val", Value: nil}},           // explicit null
+		bson.D{{Key: "other", Value: "no val key"}}, // missing field
+		bson.D{{Key: "val", Value: 42}},
+	})
+
+	cursor, err := coll.Find(ctx, bson.D{{Key: "val", Value: bson.D{{Key: "$in", Value: bson.A{nil}}}}})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	// Both null value and missing field should match $in:[null].
+	if len(results) != 2 {
+		t.Errorf("$in:[null] should match 2 documents (null + missing), got %d", len(results))
+	}
+}
+
+// TestCompatNestedArrayDotNotation verifies dot-notation queries into nested arrays.
+// Ref: https://www.mongodb.com/docs/manual/core/document/#dot-notation
+func TestCompatNestedArrayDotNotation(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_nested_arr")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "items", Value: bson.A{
+			bson.D{{Key: "name", Value: "apple"}, {Key: "qty", Value: 5}},
+			bson.D{{Key: "name", Value: "banana"}, {Key: "qty", Value: 3}},
+		}}},
+		bson.D{{Key: "items", Value: bson.A{
+			bson.D{{Key: "name", Value: "cherry"}, {Key: "qty", Value: 10}},
+		}}},
+	})
+
+	// Query using dot notation into array subdocuments.
+	cursor, err := coll.Find(ctx, bson.D{{Key: "items.name", Value: "apple"}})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 document with items.name='apple', got %d", len(results))
+	}
+}
+
+// ─── Update Operator Edge Cases (#22) ────────────────────────────────────────
+
+// TestCompatSetDotNotation verifies $set with dot notation creates nested structure.
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/update/set/
+func TestCompatSetDotNotation(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_set_dot")
+	ctx := context.Background()
+
+	_, _ = coll.InsertOne(ctx, bson.D{{Key: "name", Value: "alice"}})
+
+	_, err := coll.UpdateOne(ctx,
+		bson.D{{Key: "name", Value: "alice"}},
+		bson.D{{Key: "$set", Value: bson.D{{Key: "address.city", Value: "portland"}}}},
+	)
+	if err != nil {
+		t.Fatalf("UpdateOne: %v", err)
+	}
+
+	var doc bson.D
+	if err := coll.FindOne(ctx, bson.D{{Key: "name", Value: "alice"}}).Decode(&doc); err != nil {
+		t.Fatalf("FindOne: %v", err)
+	}
+	addr := getFieldValue(doc, "address")
+	if addr == nil {
+		t.Fatal("$set dot notation: expected 'address' field to be created")
+	}
+	addrDoc, ok := addr.(bson.D)
+	if !ok {
+		t.Fatalf("address should be bson.D, got %T", addr)
+	}
+	city := getFieldValue(addrDoc, "city")
+	if city != "portland" {
+		t.Errorf("address.city: expected 'portland', got %v", city)
+	}
+}
+
+// TestCompatUnsetNonexistentField verifies that $unset on a missing field
+// is a no-op (not an error).
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/update/unset/
+func TestCompatUnsetNonexistentField(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_unset_missing")
+	ctx := context.Background()
+
+	_, _ = coll.InsertOne(ctx, bson.D{{Key: "x", Value: 1}})
+
+	_, err := coll.UpdateOne(ctx,
+		bson.D{{Key: "x", Value: 1}},
+		bson.D{{Key: "$unset", Value: bson.D{{Key: "nonexistent", Value: ""}}}},
+	)
+	if err != nil {
+		t.Errorf("$unset on nonexistent field should not error, got: %v", err)
+	}
+}
+
+// TestCompatAddToSetNoDuplicate verifies $addToSet does not add a value
+// already present in the array.
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/update/addToSet/
+func TestCompatAddToSetNoDuplicate(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_addtoset_dup")
+	ctx := context.Background()
+
+	_, _ = coll.InsertOne(ctx, bson.D{{Key: "tags", Value: bson.A{"a", "b", "c"}}})
+
+	_, err := coll.UpdateOne(ctx,
+		bson.D{},
+		bson.D{{Key: "$addToSet", Value: bson.D{{Key: "tags", Value: "b"}}}},
+	)
+	if err != nil {
+		t.Fatalf("UpdateOne: %v", err)
+	}
+
+	var doc bson.D
+	if err := coll.FindOne(ctx, bson.D{}).Decode(&doc); err != nil {
+		t.Fatalf("FindOne: %v", err)
+	}
+	tags, ok := getFieldValue(doc, "tags").(bson.A)
+	if !ok {
+		t.Fatalf("tags should be array, got %T", getFieldValue(doc, "tags"))
+	}
+	if len(tags) != 3 {
+		t.Errorf("$addToSet duplicate: expected 3 elements, got %d", len(tags))
+	}
+}
+
+// TestCompatIncWithFloat verifies $inc with a float value increments correctly.
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/update/inc/
+func TestCompatIncWithFloat(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_inc_float")
+	ctx := context.Background()
+
+	_, _ = coll.InsertOne(ctx, bson.D{{Key: "score", Value: 10.0}})
+
+	_, err := coll.UpdateOne(ctx,
+		bson.D{},
+		bson.D{{Key: "$inc", Value: bson.D{{Key: "score", Value: 2.5}}}},
+	)
+	if err != nil {
+		t.Fatalf("UpdateOne: %v", err)
+	}
+
+	var doc bson.D
+	if err := coll.FindOne(ctx, bson.D{}).Decode(&doc); err != nil {
+		t.Fatalf("FindOne: %v", err)
+	}
+	score := getFieldValue(doc, "score")
+	f, ok := score.(float64)
+	if !ok {
+		t.Fatalf("score should be float64, got %T: %v", score, score)
+	}
+	if f != 12.5 {
+		t.Errorf("$inc float: expected 12.5, got %v", f)
+	}
+}
+
+// TestCompatMinMaxUpdate verifies $min and $max update operators.
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/update/min/
+func TestCompatMinMaxUpdate(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_minmax")
+	ctx := context.Background()
+
+	_, _ = coll.InsertOne(ctx, bson.D{{Key: "score", Value: int32(50)}})
+
+	// $min: smaller value wins.
+	_, _ = coll.UpdateOne(ctx, bson.D{}, bson.D{{Key: "$min", Value: bson.D{{Key: "score", Value: int32(30)}}}})
+	var doc bson.D
+	if err := coll.FindOne(ctx, bson.D{}).Decode(&doc); err != nil {
+		t.Fatalf("FindOne after $min: %v", err)
+	}
+	if v := toInt64(getFieldValue(doc, "score")); v != 30 {
+		t.Errorf("$min: expected 30, got %d", v)
+	}
+
+	// $max: larger value wins.
+	_, _ = coll.UpdateOne(ctx, bson.D{}, bson.D{{Key: "$max", Value: bson.D{{Key: "score", Value: int32(80)}}}})
+	if err := coll.FindOne(ctx, bson.D{}).Decode(&doc); err != nil {
+		t.Fatalf("FindOne after $max: %v", err)
+	}
+	if v := toInt64(getFieldValue(doc, "score")); v != 80 {
+		t.Errorf("$max: expected 80, got %d", v)
+	}
+}
+
+// ─── Aggregation Pipeline Edge Cases (#23) ────────────────────────────────────
+
+// TestCompatMatchWithAndOr verifies $match with $and/$or logical operators.
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
+func TestCompatMatchWithAndOr(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_match_logic")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "status", Value: "active"}, {Key: "age", Value: int32(25)}},
+		bson.D{{Key: "status", Value: "active"}, {Key: "age", Value: int32(17)}},
+		bson.D{{Key: "status", Value: "inactive"}, {Key: "age", Value: int32(30)}},
+	})
+
+	pipeline := bson.A{
+		bson.D{{Key: "$match", Value: bson.D{
+			{Key: "$and", Value: bson.A{
+				bson.D{{Key: "status", Value: "active"}},
+				bson.D{{Key: "age", Value: bson.D{{Key: "$gte", Value: int32(18)}}}},
+			}},
+		}}},
+	}
+	cursor, err := coll.Aggregate(ctx, pipeline)
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("$match $and: expected 1 result, got %d", len(results))
+	}
+}
+
+// TestCompatProjectComputedField verifies $project with a computed $concat field.
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/
+func TestCompatProjectComputedField(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_project_computed")
+	ctx := context.Background()
+
+	_, _ = coll.InsertOne(ctx, bson.D{
+		{Key: "first", Value: "John"},
+		{Key: "last", Value: "Doe"},
+	})
+
+	pipeline := bson.A{
+		bson.D{{Key: "$project", Value: bson.D{
+			{Key: "fullName", Value: bson.D{{Key: "$concat", Value: bson.A{"$first", " ", "$last"}}}},
+			{Key: "_id", Value: 0},
+		}}},
+	}
+	cursor, err := coll.Aggregate(ctx, pipeline)
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	fullName := getFieldValue(results[0], "fullName")
+	if fullName != "John Doe" {
+		t.Errorf("$project $concat: expected 'John Doe', got %v", fullName)
+	}
+}
+
+// TestCompatGroupAvgMissingField verifies that $avg ignores missing fields
+// (treats them as if they don't contribute to the average).
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/
+func TestCompatGroupAvgMissingField(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_avg_missing")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "val", Value: int32(10)}},
+		bson.D{{Key: "val", Value: int32(20)}},
+		bson.D{{Key: "other", Value: "no val"}}, // missing "val"
+	})
+
+	pipeline := bson.A{
+		bson.D{{Key: "$group", Value: bson.D{
+			{Key: "_id", Value: nil},
+			{Key: "avg", Value: bson.D{{Key: "$avg", Value: "$val"}}},
+		}}},
+	}
+	cursor, err := coll.Aggregate(ctx, pipeline)
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 group result, got %d", len(results))
+	}
+	// Average of [10, 20] ignoring missing = 15.
+	avg, ok := getFieldValue(results[0], "avg").(float64)
+	if !ok {
+		t.Fatalf("avg should be float64, got %T", getFieldValue(results[0], "avg"))
+	}
+	if avg != 15.0 {
+		t.Errorf("$avg ignoring missing: expected 15.0, got %v", avg)
+	}
+}
+
+// TestCompatSkipLargerThanResultSet verifies that $skip larger than the result
+// set returns an empty cursor (not an error).
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/aggregation/skip/
+func TestCompatSkipLargerThanResultSet(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_skip_large")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "x", Value: 1}},
+		bson.D{{Key: "x", Value: 2}},
+	})
+
+	pipeline := bson.A{
+		bson.D{{Key: "$skip", Value: int64(100)}},
+	}
+	cursor, err := coll.Aggregate(ctx, pipeline)
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("$skip > total docs: expected 0 results, got %d", len(results))
+	}
+}
+
+// TestCompatUnwindNonArrayField verifies that $unwind on a scalar field emits
+// one document with that field value (not an error).
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/
+func TestCompatUnwindNonArrayField(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_unwind_scalar")
+	ctx := context.Background()
+
+	_, _ = coll.InsertOne(ctx, bson.D{{Key: "tag", Value: "single"}})
+
+	pipeline := bson.A{
+		bson.D{{Key: "$unwind", Value: "$tag"}},
+	}
+	cursor, err := coll.Aggregate(ctx, pipeline)
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	// A scalar field acts like a single-element array: emits 1 document.
+	if len(results) != 1 {
+		t.Errorf("$unwind on scalar: expected 1 document, got %d", len(results))
+	}
+}
+
+// TestCompatUnwindEmptyArray verifies that $unwind on an empty array emits no
+// documents by default (drops the document).
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/
+func TestCompatUnwindEmptyArray(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_unwind_empty")
+	ctx := context.Background()
+
+	_, _ = coll.InsertOne(ctx, bson.D{{Key: "tags", Value: bson.A{}}})
+
+	pipeline := bson.A{
+		bson.D{{Key: "$unwind", Value: "$tags"}},
+	}
+	cursor, err := coll.Aggregate(ctx, pipeline)
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("$unwind empty array: expected 0 documents, got %d", len(results))
+	}
+}
+
+// TestCompatMultipleMatchStages verifies that multiple $match stages combine
+// correctly (each stage filters the output of the previous).
+// Ref: https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/
+func TestCompatMultipleMatchStages(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_multi_match")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "status", Value: "active"}, {Key: "score", Value: int32(90)}},
+		bson.D{{Key: "status", Value: "active"}, {Key: "score", Value: int32(40)}},
+		bson.D{{Key: "status", Value: "inactive"}, {Key: "score", Value: int32(95)}},
+	})
+
+	pipeline := bson.A{
+		bson.D{{Key: "$match", Value: bson.D{{Key: "status", Value: "active"}}}},
+		bson.D{{Key: "$match", Value: bson.D{{Key: "score", Value: bson.D{{Key: "$gte", Value: int32(80)}}}}}},
+	}
+	cursor, err := coll.Aggregate(ctx, pipeline)
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	var results []bson.D
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("multiple $match stages: expected 1 result, got %d", len(results))
+	}
+}
+
+// ─── findAndModify Edge Cases (#24) ──────────────────────────────────────────
+
+// TestCompatFindAndModifyUpsert verifies FindOneAndUpdate with upsert creates
+// a new document when no match exists.
+// Ref: https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+func TestCompatFindAndModifyUpsert(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_fam_upsert")
+	ctx := context.Background()
+
+	opts := options.FindOneAndUpdate().
+		SetUpsert(true).
+		SetReturnDocument(options.After)
+
+	var result bson.D
+	err := coll.FindOneAndUpdate(ctx,
+		bson.D{{Key: "name", Value: "nobody"}},
+		bson.D{{Key: "$set", Value: bson.D{{Key: "created", Value: true}}}},
+		opts,
+	).Decode(&result)
+	if err != nil {
+		t.Fatalf("FindOneAndUpdate upsert: %v", err)
+	}
+
+	if getFieldValue(result, "created") != true {
+		t.Error("upserted document should have created=true")
+	}
+}
+
+// TestCompatFindAndModifyReturnAfter verifies ReturnDocument(After) returns
+// the updated document, not the original.
+// Ref: https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+func TestCompatFindAndModifyReturnAfter(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_fam_after")
+	ctx := context.Background()
+
+	_, _ = coll.InsertOne(ctx, bson.D{{Key: "counter", Value: int32(0)}})
+
+	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
+	var result bson.D
+	err := coll.FindOneAndUpdate(ctx,
+		bson.D{},
+		bson.D{{Key: "$inc", Value: bson.D{{Key: "counter", Value: int32(1)}}}},
+		opts,
+	).Decode(&result)
+	if err != nil {
+		t.Fatalf("FindOneAndUpdate: %v", err)
+	}
+
+	if v := toInt64(getFieldValue(result, "counter")); v != 1 {
+		t.Errorf("ReturnDocument(After): expected counter=1, got %d", v)
+	}
+}
+
+// TestCompatFindAndModifyReturnBefore verifies ReturnDocument(Before) returns
+// the original document before the update.
+// Ref: https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+func TestCompatFindAndModifyReturnBefore(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_fam_before")
+	ctx := context.Background()
+
+	_, _ = coll.InsertOne(ctx, bson.D{{Key: "counter", Value: int32(10)}})
+
+	opts := options.FindOneAndUpdate().SetReturnDocument(options.Before)
+	var result bson.D
+	err := coll.FindOneAndUpdate(ctx,
+		bson.D{},
+		bson.D{{Key: "$inc", Value: bson.D{{Key: "counter", Value: int32(1)}}}},
+		opts,
+	).Decode(&result)
+	if err != nil {
+		t.Fatalf("FindOneAndUpdate: %v", err)
+	}
+
+	if v := toInt64(getFieldValue(result, "counter")); v != 10 {
+		t.Errorf("ReturnDocument(Before): expected counter=10 (original), got %d", v)
+	}
+}
+
+// TestCompatFindAndModifyRemove verifies FindOneAndDelete removes and returns
+// the document.
+// Ref: https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+func TestCompatFindAndModifyRemove(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_fam_remove")
+	ctx := context.Background()
+
+	_, _ = coll.InsertOne(ctx, bson.D{{Key: "name", Value: "alice"}, {Key: "age", Value: int32(30)}})
+
+	var deleted bson.D
+	err := coll.FindOneAndDelete(ctx, bson.D{{Key: "name", Value: "alice"}}).Decode(&deleted)
+	if err != nil {
+		t.Fatalf("FindOneAndDelete: %v", err)
+	}
+
+	if getFieldValue(deleted, "name") != "alice" {
+		t.Error("FindOneAndDelete: returned document should have name='alice'")
+	}
+
+	// Document should no longer exist.
+	count, err := coll.CountDocuments(ctx, bson.D{})
+	if err != nil {
+		t.Fatalf("CountDocuments: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("after FindOneAndDelete, expected 0 docs, got %d", count)
+	}
+}
+
+// TestCompatFindAndModifyWithSort verifies that FindOneAndUpdate with a sort
+// option picks the correct document to modify.
+// Ref: https://www.mongodb.com/docs/manual/reference/command/findAndModify/
+func TestCompatFindAndModifyWithSort(t *testing.T) {
+	client := newClient(t)
+	db := compatDB(t, client)
+	coll := db.Collection("compat_fam_sort")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "priority", Value: int32(3)}, {Key: "task", Value: "low"}},
+		bson.D{{Key: "priority", Value: int32(1)}, {Key: "task", Value: "high"}},
+		bson.D{{Key: "priority", Value: int32(2)}, {Key: "task", Value: "medium"}},
+	})
+
+	// Sort by priority ascending — should modify the document with priority=1.
+	opts := options.FindOneAndUpdate().
+		SetSort(bson.D{{Key: "priority", Value: 1}}).
+		SetReturnDocument(options.Before)
+
+	var result bson.D
+	err := coll.FindOneAndUpdate(ctx,
+		bson.D{},
+		bson.D{{Key: "$set", Value: bson.D{{Key: "done", Value: true}}}},
+		opts,
+	).Decode(&result)
+	if err != nil {
+		t.Fatalf("FindOneAndUpdate with sort: %v", err)
+	}
+
+	if v := toInt64(getFieldValue(result, "priority")); v != 1 {
+		t.Errorf("sort: expected to modify priority=1 doc, got priority=%d", v)
+	}
+}


### PR DESCRIPTION
## Agent Identity

```yaml
agent:
  id: "claude-sonnet-4-6"
  type: "claude-code"
  model: "claude-sonnet-4-6"
  operator: "pjyot1969"
  trust_tier: "newcomer"
```

Agent introduction: https://github.com/inder/salvobase/discussions/52

## Issues

Closes #21
Closes #22
Closes #23
Closes #24

## What Changed

22 new `TestCompat*` functions added to `tests/compat_edge_cases_test.go`:

**Array query operator edge cases (#21)**
- `TestCompatInWithEmptyArray` — `$in:[]` matches no documents
- `TestCompatNinWithEmptyArray` — `$nin:[]` matches all documents
- `TestCompatArrayFieldMatchesScalar` — array field matches scalar query value
- `TestCompatInWithNull` — `$in:[null]` matches null values and missing fields
- `TestCompatNestedArrayDotNotation` — dot notation queries into nested arrays

**Update operator edge cases (#22)**
- `TestCompatSetDotNotation` — `$set` with dot notation creates nested structure
- `TestCompatUnsetNonexistentField` — `$unset` on missing field is a no-op
- `TestCompatAddToSetNoDuplicate` — `$addToSet` does not add existing value
- `TestCompatIncWithFloat` — `$inc` with float increments correctly
- `TestCompatMinMaxUpdate` — `$min`/`$max` keep the lower/higher value

**Aggregation pipeline edge cases (#23)**
- `TestCompatMatchWithAndOr` — `$match` with `$and`/`$or`
- `TestCompatProjectComputedField` — `$project` with `$concat` computed field
- `TestCompatGroupAvgMissingField` — `$avg` ignores missing fields
- `TestCompatSkipLargerThanResultSet` — `$skip > total` returns empty cursor
- `TestCompatUnwindNonArrayField` — `$unwind` on scalar emits one document
- `TestCompatUnwindEmptyArray` — `$unwind` on empty array drops the document
- `TestCompatMultipleMatchStages` — chained `$match` stages filter cumulatively

**findAndModify edge cases (#24)**
- `TestCompatFindAndModifyUpsert` — upsert creates doc when no match
- `TestCompatFindAndModifyReturnAfter` — `ReturnDocument(After)` returns modified doc
- `TestCompatFindAndModifyReturnBefore` — `ReturnDocument(Before)` returns original doc
- `TestCompatFindAndModifyRemove` — `FindOneAndDelete` removes and returns document
- `TestCompatFindAndModifyWithSort` — sort picks correct document to modify

## Risk Assessment

- [x] Low risk: additive-only, no existing code modified, branch is based directly on upstream master

## Test Plan

- [x] `go vet ./...` — clean
- [x] All tests follow `TestCompat*` naming convention, use `compatDB()` for cleanup
- [x] Each test references the relevant MongoDB documentation URL

Supersedes #53 (which had extra unmerged commits in its diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)