### PR TITLE
fix(aggregation): deterministic $facet output field order

### DIFF
--- a/internal/aggregation/stages.go
+++ b/internal/aggregation/stages.go
@@ -1257,8 +1257,16 @@ func (s *mergeStage) Process(docs []bson.Raw) ([]bson.Raw, error) {
 
 // ─── $facet ───────────────────────────────────────────────────────────────────
 
+// facetPipeline holds a single named sub-pipeline for $facet.
+// Using an ordered slice instead of a map preserves the field order
+// from the input specification (BSON is ordered; Go maps are not).
+type facetPipeline struct {
+	name   string
+	stages []Stage
+}
+
 type facetStage struct {
-	pipelines map[string][]Stage
+	pipelines []facetPipeline
 }
 
 func buildFacetStage(spec bson.Raw, engine storage.Engine, db string) (*facetStage, error) {
@@ -1267,7 +1275,7 @@ func buildFacetStage(spec bson.Raw, engine storage.Engine, db string) (*facetSta
 		return nil, err
 	}
 
-	s := &facetStage{pipelines: make(map[string][]Stage)}
+	s := &facetStage{}
 	for _, e := range elems {
 		arr, ok := e.Value().ArrayOK()
 		if !ok {
@@ -1286,28 +1294,30 @@ func buildFacetStage(spec bson.Raw, engine storage.Engine, db string) (*facetSta
 			}
 			stages = append(stages, stage)
 		}
-		s.pipelines[e.Key()] = stages
+		s.pipelines = append(s.pipelines, facetPipeline{name: e.Key(), stages: stages})
 	}
 	return s, nil
 }
 
 func (s *facetStage) Process(docs []bson.Raw) ([]bson.Raw, error) {
 	result := bson.D{}
-	for name, stages := range s.pipelines {
+	// Iterate over the ordered slice — not a map — so output field order matches
+	// the $facet specification order (MongoDB spec requirement).
+	for _, fp := range s.pipelines {
 		current := make([]bson.Raw, len(docs))
 		copy(current, docs)
-		for _, stage := range stages {
+		for _, stage := range fp.stages {
 			var err error
 			current, err = stage.Process(current)
 			if err != nil {
-				return nil, fmt.Errorf("$facet %s: %w", name, err)
+				return nil, fmt.Errorf("$facet %s: %w", fp.name, err)
 			}
 		}
 		arr := make(bson.A, len(current))
 		for i, d := range current {
 			arr[i] = d
 		}
-		result = append(result, bson.E{Key: name, Value: arr})
+		result = append(result, bson.E{Key: fp.name, Value: arr})
 	}
 	b, err := bson.Marshal(result)
 	if err != nil {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1706,6 +1706,66 @@ func TestAggregateFacet(t *testing.T) {
 	}
 }
 
+// ─── $facet deterministic field order ────────────────────────────────────────
+
+// TestAggregateFacetFieldOrder verifies that $facet output fields appear in the
+// same order as the input specification across multiple runs (not map iteration order).
+func TestAggregateFacetFieldOrder(t *testing.T) {
+	client := newClient(t)
+	coll := client.Database(testDB(t)).Collection("docs")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "x", Value: 1}},
+		bson.D{{Key: "x", Value: 2}},
+		bson.D{{Key: "x", Value: 3}},
+	})
+
+	// Run $facet multiple times and assert field order is always "alpha", "beta", "gamma".
+	pipeline := mongo.Pipeline{
+		bson.D{{Key: "$facet", Value: bson.D{
+			{Key: "alpha", Value: bson.A{
+				bson.D{{Key: "$match", Value: bson.D{{Key: "x", Value: bson.D{{Key: "$lte", Value: 1}}}}}},
+			}},
+			{Key: "beta", Value: bson.A{
+				bson.D{{Key: "$match", Value: bson.D{{Key: "x", Value: bson.D{{Key: "$lte", Value: 2}}}}}},
+			}},
+			{Key: "gamma", Value: bson.A{
+				bson.D{{Key: "$match", Value: bson.D{{Key: "x", Value: bson.D{{Key: "$lte", Value: 3}}}}}},
+			}},
+		}}},
+	}
+
+	for run := 0; run < 10; run++ {
+		cursor, err := coll.Aggregate(ctx, pipeline)
+		if err != nil {
+			t.Fatalf("run %d: Aggregate: %v", run, err)
+		}
+		var raw bson.Raw
+		if cursor.Next(ctx) {
+			if err := cursor.Decode(&raw); err != nil {
+				_ = cursor.Close(ctx)
+				t.Fatalf("run %d: Decode: %v", run, err)
+			}
+		}
+		_ = cursor.Close(ctx)
+
+		elems, err := raw.Elements()
+		if err != nil {
+			t.Fatalf("run %d: Elements: %v", run, err)
+		}
+		want := []string{"alpha", "beta", "gamma"}
+		if len(elems) != len(want) {
+			t.Fatalf("run %d: expected %d fields, got %d", run, len(want), len(elems))
+		}
+		for i, e := range elems {
+			if e.Key() != want[i] {
+				t.Errorf("run %d: field[%d]: want %q, got %q", run, i, want[i], e.Key())
+			}
+		}
+	}
+}
+
 // ─── Null/missing field filter edge cases ────────────────────────────────────
 
 func TestNullAndMissingFilter(t *testing.T) {


### PR DESCRIPTION
Closes #89

## What
Replaced `map[string][]Stage` with `[]facetPipeline` (an ordered slice of name+stages pairs) in `facetStage`. Updated `buildFacetStage` to append to the slice in BSON element order, and updated `Process` to iterate the slice instead of the map.

Added `TestAggregateFacetFieldOrder`: runs the same 3-field $facet pipeline 10 times and asserts output fields are always in the specification order (alpha→beta→gamma).

## Why
Go map iteration is randomized at runtime. BSON is an ordered format, and MongoDB guarantees that `$facet` output fields appear in input-specification order. Applications decoding results as `bson.D` (or any ordered BSON type) received inconsistent field ordering.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#89"]
```

*Posted by the founder agent on behalf of @inder*