### PR TITLE
feat(commands): implement currentOp command

### DIFF
--- a/internal/commands/diagnostic.go
+++ b/internal/commands/diagnostic.go
@@ -383,6 +383,16 @@ func handleGetCmdLineOpts(_ *Context, _ bson.Raw) (bson.Raw, error) {
 	}), nil
 }
 
+// handleCurrentOp handles the "currentOp" command.
+// Returns in-progress operations. Salvobase does not track per-operation state,
+// so "inprog" is always empty — matching MongoDB's response when idle.
+func handleCurrentOp(_ *Context, _ bson.Raw) (bson.Raw, error) {
+	return marshalResponse(bson.D{
+		{Key: "inprog", Value: bson.A{}},
+		{Key: "ok", Value: float64(1)},
+	}), nil
+}
+
 // handleExplain handles the "explain" command.
 // It re-runs the wrapped command and adds explain output.
 func handleExplain(ctx *Context, cmd bson.Raw) (bson.Raw, error) {

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -117,6 +117,8 @@ func (d *Dispatcher) registerAll() {
 	d.register("features", handleFeatures)
 	d.register("logout", handleLogout)
 	d.register("explain", handleExplain)
+	d.register("currentop", handleCurrentOp)
+	d.register("currentOp", handleCurrentOp)
 	d.register("hostinfo", handleHostInfo)
 	d.register("hostInfo", handleHostInfo)
 	d.register("getcmdlineopts", handleGetCmdLineOpts)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -3386,6 +3386,52 @@ func TestGetCmdLineOpts(t *testing.T) {
 	}
 }
 
+// ─── currentOp command (#30) ─────────────────────────────────────────────────
+
+func TestCurrentOp(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	var result bson.M
+	err := client.Database("admin").RunCommand(ctx, bson.D{{Key: "currentOp", Value: 1}}).Decode(&result)
+	if err != nil {
+		t.Fatalf("currentOp: %v", err)
+	}
+
+	inprog, ok := result["inprog"]
+	if !ok {
+		t.Fatal("currentOp: expected 'inprog' field")
+	}
+	arr, ok := inprog.(bson.A)
+	if !ok {
+		t.Fatalf("currentOp: expected 'inprog' to be an array, got %T", inprog)
+	}
+	// Salvobase returns no tracked operations; array must be empty.
+	if len(arr) != 0 {
+		t.Errorf("currentOp: expected empty 'inprog', got %d entries", len(arr))
+	}
+
+	ok64, _ := result["ok"].(float64)
+	if ok64 != 1 {
+		t.Errorf("currentOp: expected ok=1, got %v", result["ok"])
+	}
+}
+
+func TestCurrentOpLowercase(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	var result bson.M
+	err := client.Database("admin").RunCommand(ctx, bson.D{{Key: "currentop", Value: 1}}).Decode(&result)
+	if err != nil {
+		t.Fatalf("currentop (lowercase): %v", err)
+	}
+
+	if _, ok := result["inprog"]; !ok {
+		t.Fatal("currentop: expected 'inprog' field")
+	}
+}
+
 // ─── $type query operator (#8) ────────────────────────────────────────────────
 
 func TestTypeQueryOperator(t *testing.T) {


### PR DESCRIPTION
Closes #30

## What
- Added `handleCurrentOp` handler in `internal/commands/diagnostic.go` that returns an empty `inprog` array (MongoDB-compatible response for an idle server)
- Registered `currentop` and `currentOp` in `dispatcher.go`'s `registerAll()`
- Added `TestCurrentOp` and `TestCurrentOpLowercase` integration tests to `tests/integration_test.go`

## Why
`currentOp` is part of the MongoDB wire protocol and is used by drivers and tooling to inspect in-progress operations. Without it, clients receive a `CommandNotFound` error. Returning an empty `inprog` array is the correct idle-server response.

```yaml
agent:
  id: founder-agent-s1
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#30"]
```

*Posted by the founder agent on behalf of @inder*