### PR TITLE
feat(storage): index-backed query planner for equality predicates (#63)

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
@@ -332,6 +334,261 @@ func extractIDEquality(filter bson.Raw) (bson.RawValue, bool) {
 	return v, true
 }
 
+// extractEqualityPredicates extracts simple equality conditions from a filter.
+// Returns a map of field → value for conditions of the form:
+//   - {field: scalar}          (direct equality)
+//   - {field: {$eq: scalar}}   (explicit $eq operator)
+//
+// Top-level logical operators ($and, $or, $nor) and range operators are ignored.
+// Array values are not treated as equalities (multi-key index matching is out of scope for v1).
+func extractEqualityPredicates(filter bson.Raw) map[string]bson.RawValue {
+	result := make(map[string]bson.RawValue)
+	if len(filter) == 0 {
+		return result
+	}
+	elems, err := filter.Elements()
+	if err != nil {
+		return result
+	}
+	for _, elem := range elems {
+		key := elem.Key()
+		if len(key) > 0 && key[0] == '$' {
+			continue // skip $and, $or, $nor, etc.
+		}
+		val := elem.Value()
+		switch val.Type {
+		case bson.TypeEmbeddedDocument:
+			// Could be {$eq: v} or a range predicate.
+			subElems, err := val.Document().Elements()
+			if err != nil || len(subElems) == 0 {
+				continue
+			}
+			if len(subElems) == 1 && subElems[0].Key() == "$eq" {
+				eq := subElems[0].Value()
+				if eq.Type != bson.TypeArray && eq.Type != bson.TypeEmbeddedDocument {
+					result[key] = eq
+				}
+			}
+		case bson.TypeArray:
+			// Array value — not a simple equality; skip.
+		default:
+			result[key] = val
+		}
+	}
+	return result
+}
+
+// chooseIndex selects the best secondary index to use for a filter, if any.
+// Returns (spec, prefixKey, true) when a suitable index is found.
+// The prefixKey is the encoded equality prefix to seek in the index bucket.
+//
+// An index is eligible when every field in its key has an equality predicate in
+// the filter (full-coverage only; partial compound coverage is deferred to v2).
+// Hidden indexes are skipped. The _id_ index is never stored in _meta.indexes.
+//
+// When multiple eligible indexes exist, the one with the most fields is preferred
+// (most specific wins).
+func (c *bboltCollection) chooseIndex(tx *bolt.Tx, filter bson.Raw) (IndexSpec, []byte, bool) {
+	meta := tx.Bucket([]byte(bucketMetaIndexes))
+	if meta == nil {
+		return IndexSpec{}, nil, false
+	}
+	equalities := extractEqualityPredicates(filter)
+	if len(equalities) == 0 {
+		return IndexSpec{}, nil, false
+	}
+
+	prefix := metaIdxPrefix(c.coll)
+	cur := meta.Cursor()
+
+	var bestSpec IndexSpec
+	var bestPrefix []byte
+	bestCoverage := 0
+
+	for k, v := cur.Seek(prefix); k != nil && hasPrefix(k, prefix); k, v = cur.Next() {
+		var spec IndexSpec
+		if err := json.Unmarshal(v, &spec); err != nil {
+			continue
+		}
+		if spec.Hidden {
+			continue
+		}
+		elems, err := spec.Keys.Elements()
+		if err != nil || len(elems) == 0 {
+			continue
+		}
+
+		// Count leading fields with equality predicates (must be contiguous).
+		coverage := 0
+		for _, elem := range elems {
+			if _, ok := equalities[elem.Key()]; ok {
+				coverage++
+			} else {
+				break
+			}
+		}
+
+		// Require ALL fields to be covered (full coverage only in v1).
+		// Partial coverage would require key-escaping to safely do range scans;
+		// that is deferred to v2.
+		if coverage == 0 || coverage < len(elems) {
+			continue
+		}
+
+		if coverage > bestCoverage {
+			bestCoverage = coverage
+			bestSpec = spec
+			bestPrefix = encodeEqualityPrefix(spec.Keys, equalities)
+		}
+	}
+
+	if bestCoverage == 0 {
+		return IndexSpec{}, nil, false
+	}
+	return bestSpec, bestPrefix, true
+}
+
+// fetchDoc retrieves and optionally filters/projects one document from a collection bucket
+// using its raw _id key (as stored in non-unique index entries).
+// Returns nil if the document is missing (stale index entry), doesn't match the filter,
+// or projection produces an empty result.
+func (c *bboltCollection) fetchDoc(collB *bolt.Bucket, idBytes []byte, filter bson.Raw, projection bson.Raw) (bson.Raw, error) {
+	v := collB.Get(idBytes)
+	if v == nil {
+		return nil, nil // stale index entry; skip
+	}
+	raw, err := c.engine.decompress(v)
+	if err != nil {
+		return nil, err
+	}
+	doc := bson.Raw(raw)
+
+	if len(filter) > 0 {
+		match, err := query.Filter(doc, filter)
+		if err != nil {
+			return nil, err
+		}
+		if !match {
+			return nil, nil
+		}
+	}
+	if len(projection) > 0 {
+		doc, err = query.Project(doc, projection)
+		if err != nil {
+			return nil, err
+		}
+	}
+	cp := make([]byte, len(doc))
+	copy(cp, doc)
+	return bson.Raw(cp), nil
+}
+
+// indexScanTx performs an index-backed scan within an existing read transaction.
+// For unique indexes it does a single key lookup; for non-unique indexes it does
+// a bounded range scan using the 0xFF separator byte to identify exact-match entries.
+// Any filter predicates not covered by the index are applied via fetchDoc.
+func (c *bboltCollection) indexScanTx(
+	tx *bolt.Tx,
+	spec IndexSpec,
+	prefixKey []byte,
+	filter bson.Raw,
+	projection bson.Raw,
+	so scanOpts,
+) ([]bson.Raw, error) {
+	idxB := tx.Bucket([]byte(idxBucket(c.coll, spec.Name)))
+	if idxB == nil {
+		// Index bucket is missing (should not happen after CreateIndex, but be safe).
+		return c.collectionScanTx(tx, filter, projection, so)
+	}
+	collB := tx.Bucket([]byte(collBucket(c.coll)))
+	if collB == nil {
+		return nil, nil
+	}
+
+	var docs []bson.Raw
+
+	if spec.Unique {
+		// Unique index: exact key → value is the doc's _id bytes.
+		idBytes := idxB.Get(prefixKey)
+		if idBytes == nil {
+			return nil, nil
+		}
+		doc, err := c.fetchDoc(collB, idBytes, filter, projection)
+		if err != nil {
+			return nil, err
+		}
+		if doc != nil {
+			docs = append(docs, doc)
+		}
+		return docs, nil
+	}
+
+	// Non-unique index: keys are prefixKey + 0xFF + idBytes.
+	// We scan from prefixKey and accept only keys where k[len(prefixKey)] == 0xFF.
+	// This correctly distinguishes "foo" (prefix) from "foobar" (longer string) because
+	// the 0xFF separator byte cannot be part of a partial field encoding.
+	cur := idxB.Cursor()
+	for k, _ := cur.Seek(prefixKey); k != nil && bytes.HasPrefix(k, prefixKey); k, _ = cur.Next() {
+		if len(k) <= len(prefixKey) || k[len(prefixKey)] != 0xFF {
+			// Longer field value shares our byte prefix — not an exact match.
+			continue
+		}
+		idBytes := k[len(prefixKey)+1:]
+		doc, err := c.fetchDoc(collB, idBytes, filter, projection)
+		if err != nil {
+			return nil, err
+		}
+		if doc != nil {
+			docs = append(docs, doc)
+			if !so.hasSort && so.limit > 0 && int64(len(docs)) >= so.limit {
+				break
+			}
+		}
+	}
+	return docs, nil
+}
+
+// collectionScanTx performs a full collection scan within an existing read transaction.
+// This is the fallback path when no index applies.
+func (c *bboltCollection) collectionScanTx(tx *bolt.Tx, filter bson.Raw, projection bson.Raw, so scanOpts) ([]bson.Raw, error) {
+	b := tx.Bucket([]byte(collBucket(c.coll)))
+	if b == nil {
+		return nil, nil
+	}
+	var docs []bson.Raw
+	err := b.ForEach(func(k, v []byte) error {
+		raw, err := c.engine.decompress(v)
+		if err != nil {
+			return err
+		}
+		doc := bson.Raw(raw)
+		match, err := query.Filter(doc, filter)
+		if err != nil {
+			return err
+		}
+		if !match {
+			return nil
+		}
+		if len(projection) > 0 {
+			doc, err = query.Project(doc, projection)
+			if err != nil {
+				return err
+			}
+		}
+		cp := make([]byte, len(doc))
+		copy(cp, doc)
+		docs = append(docs, bson.Raw(cp))
+		if !so.hasSort && so.limit > 0 && int64(len(docs)) >= so.limit {
+			return errStopIteration
+		}
+		return nil
+	})
+	if err != nil && err != errStopIteration {
+		return nil, err
+	}
+	return docs, nil
+}
+
 // scanOpts controls early-exit behaviour during a collection scan.
 // When limit > 0 and hasSort is false, the scan stops as soon as limit
 // matching documents have been collected, avoiding a full collection walk.
@@ -340,16 +597,20 @@ type scanOpts struct {
 	hasSort bool  // true = all docs must be visited to sort correctly
 }
 
-// scanFilter does a full (or limited) collection scan and applies filter + projection.
-// When the filter is a simple {_id: value} equality, it uses a direct key lookup.
-// When so.limit > 0 and so.hasSort is false, the scan stops after so.limit matches.
+// scanFilter returns matching documents for filter with optional projection.
+//
+// Execution strategy (in priority order):
+//  1. {_id: <scalar>} equality → direct key lookup in the collection bucket (O(log N)).
+//  2. Filter has equality predicates that fully cover a secondary index → index scan
+//     (O(log N + k) where k = matching docs).
+//  3. Otherwise → full collection scan (O(N)).
 func (c *bboltCollection) scanFilter(filter bson.Raw, projection bson.Raw, so scanOpts) ([]bson.Raw, error) {
 	boltDB, err := c.engine.getDB(c.db)
 	if err != nil {
 		return nil, err
 	}
 
-	// Fast path: direct _id key lookup.
+	// Fast path 1: direct _id key lookup.
 	if idVal, ok := extractIDEquality(filter); ok {
 		key := encodeIDValue(idVal)
 		var docs []bson.Raw
@@ -383,41 +644,18 @@ func (c *bboltCollection) scanFilter(filter bson.Raw, projection bson.Raw, so sc
 		return docs, nil
 	}
 
+	// Fast path 2 + fallback: choose index or full scan inside a single transaction.
 	var docs []bson.Raw
 	if err := boltDB.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(collBucket(c.coll)))
-		if b == nil {
-			return nil
+		if spec, prefixKey, ok := c.chooseIndex(tx, filter); ok {
+			var scanErr error
+			docs, scanErr = c.indexScanTx(tx, spec, prefixKey, filter, projection, so)
+			return scanErr
 		}
-		return b.ForEach(func(k, v []byte) error {
-			raw, err := c.engine.decompress(v)
-			if err != nil {
-				return err
-			}
-			doc := bson.Raw(raw)
-			match, err := query.Filter(doc, filter)
-			if err != nil {
-				return err
-			}
-			if !match {
-				return nil
-			}
-			if len(projection) > 0 {
-				doc, err = query.Project(doc, projection)
-				if err != nil {
-					return err
-				}
-			}
-			cp := make([]byte, len(doc))
-			copy(cp, doc)
-			docs = append(docs, bson.Raw(cp))
-			// Early exit: stop scanning once we have enough docs (only safe without a sort).
-			if !so.hasSort && so.limit > 0 && int64(len(docs)) >= so.limit {
-				return errStopIteration
-			}
-			return nil
-		})
-	}); err != nil && err != errStopIteration {
+		var scanErr error
+		docs, scanErr = c.collectionScanTx(tx, filter, projection, so)
+		return scanErr
+	}); err != nil {
 		return nil, err
 	}
 	return docs, nil

--- a/internal/storage/index.go
+++ b/internal/storage/index.go
@@ -148,9 +148,12 @@ func encodeIndexKeyFromRaw(v bson.RawValue) []byte {
 		copy(b[1:], v.Value)
 		return b
 	}
-	// Unknown type: use raw bytes
+	// Unknown type: use 0xFE as the type tag.
+	// 0xFF is reserved as the separator between encoded field keys and the _id suffix
+	// in non-unique index entries (buildIndexKey). Using 0xFF here would make the
+	// separator indistinguishable from a leading byte of an unknown-type field value.
 	b := make([]byte, 1+len(v.Value))
-	b[0] = 0xFF
+	b[0] = 0xFE
 	copy(b[1:], v.Value)
 	return b
 }
@@ -255,6 +258,9 @@ func buildUniqueIndexKey(keys bson.Raw, doc bson.Raw) []byte {
 }
 
 // buildFieldKeys builds the encoded key for a compound index from a document.
+// Uses encodeIndexField for each field so that the encoding is identical to
+// encodeEqualityPrefix — the two functions MUST produce the same bytes for the
+// same field value or index scans will silently miss documents.
 func buildFieldKeys(keys bson.Raw, doc bson.Raw) []byte {
 	if len(keys) == 0 {
 		return nil
@@ -264,48 +270,73 @@ func buildFieldKeys(keys bson.Raw, doc bson.Raw) []byte {
 		return nil
 	}
 
-	var parts [][]byte
-	for _, elem := range elems {
-		// Lookup the field value in the doc (supports dot notation)
-		fieldVal := lookupIndexField(doc, elem.Key())
-		encoded := encodeIndexKeyFromRaw(fieldVal)
-
-		// For descending indexes, flip the bytes
-		dirVal := elem.Value()
-		dir := float64(1)
-		switch dirVal.Type {
-		case bson.TypeDouble:
-			f, _ := dirVal.DoubleOK()
-			dir = f
-		case bson.TypeInt32:
-			n, _ := dirVal.Int32OK()
-			dir = float64(n)
-		case bson.TypeInt64:
-			n, _ := dirVal.Int64OK()
-			dir = float64(n)
-		}
-		if dir < 0 {
-			// Flip bytes to reverse sort order
-			flipped := make([]byte, len(encoded))
-			for i, b := range encoded {
-				flipped[i] = 0xFF ^ b
-			}
-			encoded = flipped
-		}
-		parts = append(parts, encoded)
-	}
-
-	// Join parts with a separator that can't appear in encoded field values
-	// Use null bytes between parts since our encodings start with a type byte
-	if len(parts) == 0 {
-		return nil
-	}
 	var result []byte
-	for i, p := range parts {
+	for i, elem := range elems {
+		fieldVal := lookupIndexField(doc, elem.Key())
+		encoded := encodeIndexField(elem.Value(), fieldVal)
 		if i > 0 {
 			result = append(result, 0x01) // field separator
 		}
-		result = append(result, p...)
+		result = append(result, encoded...)
+	}
+	return result
+}
+
+// encodeIndexField encodes a single index field value and applies the direction
+// flip for descending index specifications (dir < 0). This is the shared encoding
+// kernel used by both buildFieldKeys and encodeEqualityPrefix to guarantee that
+// the two functions produce identical byte sequences for the same input.
+//
+// dirVal is the direction element from the index key spec (e.g. Int32(1) or Int32(-1)).
+// fieldVal is the document field value to encode.
+func encodeIndexField(dirVal, fieldVal bson.RawValue) []byte {
+	encoded := encodeIndexKeyFromRaw(fieldVal)
+
+	dir := float64(1)
+	switch dirVal.Type {
+	case bson.TypeDouble:
+		f, _ := dirVal.DoubleOK()
+		dir = f
+	case bson.TypeInt32:
+		n, _ := dirVal.Int32OK()
+		dir = float64(n)
+	case bson.TypeInt64:
+		n, _ := dirVal.Int64OK()
+		dir = float64(n)
+	}
+	if dir < 0 {
+		flipped := make([]byte, len(encoded))
+		for i, b := range encoded {
+			flipped[i] = 0xFF ^ b
+		}
+		return flipped
+	}
+	return encoded
+}
+
+// encodeEqualityPrefix builds the index key prefix for a set of equality predicates.
+// It uses encodeIndexField (the same kernel as buildFieldKeys) to guarantee that
+// the generated prefix exactly matches the keys stored in the index bucket.
+// Encoding stops at the first index field not present in equalities.
+func encodeEqualityPrefix(keys bson.Raw, equalities map[string]bson.RawValue) []byte {
+	if len(keys) == 0 {
+		return nil
+	}
+	elems, err := keys.Elements()
+	if err != nil {
+		return nil
+	}
+	var result []byte
+	for i, elem := range elems {
+		val, ok := equalities[elem.Key()]
+		if !ok {
+			break
+		}
+		encoded := encodeIndexField(elem.Value(), val)
+		if i > 0 {
+			result = append(result, 0x01) // field separator (same as buildFieldKeys)
+		}
+		result = append(result, encoded...)
 	}
 	return result
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -3163,6 +3163,156 @@ func TestTypeQueryOperator(t *testing.T) {
 	}
 }
 
+// TestIndexQueryPlanner verifies that secondary-index equality lookups return
+// correct results — both for string equality and integer equality predicates,
+// and that the {$eq: v} operator form also resolves through the index.
+func TestIndexQueryPlanner(t *testing.T) {
+	client := newClient(t)
+	db := client.Database(testDB(t))
+	coll := db.Collection("users")
+	ctx := context.Background()
+
+	// Insert 200 docs: 100 active, 100 inactive, each with a unique username.
+	var activeDocs []interface{}
+	var inactiveDocs []interface{}
+	for i := 0; i < 100; i++ {
+		activeDocs = append(activeDocs, bson.D{
+			{Key: "username", Value: fmt.Sprintf("active_user_%d", i)},
+			{Key: "status", Value: "active"},
+			{Key: "score", Value: int32(i)},
+		})
+		inactiveDocs = append(inactiveDocs, bson.D{
+			{Key: "username", Value: fmt.Sprintf("inactive_user_%d", i)},
+			{Key: "status", Value: "inactive"},
+			{Key: "score", Value: int32(i + 100)},
+		})
+	}
+	_, err := coll.InsertMany(ctx, append(activeDocs, inactiveDocs...))
+	if err != nil {
+		t.Fatalf("InsertMany: %v", err)
+	}
+
+	// Create a single-field index on "status".
+	idxModel := mongo.IndexModel{Keys: bson.D{{Key: "status", Value: 1}}}
+	if _, err := coll.Indexes().CreateOne(ctx, idxModel); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+
+	// Create a unique index on "username".
+	uniqModel := mongo.IndexModel{
+		Keys:    bson.D{{Key: "username", Value: 1}},
+		Options: options.Index().SetUnique(true),
+	}
+	if _, err := coll.Indexes().CreateOne(ctx, uniqModel); err != nil {
+		t.Fatalf("CreateIndex (unique): %v", err)
+	}
+
+	// Create a compound index on {status, score}.
+	compModel := mongo.IndexModel{Keys: bson.D{
+		{Key: "status", Value: 1},
+		{Key: "score", Value: 1},
+	}}
+	if _, err := coll.Indexes().CreateOne(ctx, compModel); err != nil {
+		t.Fatalf("CreateIndex (compound): %v", err)
+	}
+
+	t.Run("non-unique single-field equality", func(t *testing.T) {
+		cursor, err := coll.Find(ctx, bson.D{{Key: "status", Value: "active"}})
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		var results []bson.M
+		if err := cursor.All(ctx, &results); err != nil {
+			t.Fatalf("cursor.All: %v", err)
+		}
+		if len(results) != 100 {
+			t.Errorf("expected 100 active docs, got %d", len(results))
+		}
+		for _, r := range results {
+			if r["status"] != "active" {
+				t.Errorf("expected status=active, got %v", r["status"])
+			}
+		}
+	})
+
+	t.Run("$eq operator form", func(t *testing.T) {
+		cursor, err := coll.Find(ctx, bson.D{{Key: "status", Value: bson.D{{Key: "$eq", Value: "inactive"}}}})
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		var results []bson.M
+		if err := cursor.All(ctx, &results); err != nil {
+			t.Fatalf("cursor.All: %v", err)
+		}
+		if len(results) != 100 {
+			t.Errorf("expected 100 inactive docs, got %d", len(results))
+		}
+	})
+
+	t.Run("unique index equality", func(t *testing.T) {
+		result := coll.FindOne(ctx, bson.D{{Key: "username", Value: "active_user_42"}})
+		if result.Err() != nil {
+			t.Fatalf("FindOne: %v", result.Err())
+		}
+		var doc bson.M
+		if err := result.Decode(&doc); err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		if doc["username"] != "active_user_42" {
+			t.Errorf("wrong doc: %v", doc)
+		}
+	})
+
+	t.Run("compound index full equality", func(t *testing.T) {
+		cursor, err := coll.Find(ctx, bson.D{
+			{Key: "status", Value: "active"},
+			{Key: "score", Value: int32(7)},
+		})
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		var results []bson.M
+		if err := cursor.All(ctx, &results); err != nil {
+			t.Fatalf("cursor.All: %v", err)
+		}
+		if len(results) != 1 {
+			t.Errorf("expected 1 doc, got %d", len(results))
+		}
+		if len(results) == 1 && results[0]["username"] != "active_user_7" {
+			t.Errorf("wrong doc: %v", results[0])
+		}
+	})
+
+	t.Run("index with limit (early exit)", func(t *testing.T) {
+		opts := options.Find().SetLimit(10)
+		cursor, err := coll.Find(ctx, bson.D{{Key: "status", Value: "active"}}, opts)
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		var results []bson.M
+		if err := cursor.All(ctx, &results); err != nil {
+			t.Fatalf("cursor.All: %v", err)
+		}
+		if len(results) != 10 {
+			t.Errorf("expected 10 docs with limit=10, got %d", len(results))
+		}
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		cursor, err := coll.Find(ctx, bson.D{{Key: "status", Value: "deleted"}})
+		if err != nil {
+			t.Fatalf("Find: %v", err)
+		}
+		var results []bson.M
+		if err := cursor.All(ctx, &results); err != nil {
+			t.Fatalf("cursor.All: %v", err)
+		}
+		if len(results) != 0 {
+			t.Errorf("expected 0 docs, got %d", len(results))
+		}
+	})
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -3313,6 +3313,112 @@ func TestIndexQueryPlanner(t *testing.T) {
 	})
 }
 
+// TestIndexQueryPlannerDescending exercises the descending index path in
+// encodeIndexField (dir < 0 branch) to ensure the bit-flip logic produces
+// consistent keys on both insert and query sides.
+func TestIndexQueryPlannerDescending(t *testing.T) {
+	client := newClient(t)
+	coll := client.Database(testDB(t)).Collection("scores")
+	ctx := context.Background()
+
+	for i := 0; i < 20; i++ {
+		_, err := coll.InsertOne(ctx, bson.D{
+			{Key: "score", Value: int32(i)},
+			{Key: "label", Value: fmt.Sprintf("doc_%d", i)},
+		})
+		if err != nil {
+			t.Fatalf("InsertOne: %v", err)
+		}
+	}
+
+	// Create descending index on score.
+	idxModel := mongo.IndexModel{Keys: bson.D{{Key: "score", Value: -1}}}
+	if _, err := coll.Indexes().CreateOne(ctx, idxModel); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+
+	// Direct equality on a descending-indexed field.
+	result := coll.FindOne(ctx, bson.D{{Key: "score", Value: int32(7)}})
+	if result.Err() != nil {
+		t.Fatalf("FindOne: %v", result.Err())
+	}
+	var doc bson.M
+	if err := result.Decode(&doc); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if doc["label"] != "doc_7" {
+		t.Errorf("expected label=doc_7, got %v", doc["label"])
+	}
+
+	// $eq form on descending index.
+	cursor, err := coll.Find(ctx, bson.D{{Key: "score", Value: bson.D{{Key: "$eq", Value: int32(15)}}}})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	var results []bson.M
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 1 || results[0]["label"] != "doc_15" {
+		t.Errorf("expected 1 doc with label=doc_15, got %v", results)
+	}
+}
+
+// TestIndexQueryPlannerPartialCompoundFallback verifies that a query with
+// equality on only the FIRST field of a two-field compound index correctly
+// falls back to a full collection scan (partial compound coverage is not
+// supported in v1) and still returns correct results.
+func TestIndexQueryPlannerPartialCompoundFallback(t *testing.T) {
+	client := newClient(t)
+	coll := client.Database(testDB(t)).Collection("items")
+	ctx := context.Background()
+
+	for i := 0; i < 10; i++ {
+		_, err := coll.InsertOne(ctx, bson.D{
+			{Key: "category", Value: "books"},
+			{Key: "rank", Value: int32(i)},
+		})
+		if err != nil {
+			t.Fatalf("InsertOne: %v", err)
+		}
+	}
+	_, err := coll.InsertOne(ctx, bson.D{
+		{Key: "category", Value: "electronics"},
+		{Key: "rank", Value: int32(99)},
+	})
+	if err != nil {
+		t.Fatalf("InsertOne electronics: %v", err)
+	}
+
+	// Compound index on {category, rank}.
+	compModel := mongo.IndexModel{Keys: bson.D{
+		{Key: "category", Value: 1},
+		{Key: "rank", Value: 1},
+	}}
+	if _, err := coll.Indexes().CreateOne(ctx, compModel); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+
+	// Query only on "category" (partial coverage — must fall back to full scan).
+	// The result must still be correct regardless of which scan path was taken.
+	cursor, err := coll.Find(ctx, bson.D{{Key: "category", Value: "books"}})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	var results []bson.M
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+	if len(results) != 10 {
+		t.Errorf("expected 10 books docs, got %d", len(results))
+	}
+	for _, r := range results {
+		if r["category"] != "books" {
+			t.Errorf("expected category=books, got %v", r["category"])
+		}
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())


### PR DESCRIPTION
## Agent Identity

```
model:    claude-sonnet-4-6
operator: inder (founder agent)
role:     maintainer
```

## Summary

Implements the index query planner for issue #63 — the single highest-impact performance fix in the backlog. Queries with equality predicates on indexed fields now use an index scan (O(log N + k)) instead of a full collection scan (O(N)).

**Changes:**
- `internal/storage/collection.go`: added `extractEqualityPredicates`, `chooseIndex`, `indexScanTx`, `collectionScanTx`, `fetchDoc`; refactored `scanFilter` to dispatch through the planner
- `internal/storage/index.go`: added `encodeIndexField` shared kernel; added `encodeEqualityPrefix`; **fixed a latent bug** where unknown BSON types were encoded with `0xFF` as the type tag — the same byte as the field/id separator in non-unique index keys (changed to `0xFE`)
- `tests/integration_test.go`: added `TestIndexQueryPlanner` with 5 sub-tests

## Planner design (v1)

| Scenario | Path | Complexity |
|---|---|---|
| `{_id: v}` | Direct key lookup (unchanged) | O(log N) |
| `{field: v}` with index on `field` | Index scan | O(log N + k) |
| `{f1: v1, f2: v2}` fully covering compound index | Index scan | O(log N + k) |
| `{f1: v1}` on `{f1, f2}` compound index | Full scan (v2) | O(N) |
| No matching index | Full scan | O(N) |

**Correctness guarantees:**
- Non-unique index scan uses `k[len(prefix)] == 0xFF` guard to reject longer field values (e.g. searching `"foo"` won't match `"foobar"` entries)
- Residual `query.Filter` applied via `fetchDoc` for predicates not covered by the index
- Both `buildFieldKeys` and `encodeEqualityPrefix` now share `encodeIndexField` — they are guaranteed to produce identical bytes for identical inputs

**Known limitations (documented in code):**
- Partial compound index coverage not supported in v1 (requires key-escaping to safely do range scans)
- No range operator support (`$gt`, `$lt`, `$in`) — those still go to full scan

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/...` passes
- [ ] Integration: `TestIndexQueryPlanner` — non-unique equality, `$eq` operator form, unique index lookup, compound full equality, limit with early-exit, no-match returns empty
- [ ] Existing integration tests unchanged

Closes #63

*Posted by the founder agent on behalf of @inder*