### PR TITLE
feat(query): upgrade $expr to full aggregation expression evaluator

### DIFF
--- a/internal/aggregation/expr_filter.go
+++ b/internal/aggregation/expr_filter.go
@@ -1,0 +1,29 @@
+package aggregation
+
+import (
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/inder/salvobase/internal/query"
+)
+
+func init() {
+	// Register the full aggregation expression evaluator with the query package
+	// so that $expr in query context (find, update, delete, $match) has access
+	// to all aggregation operators — arithmetic, string, date, conditional, etc.
+	//
+	// This init() runs whenever the aggregation package is imported (e.g. by the
+	// commands package). The query package cannot import aggregation directly
+	// (that would create a cycle: aggregation→query→aggregation), so we use this
+	// registration pattern instead.
+	query.RegisterExprEvaluator(evalFullExprFilter)
+}
+
+// evalFullExprFilter evaluates a $expr operator using the full aggregation
+// expression evaluator (EvalExpr). Returns true if the result is truthy.
+func evalFullExprFilter(doc bson.Raw, opVal bson.RawValue) (bool, error) {
+	result, err := EvalExpr(opVal, doc)
+	if err != nil {
+		return false, err
+	}
+	return toBoolInterface(result), nil
+}

--- a/internal/query/filter.go
+++ b/internal/query/filter.go
@@ -775,8 +775,37 @@ func textSearchDoc(doc bson.Raw, search string) bool {
 	return false
 }
 
-// evalExprFilter provides basic $expr support.
+// exprEvaluatorFn is the full aggregation expression evaluator registered at
+// startup by the aggregation package. When set, evalExprFilter delegates to it
+// for the full operator set (arithmetic, string, date, etc.). When nil, the
+// built-in limited evaluator handles only comparison and boolean operators.
+//
+// This indirection breaks the import cycle: aggregation→query is allowed;
+// query→aggregation is not. The aggregation package registers itself via
+// RegisterExprEvaluator in its init().
+var exprEvaluatorFn func(doc bson.Raw, expr bson.RawValue) (bool, error)
+
+// RegisterExprEvaluator sets the full-featured $expr evaluator. Called once by
+// the aggregation package during init.
+func RegisterExprEvaluator(fn func(doc bson.Raw, expr bson.RawValue) (bool, error)) {
+	exprEvaluatorFn = fn
+}
+
+// evalExprFilter evaluates a $expr operator against a document.
+// Delegates to the full aggregation expression evaluator when available,
+// otherwise falls back to the built-in limited evaluator that supports
+// comparison and boolean operators only.
 func evalExprFilter(doc bson.Raw, opVal bson.RawValue) (bool, error) {
+	// Delegate to the full aggregation evaluator when registered.
+	if exprEvaluatorFn != nil {
+		return exprEvaluatorFn(doc, opVal)
+	}
+	return evalExprFilterFallback(doc, opVal)
+}
+
+// evalExprFilterFallback is the built-in limited $expr evaluator used when the
+// aggregation package has not been imported (e.g. unit tests of query alone).
+func evalExprFilterFallback(doc bson.Raw, opVal bson.RawValue) (bool, error) {
 	if opVal.Type != bson.TypeEmbeddedDocument {
 		// Boolean literal
 		if opVal.Type == bson.TypeBoolean {
@@ -840,7 +869,7 @@ func evalExprFilter(doc bson.Raw, opVal bson.RawValue) (bool, error) {
 		}
 		args, _ := val.Array().Values()
 		for _, a := range args {
-			m, err := evalExprFilter(doc, a)
+			m, err := evalExprFilterFallback(doc, a)
 			if err != nil {
 				return false, err
 			}
@@ -855,7 +884,7 @@ func evalExprFilter(doc bson.Raw, opVal bson.RawValue) (bool, error) {
 		}
 		args, _ := val.Array().Values()
 		for _, a := range args {
-			m, err := evalExprFilter(doc, a)
+			m, err := evalExprFilterFallback(doc, a)
 			if err != nil {
 				return false, err
 			}
@@ -865,7 +894,7 @@ func evalExprFilter(doc bson.Raw, opVal bson.RawValue) (bool, error) {
 		}
 		return false, nil
 	case "$not":
-		m, err := evalExprFilter(doc, val)
+		m, err := evalExprFilterFallback(doc, val)
 		if err != nil {
 			return false, err
 		}

--- a/internal/query/filter_test.go
+++ b/internal/query/filter_test.go
@@ -793,3 +793,101 @@ func TestEvalAll(t *testing.T) {
 		})
 	}
 }
+
+// ─── $expr (fallback evaluator) ───────────────────────────────────────────────
+
+// TestEvalExprFallback tests the built-in limited $expr evaluator directly
+// (without the aggregation package registered). Covers comparison and boolean
+// operators. Arithmetic support is tested via integration tests.
+func TestEvalExprFallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		doc       bson.D
+		filter    bson.D
+		wantMatch bool
+		wantErr   bool
+	}{
+		{
+			name:      "$expr $gt field-to-field match",
+			doc:       bson.D{{Key: "price", Value: int32(10)}, {Key: "cost", Value: int32(5)}},
+			filter:    bson.D{{Key: "$expr", Value: bson.D{{Key: "$gt", Value: bson.A{"$price", "$cost"}}}}},
+			wantMatch: true,
+		},
+		{
+			name:      "$expr $gt field-to-field no match",
+			doc:       bson.D{{Key: "price", Value: int32(3)}, {Key: "cost", Value: int32(7)}},
+			filter:    bson.D{{Key: "$expr", Value: bson.D{{Key: "$gt", Value: bson.A{"$price", "$cost"}}}}},
+			wantMatch: false,
+		},
+		{
+			name:      "$expr $eq break-even",
+			doc:       bson.D{{Key: "price", Value: int32(8)}, {Key: "cost", Value: int32(8)}},
+			filter:    bson.D{{Key: "$expr", Value: bson.D{{Key: "$eq", Value: bson.A{"$price", "$cost"}}}}},
+			wantMatch: true,
+		},
+		{
+			name:      "$expr boolean literal true",
+			doc:       bson.D{{Key: "x", Value: int32(1)}},
+			filter:    bson.D{{Key: "$expr", Value: true}},
+			wantMatch: true,
+		},
+		{
+			name:      "$expr boolean literal false",
+			doc:       bson.D{{Key: "x", Value: int32(1)}},
+			filter:    bson.D{{Key: "$expr", Value: false}},
+			wantMatch: false,
+		},
+		{
+			name: "$expr $and both true",
+			doc:  bson.D{{Key: "a", Value: int32(5)}, {Key: "b", Value: int32(3)}, {Key: "c", Value: int32(1)}},
+			filter: bson.D{{Key: "$expr", Value: bson.D{{Key: "$and", Value: bson.A{
+				bson.D{{Key: "$gt", Value: bson.A{"$a", "$b"}}},
+				bson.D{{Key: "$gt", Value: bson.A{"$b", "$c"}}},
+			}}}}},
+			wantMatch: true,
+		},
+		{
+			name: "$expr $and second false",
+			doc:  bson.D{{Key: "a", Value: int32(5)}, {Key: "b", Value: int32(3)}, {Key: "c", Value: int32(4)}},
+			filter: bson.D{{Key: "$expr", Value: bson.D{{Key: "$and", Value: bson.A{
+				bson.D{{Key: "$gt", Value: bson.A{"$a", "$b"}}},
+				bson.D{{Key: "$gt", Value: bson.A{"$b", "$c"}}},
+			}}}}},
+			wantMatch: false,
+		},
+		{
+			name: "$expr $not",
+			doc:  bson.D{{Key: "price", Value: int32(3)}, {Key: "cost", Value: int32(7)}},
+			filter: bson.D{{Key: "$expr", Value: bson.D{{Key: "$not", Value: bson.D{
+				{Key: "$gt", Value: bson.A{"$price", "$cost"}},
+			}}}}},
+			wantMatch: true,
+		},
+		{
+			name:    "$expr unsupported op in fallback returns error",
+			doc:     bson.D{{Key: "x", Value: int32(1)}},
+			filter:  bson.D{{Key: "$expr", Value: bson.D{{Key: "$multiply", Value: bson.A{"$x", 2}}}}},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := mustMarshal(tc.doc)
+			filter := mustMarshal(tc.filter)
+			match, err := Filter(doc, filter)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if match != tc.wantMatch {
+				t.Errorf("got match=%v, want %v", match, tc.wantMatch)
+			}
+		})
+	}
+}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1768,6 +1768,100 @@ func TestAggregateFacetFieldOrder(t *testing.T) {
 
 // ─── Null/missing field filter edge cases ────────────────────────────────────
 
+// ─── $expr query operator ─────────────────────────────────────────────────────
+
+// TestQueryExpr verifies $expr in find, update, delete, and aggregate $match.
+func TestQueryExpr(t *testing.T) {
+	client := newClient(t)
+	coll := client.Database(testDB(t)).Collection("budget")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		bson.D{{Key: "item", Value: "pen"}, {Key: "price", Value: 10}, {Key: "cost", Value: 5}},    // over budget
+		bson.D{{Key: "item", Value: "book"}, {Key: "price", Value: 3}, {Key: "cost", Value: 7}},   // under budget
+		bson.D{{Key: "item", Value: "ruler"}, {Key: "price", Value: 8}, {Key: "cost", Value: 8}},  // break-even
+	})
+
+	exprFilter := bson.D{{Key: "$expr", Value: bson.D{{Key: "$gt", Value: bson.A{"$price", "$cost"}}}}}
+
+	// find
+	cursor, err := coll.Find(ctx, exprFilter)
+	if err != nil {
+		t.Fatalf("$expr find: %v", err)
+	}
+	var results []bson.M
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("$expr cursor.All: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("$expr find: expected 1 result, got %d", len(results))
+	}
+	if results[0]["item"] != "pen" {
+		t.Errorf("$expr find: expected 'pen', got %v", results[0]["item"])
+	}
+
+	// aggregate $match
+	aggCursor, err := coll.Aggregate(ctx, mongo.Pipeline{
+		bson.D{{Key: "$match", Value: exprFilter}},
+	})
+	if err != nil {
+		t.Fatalf("$expr $match: %v", err)
+	}
+	var aggResults []bson.M
+	if err := aggCursor.All(ctx, &aggResults); err != nil {
+		t.Fatalf("$expr $match cursor: %v", err)
+	}
+	if len(aggResults) != 1 {
+		t.Fatalf("$expr $match: expected 1 result, got %d", len(aggResults))
+	}
+
+	// count via CountDocuments
+	count, err := coll.CountDocuments(ctx, exprFilter)
+	if err != nil {
+		t.Fatalf("$expr CountDocuments: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("$expr CountDocuments: expected 1, got %d", count)
+	}
+}
+
+// TestQueryExprArithmetic verifies that $expr supports nested arithmetic expressions.
+func TestQueryExprArithmetic(t *testing.T) {
+	client := newClient(t)
+	coll := client.Database(testDB(t)).Collection("orders")
+	ctx := context.Background()
+
+	_, _ = coll.InsertMany(ctx, []interface{}{
+		// total = qty * price; match where total > 100
+		bson.D{{Key: "item", Value: "a"}, {Key: "qty", Value: 5}, {Key: "price", Value: 25}},  // 125 > 100 ✓
+		bson.D{{Key: "item", Value: "b"}, {Key: "qty", Value: 2}, {Key: "price", Value: 40}},  // 80 not > 100
+		bson.D{{Key: "item", Value: "c"}, {Key: "qty", Value: 10}, {Key: "price", Value: 15}}, // 150 > 100 ✓
+	})
+
+	// {$expr: {$gt: [{$multiply: ["$qty", "$price"]}, 100]}}
+	exprFilter := bson.D{{Key: "$expr", Value: bson.D{
+		{Key: "$gt", Value: bson.A{
+			bson.D{{Key: "$multiply", Value: bson.A{"$qty", "$price"}}},
+			100,
+		}},
+	}}}
+
+	cursor, err := coll.Find(ctx, exprFilter, options.Find().SetSort(bson.D{{Key: "item", Value: 1}}))
+	if err != nil {
+		t.Fatalf("$expr arithmetic find: %v", err)
+	}
+	var results []bson.M
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("$expr arithmetic cursor.All: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("$expr arithmetic: expected 2 results, got %d", len(results))
+	}
+	if results[0]["item"] != "a" || results[1]["item"] != "c" {
+		t.Errorf("$expr arithmetic: expected [a, c], got [%v, %v]", results[0]["item"], results[1]["item"])
+	}
+}
+
 func TestNullAndMissingFilter(t *testing.T) {
 	client := newClient(t)
 	coll := client.Database(testDB(t)).Collection("docs")


### PR DESCRIPTION
Closes #6

## What
- Added `RegisterExprEvaluator` in `internal/query/filter.go` — a function-injection hook that breaks the import cycle between query and aggregation
- New file `internal/aggregation/expr_filter.go` — registers `evalFullExprFilter` via `init()`, wrapping the full `EvalExpr` with a truthiness check
- `evalExprFilter` in filter.go now delegates to the registered full evaluator when present; falls back to the built-in limited path (comparison + boolean only) otherwise
- Unit tests: `TestEvalExprFallback` in `filter_test.go`
- Integration tests: `TestQueryExpr` (field refs in find/match/count) and `TestQueryExprArithmetic` ($multiply inside $expr)

## Why
The original `evalExprFilter` hand-rolled comparison and boolean operators only. The full aggregation expression evaluator (`EvalExpr`) already supports arithmetic, string, date, type conversion, and everything else. We wire them together without creating a circular import by using a registered callback set in `init()`.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#6"]
```

*Posted by the founder agent on behalf of @inder*