### PR TITLE
fix(lint): fix gofmt violations in test files (CI unblock)

### DIFF
--- a/internal/aggregation/expressions_test.go
+++ b/internal/aggregation/expressions_test.go
@@ -291,9 +291,9 @@ func TestExprCondArray(t *testing.T) {
 
 func TestExprIfNull(t *testing.T) {
 	tests := []struct {
-		name  string
-		doc   bson.D
-		want  interface{}
+		name string
+		doc  bson.D
+		want interface{}
 	}{
 		{
 			"field present non-null",

--- a/tests/compat_edge_cases_test.go
+++ b/tests/compat_edge_cases_test.go
@@ -865,8 +865,8 @@ func TestCompatNestedArrayDotNotation(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		filter   bson.D
+		name      string
+		filter    bson.D
 		wantCount int
 		wantNames []string
 	}{

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1869,9 +1869,9 @@ func TestQueryExpr(t *testing.T) {
 	ctx := context.Background()
 
 	_, _ = coll.InsertMany(ctx, []interface{}{
-		bson.D{{Key: "item", Value: "pen"}, {Key: "price", Value: 10}, {Key: "cost", Value: 5}},    // over budget
-		bson.D{{Key: "item", Value: "book"}, {Key: "price", Value: 3}, {Key: "cost", Value: 7}},   // under budget
-		bson.D{{Key: "item", Value: "ruler"}, {Key: "price", Value: 8}, {Key: "cost", Value: 8}},  // break-even
+		bson.D{{Key: "item", Value: "pen"}, {Key: "price", Value: 10}, {Key: "cost", Value: 5}},  // over budget
+		bson.D{{Key: "item", Value: "book"}, {Key: "price", Value: 3}, {Key: "cost", Value: 7}},  // under budget
+		bson.D{{Key: "item", Value: "ruler"}, {Key: "price", Value: 8}, {Key: "cost", Value: 8}}, // break-even
 	})
 
 	exprFilter := bson.D{{Key: "$expr", Value: bson.D{{Key: "$gt", Value: bson.A{"$price", "$cost"}}}}}


### PR DESCRIPTION
## What
Fix gofmt formatting violations in three test files that broke the Lint CI job on master.

Files:
- `internal/aggregation/expressions_test.go` (line 294): struct fields had extra spaces
- `tests/compat_edge_cases_test.go`: same alignment issue
- `tests/integration_test.go`: same alignment issue

## Why
CI Lint job is failing on master since commit `7fb19bc`. Restoring green CI unblocks all future contributor PRs.

```yaml
agent:
  id: founder-agent-ci
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: []
```

*Posted by the founder agent on behalf of @inder*