### PR TITLE
perf(compression): default to none, eliminating per-doc decompress cost on scans

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -603,7 +603,7 @@ Within each bbolt database:
 ```
 Bucket "col.<collectionName>"
     Key: _id (12-byte ObjectID or user-provided key bytes)
-    Value: BSON document (optionally snappy-compressed)
+    Value: BSON document (optionally compressed: snappy or zstd; default: none)
 
 Bucket "idx.<collectionName>.<indexName>"
     Key: <indexed value bytes> + <_id bytes>

--- a/cmd/mongod/main.go
+++ b/cmd/mongod/main.go
@@ -56,7 +56,7 @@ Improvements over MongoDB Community:
 
 	// Storage flags
 	cmd.Flags().StringVar(&cfg.DataDir, "datadir", "./data", "Directory for database files")
-	cmd.Flags().StringVar(&cfg.Compression, "compression", "snappy", "Document compression: none, snappy, zstd")
+	cmd.Flags().StringVar(&cfg.Compression, "compression", "none", "Document compression: none, snappy, zstd")
 	cmd.Flags().BoolVar(&cfg.SyncOnWrite, "syncOnWrite", true, "Sync writes to disk before acknowledging")
 
 	// Auth flags

--- a/configs/mongod.yaml
+++ b/configs/mongod.yaml
@@ -17,7 +17,7 @@ storage:
   # Directory for database files (one .db file per database)
   dataDir: "/var/lib/mongoclone"
   # Document compression: none, snappy, zstd
-  compression: "snappy"
+  compression: "none"
   # Sync writes to disk before acknowledging (safer but slower)
   syncOnWrite: true
   # Maximum database file size in bytes (0 = unlimited)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -164,7 +164,7 @@ storage:
   # One .db file per database is created here
   dataDir: "/var/lib/salvobase"
   # Document compression: none | snappy | zstd
-  compression: "snappy"
+  compression: "none"
   # Sync writes to disk before acknowledging (safer but ~30% slower)
   syncOnWrite: true
   # Maximum database file size in bytes (0 = unlimited)
@@ -209,7 +209,7 @@ replication:
 | `--bind_ip` | `0.0.0.0` | IP address to listen on |
 | `--maxConns` | `1000` | Maximum concurrent connections |
 | `--datadir` | `./data` | Directory for database files |
-| `--compression` | `snappy` | Document compression: `none`, `snappy`, `zstd` |
+| `--compression` | `none` | Document compression: `none`, `snappy`, `zstd` |
 | `--syncOnWrite` | `true` | Sync writes before acknowledging |
 | `--noauth` | `false` | Disable authentication (dev only) |
 | `--logLevel` | `info` | Log level: `debug`, `info`, `warn`, `error` |


### PR DESCRIPTION
## Summary

- Changes default compression from `snappy` to `none` in `cmd/mongod/main.go` and `configs/mongod.yaml`
- Eliminates the per-document Snappy decompress cost on every full collection scan for new deployments
- Decompression cannot be deferred past the filter step (BSON field values are needed), so the correct fix is removing the overhead by default
- `snappy` and `zstd` remain available via `--compression snappy/zstd`; existing deployments are unaffected

## Why this approach

Issue #67 explored deferring decompression until after filtering. That's architecturally impossible — the filter evaluates BSON field values, which requires decompressed bytes. **Option A (change the default) is the only viable fix** that doesn't require a storage format migration.

## Closes

Closes #67

## Agent identity block

```
agent: founder
model: claude-sonnet-4-6
operator: "inder"
trust: maintainer
```

*Posted by the founder agent on behalf of @inder*