### PR TITLE
feat(compat): expand probe coverage — $expr, aggregation stages, dot-notation array bug

### DIFF
--- a/tools/compat/main.go
+++ b/tools/compat/main.go
@@ -496,6 +496,49 @@ func main() {
 	run("$mod", "Query Operators", queryOp("$mod",
 		bson.D{{Key: "n", Value: bson.D{{Key: "$mod", Value: bson.A{2, 1}}}}}, 1))
 
+	run("$expr", "Query Operators", func(c context.Context) CompatResult {
+		coll := db.Collection("qop_expr")
+		_, _ = coll.InsertMany(c, []interface{}{
+			bson.D{{Key: "a", Value: 5}, {Key: "b", Value: 3}},
+			bson.D{{Key: "a", Value: 2}, {Key: "b", Value: 8}},
+		})
+		// find docs where a > b — only the first doc matches
+		cur, err := coll.Find(c, bson.D{{Key: "$expr", Value: bson.D{{Key: "$gt", Value: bson.A{"$a", "$b"}}}}})
+		if err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		defer cur.Close(c)
+		var res []bson.D
+		if err := cur.All(c, &res); err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		if len(res) != 1 {
+			return CompatResult{Status: "partial", Note: fmt.Sprintf("expected 1 result (a>b), got %d", len(res))}
+		}
+		return CompatResult{Status: "pass"}
+	})
+
+	run("dot-notation into nested arrays", "Query Operators", func(c context.Context) CompatResult {
+		coll := db.Collection("qop_dotnested")
+		_, _ = coll.InsertOne(c, bson.D{{Key: "items", Value: bson.A{
+			bson.D{{Key: "name", Value: "apple"}},
+			bson.D{{Key: "name", Value: "banana"}},
+		}}})
+		cur, err := coll.Find(c, bson.D{{Key: "items.name", Value: "apple"}})
+		if err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		defer cur.Close(c)
+		var res []bson.D
+		if err := cur.All(c, &res); err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		if len(res) != 1 {
+			return CompatResult{Status: "fail", Note: fmt.Sprintf("expected 1 doc via dot-notation into nested array, got %d", len(res))}
+		}
+		return CompatResult{Status: "pass"}
+	})
+
 	// ─── Update Operators ──────────────────────────────────────────────────────
 
 	log.Println("=== Update Operators ===")
@@ -760,6 +803,98 @@ func main() {
 		var docs []bson.D
 		if err := cur.All(c, &docs); err != nil {
 			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		return CompatResult{Status: "pass"}
+	})
+
+	run("$set (pipeline stage)", "Aggregation Stages", func(c context.Context) CompatResult {
+		coll := db.Collection("agg_set_stage")
+		_, _ = coll.InsertOne(c, bson.D{{Key: "x", Value: 1}})
+		cur, err := coll.Aggregate(c, bson.A{
+			bson.D{{Key: "$set", Value: bson.D{{Key: "y", Value: 2}}}},
+		})
+		if err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		defer cur.Close(c)
+		var res []bson.D
+		if err := cur.All(c, &res); err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		if len(res) == 0 {
+			return CompatResult{Status: "fail", Note: "no results"}
+		}
+		if _, ok := getKey(res[0], "y"); !ok {
+			return CompatResult{Status: "partial", Note: "field y not added by $set stage"}
+		}
+		return CompatResult{Status: "pass"}
+	})
+
+	run("$unset (pipeline stage)", "Aggregation Stages", func(c context.Context) CompatResult {
+		coll := db.Collection("agg_unset_stage")
+		_, _ = coll.InsertOne(c, bson.D{{Key: "x", Value: 1}, {Key: "y", Value: 2}})
+		cur, err := coll.Aggregate(c, bson.A{
+			bson.D{{Key: "$unset", Value: "y"}},
+		})
+		if err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		defer cur.Close(c)
+		var res []bson.D
+		if err := cur.All(c, &res); err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		if len(res) == 0 {
+			return CompatResult{Status: "fail", Note: "no results"}
+		}
+		if _, ok := getKey(res[0], "y"); ok {
+			return CompatResult{Status: "partial", Note: "field y not removed by $unset stage"}
+		}
+		return CompatResult{Status: "pass"}
+	})
+
+	run("$replaceWith (pipeline stage)", "Aggregation Stages", func(c context.Context) CompatResult {
+		coll := db.Collection("agg_replacewith")
+		_, _ = coll.InsertOne(c, bson.D{{Key: "nested", Value: bson.D{{Key: "a", Value: 1}}}})
+		cur, err := coll.Aggregate(c, bson.A{
+			bson.D{{Key: "$replaceWith", Value: "$nested"}},
+		})
+		if err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		defer cur.Close(c)
+		var res []bson.D
+		if err := cur.All(c, &res); err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		if len(res) == 0 {
+			return CompatResult{Status: "fail", Note: "no results"}
+		}
+		// After $replaceWith "$nested", the root should be the nested doc with field "a"
+		if _, ok := getKey(res[0], "a"); !ok {
+			return CompatResult{Status: "partial", Note: "expected 'a' field after $replaceWith, got wrong root"}
+		}
+		return CompatResult{Status: "pass"}
+	})
+
+	run("$unionWith (pipeline stage)", "Aggregation Stages", func(c context.Context) CompatResult {
+		coll := db.Collection("agg_unionwith_a")
+		coll2 := db.Collection("agg_unionwith_b")
+		_, _ = coll.InsertOne(c, bson.D{{Key: "v", Value: 1}})
+		_, _ = coll2.InsertOne(c, bson.D{{Key: "v", Value: 2}})
+		cur, err := coll.Aggregate(c, bson.A{
+			bson.D{{Key: "$unionWith", Value: bson.D{{Key: "coll", Value: "agg_unionwith_b"}}}},
+		})
+		if err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		defer cur.Close(c)
+		var res []bson.D
+		if err := cur.All(c, &res); err != nil {
+			return CompatResult{Status: "fail", Note: err.Error()}
+		}
+		if len(res) != 2 {
+			return CompatResult{Status: "partial", Note: fmt.Sprintf("$unionWith: expected 2 docs, got %d", len(res))}
 		}
 		return CompatResult{Status: "pass"}
 	})


### PR DESCRIPTION
Closes #86

## What
Add 6 new probes to `tools/compat/main.go`:

**Query Operators:**
- `$expr`: inserts `{a:5, b:3}` and `{a:2, b:8}`, finds where `a > b` — expects 1 result
- `dot-notation into nested arrays`: queries `items.name = "apple"` against an array of sub-documents — tracks the known limitation (issue #61 fix verification)

**Aggregation Stages:**
- `$set (pipeline stage)`: inserts `{x:1}`, applies `$set: {y: 2}`, asserts field `y` is present
- `$unset (pipeline stage)`: inserts `{x:1, y:2}`, applies `$unset: "y"`, asserts field `y` is absent
- `$replaceWith`: inserts `{nested: {a: 1}}`, applies `$replaceWith: "$nested"`, asserts root becomes `{a: 1}`
- `$unionWith`: inserts 1 doc each in two collections, unions them, asserts 2 total docs returned

## Why
The compat matrix had gaps for these features. New probes that start as `fail` or `partial` do not trigger the regression gate — `check_regression.py` only blocks `pass → fail` transitions. This gives CI accurate tracking of unimplemented features rather than false confidence from absence of coverage.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#86"]
```

*Posted by the founder agent on behalf of @inder*