### PR TITLE
feat(storage): add event bus for change stream notifications

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -158,6 +158,22 @@ func (c *bboltCollection) InsertMany(docs []bson.Raw, opts InsertOptions) ([]bso
 	}
 
 	c.engine.opInsert.Add(successCount)
+
+	// Publish ChangeInsert events for each successfully inserted document.
+	if c.engine.eventBus.HasStream(c.db, c.coll) {
+		for i, id := range ids {
+			if id == (bson.ObjectID{}) {
+				continue // insert failed (dup key or prep error)
+			}
+			doc := results[i].prep.finalDoc
+			c.engine.eventBus.Publish(c.db, c.coll, ChangeEvent{
+				OperationType: ChangeInsert,
+				DocumentKey:   makeDocumentKey(doc.Lookup("_id")),
+				FullDocument:  doc,
+			})
+		}
+	}
+
 	return ids, insertErr
 }
 
@@ -1378,6 +1394,7 @@ func (c *bboltCollection) updateDocs(filter, update bson.Raw, opts UpdateOptions
 	}
 
 	var result UpdateResult
+	var pendingEvents []ChangeEvent // collected inside tx, published after commit
 
 	if err := boltDB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(collBucket(c.coll)))
@@ -1447,6 +1464,11 @@ func (c *bboltCollection) updateDocs(filter, update bson.Raw, opts UpdateOptions
 			result.UpsertedCount = 1
 			result.UpsertedID = newDoc.Lookup("_id")
 			c.engine.opInsert.Add(1)
+			pendingEvents = append(pendingEvents, ChangeEvent{
+				OperationType: ChangeInsert,
+				DocumentKey:   makeDocumentKey(newDoc.Lookup("_id")),
+				FullDocument:  newDoc,
+			})
 			return nil
 		}
 
@@ -1484,6 +1506,11 @@ func (c *bboltCollection) updateDocs(filter, update bson.Raw, opts UpdateOptions
 			}
 			c.engine.insertIntoIndexes(tx, c.db, c.coll, newKey, newDoc) //nolint:errcheck
 			result.ModifiedCount++
+			pendingEvents = append(pendingEvents, ChangeEvent{
+				OperationType:     ChangeUpdate,
+				DocumentKey:       makeDocumentKey(newDoc.Lookup("_id")),
+				UpdateDescription: updateDescriptionPlaceholder,
+			})
 		}
 		return nil
 	}); err != nil {
@@ -1491,6 +1518,14 @@ func (c *bboltCollection) updateDocs(filter, update bson.Raw, opts UpdateOptions
 	}
 
 	c.engine.opUpdate.Add(1)
+
+	// Publish change events for committed mutations.
+	if c.engine.eventBus.HasStream(c.db, c.coll) {
+		for _, ev := range pendingEvents {
+			c.engine.eventBus.Publish(c.db, c.coll, ev)
+		}
+	}
+
 	return result, nil
 }
 
@@ -1501,6 +1536,7 @@ func (c *bboltCollection) replaceDocs(filter, replacement bson.Raw, opts UpdateO
 	}
 
 	var result UpdateResult
+	var pendingEvent *ChangeEvent // at most one event for ReplaceOne
 
 	if err := boltDB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(collBucket(c.coll)))
@@ -1567,6 +1603,12 @@ func (c *bboltCollection) replaceDocs(filter, replacement bson.Raw, opts UpdateO
 				c.engine.insertIntoIndexes(tx, c.db, c.coll, upsertKey, newDoc) //nolint:errcheck
 				result.UpsertedCount = 1
 				result.UpsertedID = newDoc.Lookup("_id")
+				ev := ChangeEvent{
+					OperationType: ChangeInsert,
+					DocumentKey:   makeDocumentKey(newDoc.Lookup("_id")),
+					FullDocument:  newDoc,
+				}
+				pendingEvent = &ev
 			}
 			return nil
 		}
@@ -1608,12 +1650,24 @@ func (c *bboltCollection) replaceDocs(filter, replacement bson.Raw, opts UpdateO
 		c.engine.insertIntoIndexes(tx, c.db, c.coll, newKey, newDoc) //nolint:errcheck
 		result.MatchedCount = 1
 		result.ModifiedCount = 1
+		ev := ChangeEvent{
+			OperationType: ChangeReplace,
+			DocumentKey:   makeDocumentKey(newDoc.Lookup("_id")),
+			FullDocument:  newDoc,
+		}
+		pendingEvent = &ev
 		return nil
 	}); err != nil {
 		return result, err
 	}
 
 	c.engine.opUpdate.Add(1)
+
+	// Publish the change event for the committed mutation.
+	if pendingEvent != nil && c.engine.eventBus.HasStream(c.db, c.coll) {
+		c.engine.eventBus.Publish(c.db, c.coll, *pendingEvent)
+	}
+
 	return result, nil
 }
 
@@ -1716,6 +1770,7 @@ func (c *bboltCollection) deleteDocs(filter bson.Raw, multi bool) (int64, error)
 	}
 
 	var deleted int64
+	var deletedDocs []bson.Raw // document keys collected for change events
 
 	if err := boltDB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket([]byte(collBucket(c.coll)))
@@ -1762,6 +1817,7 @@ func (c *bboltCollection) deleteDocs(filter bson.Raw, multi bool) (int64, error)
 			idKey := encodeIDValue(item.doc.Lookup("_id"))
 			c.engine.removeFromIndexes(tx, c.db, c.coll, idKey, item.doc) //nolint:errcheck
 			deleted++
+			deletedDocs = append(deletedDocs, item.doc)
 		}
 		return nil
 	}); err != nil {
@@ -1769,6 +1825,17 @@ func (c *bboltCollection) deleteDocs(filter bson.Raw, multi bool) (int64, error)
 	}
 
 	c.engine.opDelete.Add(1)
+
+	// Publish ChangeDelete events for each deleted document.
+	if len(deletedDocs) > 0 && c.engine.eventBus.HasStream(c.db, c.coll) {
+		for _, doc := range deletedDocs {
+			c.engine.eventBus.Publish(c.db, c.coll, ChangeEvent{
+				OperationType: ChangeDelete,
+				DocumentKey:   makeDocumentKey(doc.Lookup("_id")),
+			})
+		}
+	}
+
 	return deleted, nil
 }
 

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -25,8 +25,9 @@ type BBoltEngine struct {
 	mu  sync.RWMutex
 	dbs map[string]*bolt.DB // open bbolt databases, keyed by db name
 
-	cursors *cursorStore
-	users   *userStore
+	cursors  *cursorStore
+	users    *userStore
+	eventBus *EventBus
 
 	startTime time.Time
 	pid       int64
@@ -76,6 +77,7 @@ func NewBBoltEngine(dataDir, compression string, syncOnWrite bool) (*BBoltEngine
 	}
 	e.cursors = &cursorStore{cursors: make(map[int64]*cursorEntry)}
 	e.users = &userStore{engine: e}
+	e.eventBus = NewEventBus(0)
 
 	// Always open admin db eagerly so user storage is available immediately.
 	if _, err := e.openDB("admin"); err != nil {
@@ -872,12 +874,16 @@ func (e *BBoltEngine) getCollectionInfo(db, coll string) (CollectionInfo, bool) 
 
 // ─── Cursors / Users ──────────────────────────────────────────────────────────
 
-func (e *BBoltEngine) Cursors() CursorStore { return e.cursors }
-func (e *BBoltEngine) Users() UserStore     { return e.users }
+func (e *BBoltEngine) Cursors() CursorStore   { return e.cursors }
+func (e *BBoltEngine) Users() UserStore       { return e.users }
+func (e *BBoltEngine) EventBus() *EventBus    { return e.eventBus }
 
 // ─── Close ────────────────────────────────────────────────────────────────────
 
 func (e *BBoltEngine) Close() error {
+	if e.eventBus != nil {
+		e.eventBus.Close()
+	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	var firstErr error

--- a/internal/storage/event_bus.go
+++ b/internal/storage/event_bus.go
@@ -1,0 +1,309 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// EventBusDefaultBufferSize is the default ring-buffer capacity per namespace.
+const EventBusDefaultBufferSize = 1000
+
+// ErrBufOverflow is returned when a subscriber's read position has been lapped
+// by the ring buffer (the subscriber is too slow to consume events).
+var ErrBufOverflow = errors.New("change stream history lost")
+
+// ChangeEventType describes the type of a collection mutation.
+type ChangeEventType string
+
+const (
+	ChangeInsert  ChangeEventType = "insert"
+	ChangeUpdate  ChangeEventType = "update"
+	ChangeDelete  ChangeEventType = "delete"
+	ChangeReplace ChangeEventType = "replace"
+)
+
+// ResumeToken uniquely identifies a change event within a namespace.
+// Encoded as 16 big-endian bytes: 8-byte nanosecond timestamp + 8-byte sequence.
+type ResumeToken struct {
+	TimestampNS int64
+	Seq         int64
+}
+
+// ChangeEvent is a single mutation event published to the bus.
+type ChangeEvent struct {
+	// ResumeToken uniquely identifies this event within a namespace.
+	ResumeToken ResumeToken
+
+	// Namespace is "db.collection".
+	Namespace string
+
+	// OperationType is the kind of mutation.
+	OperationType ChangeEventType
+
+	// DocumentKey holds the _id of the affected document as {"_id": <value>}.
+	DocumentKey bson.Raw
+
+	// FullDocument is populated for insert and replace; nil for update/delete in Phase 1.
+	FullDocument bson.Raw
+
+	// UpdateDescription is set for update events (Phase 1: placeholder with empty sets).
+	UpdateDescription bson.Raw
+}
+
+// updateDescriptionPlaceholder is a placeholder UpdateDescription for update events.
+// Phase 1 does not compute field-level diffs; the placeholder matches MongoDB's shape.
+var updateDescriptionPlaceholder bson.Raw
+
+func init() {
+	var err error
+	updateDescriptionPlaceholder, err = bson.Marshal(bson.D{
+		{Key: "updatedFields", Value: bson.D{}},
+		{Key: "removedFields", Value: bson.A{}},
+		{Key: "truncatedArrays", Value: bson.A{}},
+	})
+	if err != nil {
+		panic("event_bus: marshal updateDescriptionPlaceholder: " + err.Error())
+	}
+}
+
+// makeDocumentKey builds a {"_id": <value>} BSON document from a raw _id value.
+func makeDocumentKey(idVal bson.RawValue) bson.Raw {
+	d := bson.D{{Key: "_id", Value: rawValueToGo(idVal)}}
+	raw, _ := bson.Marshal(d)
+	return raw
+}
+
+// nsStream holds the ring buffer for one namespace.
+// All mutable fields are protected by mu (cond is sync.NewCond(&mu)).
+type nsStream struct {
+	mu     sync.Mutex
+	cond   *sync.Cond
+	buf    []ChangeEvent // ring buffer, len = capacity
+	seq    int64         // sequence number of the last published event (0 = none published)
+	closed bool
+}
+
+func newNsStream(size int) *nsStream {
+	st := &nsStream{
+		buf: make([]ChangeEvent, size),
+	}
+	st.cond = sync.NewCond(&st.mu)
+	return st
+}
+
+// EventBus manages per-namespace ring buffers and fan-out to subscribers.
+// One instance is created per BBoltEngine and shared across all collections.
+type EventBus struct {
+	mu      sync.RWMutex
+	streams map[string]*nsStream
+	bufSize int
+}
+
+// NewEventBus creates an EventBus with the given ring-buffer size per namespace.
+// If bufSize <= 0, EventBusDefaultBufferSize is used.
+func NewEventBus(bufSize int) *EventBus {
+	if bufSize <= 0 {
+		bufSize = EventBusDefaultBufferSize
+	}
+	return &EventBus{
+		streams: make(map[string]*nsStream),
+		bufSize: bufSize,
+	}
+}
+
+// HasStream reports whether any subscriber has registered interest in db.coll.
+// Used by mutation methods to skip event construction when nobody is watching.
+func (b *EventBus) HasStream(db, coll string) bool {
+	if b == nil {
+		return false
+	}
+	ns := db + "." + coll
+	b.mu.RLock()
+	_, ok := b.streams[ns]
+	b.mu.RUnlock()
+	return ok
+}
+
+// Publish writes a change event to the bus for db.coll.
+//
+// Fast path: returns immediately if no nsStream exists for this namespace (nobody
+// has ever subscribed), so zero-subscriber collections incur only a single RLock.
+//
+// Never blocks. When the ring buffer is full the oldest event is silently
+// overwritten; subscribers that have fallen behind will receive ErrBufOverflow
+// on their next Recv call.
+func (b *EventBus) Publish(db, coll string, event ChangeEvent) {
+	if b == nil {
+		return
+	}
+	ns := db + "." + coll
+
+	// Fast path: if nobody has ever subscribed to this namespace, do nothing.
+	b.mu.RLock()
+	st, ok := b.streams[ns]
+	b.mu.RUnlock()
+	if !ok {
+		return
+	}
+
+	st.mu.Lock()
+	st.seq++
+	s := st.seq
+	event.ResumeToken = ResumeToken{
+		TimestampNS: time.Now().UnixNano(),
+		Seq:         s,
+	}
+	event.Namespace = ns
+	cap := int64(len(st.buf))
+	pos := (s - 1) % cap
+	st.buf[pos] = event
+	st.mu.Unlock()
+
+	st.cond.Broadcast()
+}
+
+// Subscription is a handle for receiving events from a specific namespace.
+// Obtain via EventBus.Subscribe; release with EventBus.Unsubscribe.
+type Subscription struct {
+	stream  *nsStream
+	readSeq int64      // last consumed sequence number (0 = nothing consumed yet)
+	closed  atomic.Bool
+}
+
+// Subscribe creates a subscription for the namespace ns (formatted as "db.coll").
+// The subscription receives only events published after this call.
+// Subscribe creates the nsStream for ns if it does not already exist; subsequent
+// Publish calls to ns will then write to the ring buffer.
+func (b *EventBus) Subscribe(ns string) *Subscription {
+	b.mu.Lock()
+	st, ok := b.streams[ns]
+	if !ok {
+		st = newNsStream(b.bufSize)
+		b.streams[ns] = st
+	}
+	b.mu.Unlock()
+
+	st.mu.Lock()
+	startSeq := st.seq // start from the current tail: only future events are returned
+	st.mu.Unlock()
+
+	return &Subscription{
+		stream:  st,
+		readSeq: startSeq,
+	}
+}
+
+// Unsubscribe marks the subscription as closed and wakes any goroutine blocked
+// in Recv so it can return promptly.
+func (b *EventBus) Unsubscribe(sub *Subscription) {
+	if sub == nil {
+		return
+	}
+	sub.closed.Store(true)
+	sub.stream.cond.Broadcast()
+}
+
+// Recv waits up to maxWaitMS milliseconds for new events and returns them as a batch.
+//
+//   - Returns (events, nil) when one or more events are available.
+//   - Returns (nil, nil) when the timeout elapses with no events, or when the
+//     subscription has been closed.
+//   - Returns (nil, ErrBufOverflow) when the subscriber has fallen more than
+//     bufSize events behind (ring buffer has lapped the read position).
+//   - Returns (nil, ctx.Err()) when the context is cancelled.
+func (sub *Subscription) Recv(ctx context.Context, maxWaitMS int64) ([]ChangeEvent, error) {
+	if sub.closed.Load() {
+		return nil, nil
+	}
+
+	deadline := time.Now().Add(time.Duration(maxWaitMS) * time.Millisecond)
+
+	sub.stream.mu.Lock()
+	defer sub.stream.mu.Unlock()
+
+	// timedOut is set by the AfterFunc goroutine (under sub.stream.mu) and read
+	// in the main goroutine (also under sub.stream.mu, via cond.Wait semantics).
+	var timedOut bool
+	timer := time.AfterFunc(time.Until(deadline), func() {
+		sub.stream.mu.Lock()
+		timedOut = true
+		sub.stream.mu.Unlock()
+		sub.stream.cond.Broadcast()
+	})
+	defer timer.Stop()
+
+	// Wake the cond if the context is cancelled, so we don't block forever.
+	watchDone := make(chan struct{})
+	defer close(watchDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			sub.stream.cond.Broadcast()
+		case <-watchDone:
+		}
+	}()
+
+	cap := int64(len(sub.stream.buf))
+
+	for {
+		// Check subscription closed.
+		if sub.closed.Load() {
+			return nil, nil
+		}
+
+		// Check context cancelled.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		lastSeq := sub.stream.seq
+
+		// Check overflow: subscriber is more than one full ring buffer behind.
+		if lastSeq-sub.readSeq > cap {
+			return nil, ErrBufOverflow
+		}
+
+		// Events available?
+		if sub.readSeq < lastSeq {
+			count := lastSeq - sub.readSeq
+			events := make([]ChangeEvent, 0, count)
+			for s := sub.readSeq + 1; s <= lastSeq; s++ {
+				pos := (s - 1) % cap
+				events = append(events, sub.stream.buf[pos])
+			}
+			sub.readSeq = lastSeq
+			return events, nil
+		}
+
+		// Timeout?
+		if timedOut {
+			return nil, nil
+		}
+
+		sub.stream.cond.Wait()
+	}
+}
+
+// Close shuts down the EventBus, waking all goroutines blocked in Recv.
+func (b *EventBus) Close() {
+	b.mu.Lock()
+	streams := make([]*nsStream, 0, len(b.streams))
+	for _, st := range b.streams {
+		streams = append(streams, st)
+	}
+	b.mu.Unlock()
+
+	for _, st := range streams {
+		st.mu.Lock()
+		st.closed = true
+		st.mu.Unlock()
+		st.cond.Broadcast()
+	}
+}

--- a/internal/storage/event_bus_test.go
+++ b/internal/storage/event_bus_test.go
@@ -1,0 +1,317 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// TestEventBusFastPath verifies that Publish returns immediately when no
+// subscriber has ever registered for the namespace (zero-watcher fast path).
+func TestEventBusFastPath(t *testing.T) {
+	bus := NewEventBus(10)
+
+	// Publishing to an unwatched namespace should be a no-op.
+	for i := 0; i < 100; i++ {
+		bus.Publish("db", "coll", ChangeEvent{OperationType: ChangeInsert})
+	}
+
+	// No nsStream should have been created.
+	bus.mu.RLock()
+	_, ok := bus.streams["db.coll"]
+	bus.mu.RUnlock()
+	if ok {
+		t.Fatal("fast path: nsStream created for unwatched namespace")
+	}
+}
+
+// TestEventBusPubSub verifies basic subscribe-then-publish-then-recv semantics.
+func TestEventBusPubSub(t *testing.T) {
+	bus := NewEventBus(100)
+
+	sub := bus.Subscribe("db.orders")
+
+	// Publish three events after subscribing.
+	bus.Publish("db", "orders", ChangeEvent{OperationType: ChangeInsert})
+	bus.Publish("db", "orders", ChangeEvent{OperationType: ChangeUpdate})
+	bus.Publish("db", "orders", ChangeEvent{OperationType: ChangeDelete})
+
+	ctx := context.Background()
+	events, err := sub.Recv(ctx, 1000)
+	if err != nil {
+		t.Fatalf("Recv error: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+	if events[0].OperationType != ChangeInsert {
+		t.Errorf("event[0].OperationType = %v, want ChangeInsert", events[0].OperationType)
+	}
+	if events[1].OperationType != ChangeUpdate {
+		t.Errorf("event[1].OperationType = %v, want ChangeUpdate", events[1].OperationType)
+	}
+	if events[2].OperationType != ChangeDelete {
+		t.Errorf("event[2].OperationType = %v, want ChangeDelete", events[2].OperationType)
+	}
+}
+
+// TestEventBusResumeToken verifies that each event gets a unique, monotonically
+// increasing resume token.
+func TestEventBusResumeToken(t *testing.T) {
+	bus := NewEventBus(10)
+	sub := bus.Subscribe("db.col")
+
+	bus.Publish("db", "col", ChangeEvent{OperationType: ChangeInsert})
+	bus.Publish("db", "col", ChangeEvent{OperationType: ChangeInsert})
+	bus.Publish("db", "col", ChangeEvent{OperationType: ChangeInsert})
+
+	events, err := sub.Recv(context.Background(), 500)
+	if err != nil {
+		t.Fatalf("Recv error: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(events))
+	}
+
+	// Tokens must be strictly increasing in Seq.
+	for i := 1; i < len(events); i++ {
+		if events[i].ResumeToken.Seq <= events[i-1].ResumeToken.Seq {
+			t.Errorf("event[%d].Seq = %d not > event[%d].Seq = %d",
+				i, events[i].ResumeToken.Seq,
+				i-1, events[i-1].ResumeToken.Seq)
+		}
+	}
+}
+
+// TestEventBusNamespace verifies that events carry the correct Namespace field.
+func TestEventBusNamespace(t *testing.T) {
+	bus := NewEventBus(10)
+	sub := bus.Subscribe("mydb.mycoll")
+
+	bus.Publish("mydb", "mycoll", ChangeEvent{OperationType: ChangeInsert})
+
+	events, err := sub.Recv(context.Background(), 500)
+	if err != nil {
+		t.Fatalf("Recv error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Namespace != "mydb.mycoll" {
+		t.Errorf("Namespace = %q, want %q", events[0].Namespace, "mydb.mycoll")
+	}
+}
+
+// TestEventBusMultipleSubscribers verifies fan-out: all subscribers receive the event.
+func TestEventBusMultipleSubscribers(t *testing.T) {
+	bus := NewEventBus(100)
+
+	sub1 := bus.Subscribe("db.items")
+	sub2 := bus.Subscribe("db.items")
+	sub3 := bus.Subscribe("db.items")
+
+	bus.Publish("db", "items", ChangeEvent{OperationType: ChangeReplace})
+
+	ctx := context.Background()
+	for i, sub := range []*Subscription{sub1, sub2, sub3} {
+		events, err := sub.Recv(ctx, 500)
+		if err != nil {
+			t.Fatalf("sub%d Recv error: %v", i+1, err)
+		}
+		if len(events) != 1 {
+			t.Fatalf("sub%d: expected 1 event, got %d", i+1, len(events))
+		}
+		if events[0].OperationType != ChangeReplace {
+			t.Errorf("sub%d: OperationType = %v, want ChangeReplace", i+1, events[0].OperationType)
+		}
+	}
+}
+
+// TestEventBusRingBufferOverflow verifies that ErrBufOverflow is returned when
+// the subscriber falls more than bufSize events behind.
+func TestEventBusRingBufferOverflow(t *testing.T) {
+	const bufSize = 5
+	bus := NewEventBus(bufSize)
+	sub := bus.Subscribe("db.fast")
+
+	// Publish bufSize+1 events without consuming any — this laps the ring buffer.
+	for i := 0; i <= bufSize; i++ {
+		bus.Publish("db", "fast", ChangeEvent{OperationType: ChangeInsert})
+	}
+
+	_, err := sub.Recv(context.Background(), 100)
+	if err != ErrBufOverflow {
+		t.Fatalf("expected ErrBufOverflow, got %v", err)
+	}
+}
+
+// TestEventBusTimeout verifies that Recv returns (nil, nil) when no events
+// arrive within maxWaitMS.
+func TestEventBusTimeout(t *testing.T) {
+	bus := NewEventBus(10)
+	sub := bus.Subscribe("db.slow")
+
+	start := time.Now()
+	events, err := sub.Recv(context.Background(), 50) // 50 ms timeout
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected nil error on timeout, got %v", err)
+	}
+	if events != nil {
+		t.Fatalf("expected nil events on timeout, got %v", events)
+	}
+	if elapsed < 40*time.Millisecond {
+		t.Errorf("returned too quickly: %v (expected ~50ms)", elapsed)
+	}
+}
+
+// TestEventBusUnsubscribeWakesRecv verifies that Unsubscribe wakes a blocked Recv.
+func TestEventBusUnsubscribeWakesRecv(t *testing.T) {
+	bus := NewEventBus(10)
+	sub := bus.Subscribe("db.wake")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		events, err := sub.Recv(context.Background(), 5000)
+		if err != nil {
+			t.Errorf("Recv error: %v", err)
+		}
+		if events != nil {
+			t.Errorf("expected nil events after Unsubscribe, got %v", events)
+		}
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	bus.Unsubscribe(sub)
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Recv did not return after Unsubscribe")
+	}
+}
+
+// TestEventBusContextCancel verifies that a cancelled context unblocks Recv.
+func TestEventBusContextCancel(t *testing.T) {
+	bus := NewEventBus(10)
+	sub := bus.Subscribe("db.ctx")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := sub.Recv(ctx, 5000)
+		done <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Recv did not return after context cancel")
+	}
+}
+
+// TestEventBusPublishSetsFields verifies that Publish sets ResumeToken and
+// Namespace on the stored event, overriding any caller-supplied values.
+func TestEventBusPublishSetsFields(t *testing.T) {
+	bus := NewEventBus(10)
+	sub := bus.Subscribe("mydb.coll")
+
+	docKeyRaw, _ := bson.Marshal(bson.D{{Key: "_id", Value: 42}})
+	fullDoc, _ := bson.Marshal(bson.D{{Key: "_id", Value: 42}, {Key: "x", Value: 1}})
+
+	bus.Publish("mydb", "coll", ChangeEvent{
+		OperationType: ChangeInsert,
+		DocumentKey:   docKeyRaw,
+		FullDocument:  fullDoc,
+	})
+
+	events, err := sub.Recv(context.Background(), 500)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("Recv returned (%v, %v)", events, err)
+	}
+
+	ev := events[0]
+	if ev.Namespace != "mydb.coll" {
+		t.Errorf("Namespace = %q, want %q", ev.Namespace, "mydb.coll")
+	}
+	if ev.ResumeToken.Seq != 1 {
+		t.Errorf("ResumeToken.Seq = %d, want 1", ev.ResumeToken.Seq)
+	}
+	if ev.ResumeToken.TimestampNS == 0 {
+		t.Error("ResumeToken.TimestampNS is zero")
+	}
+	if ev.OperationType != ChangeInsert {
+		t.Errorf("OperationType = %v, want ChangeInsert", ev.OperationType)
+	}
+}
+
+// TestEventBusIsolatedNamespaces verifies that events for one namespace do not
+// appear in subscriptions for a different namespace.
+func TestEventBusIsolatedNamespaces(t *testing.T) {
+	bus := NewEventBus(10)
+
+	subA := bus.Subscribe("db.a")
+	subB := bus.Subscribe("db.b")
+
+	bus.Publish("db", "a", ChangeEvent{OperationType: ChangeInsert})
+
+	ctx := context.Background()
+
+	eventsA, err := subA.Recv(ctx, 100)
+	if err != nil || len(eventsA) != 1 {
+		t.Fatalf("subA: expected 1 event, got (%v, %v)", eventsA, err)
+	}
+
+	// subB should time out with no events.
+	eventsB, err := subB.Recv(ctx, 30)
+	if err != nil {
+		t.Fatalf("subB: unexpected error %v", err)
+	}
+	if len(eventsB) != 0 {
+		t.Fatalf("subB: expected 0 events (different ns), got %d", len(eventsB))
+	}
+}
+
+// TestEventBusHasStream verifies the HasStream fast-path helper.
+func TestEventBusHasStream(t *testing.T) {
+	bus := NewEventBus(10)
+
+	if bus.HasStream("db", "coll") {
+		t.Error("HasStream: expected false before any Subscribe")
+	}
+
+	bus.Subscribe("db.coll")
+
+	if !bus.HasStream("db", "coll") {
+		t.Error("HasStream: expected true after Subscribe")
+	}
+}
+
+// TestEventBusMakeDocumentKey verifies the makeDocumentKey helper.
+func TestEventBusMakeDocumentKey(t *testing.T) {
+	id := bson.NewObjectID()
+	idVal := bson.RawValue{Type: bson.TypeObjectID}
+	raw, _ := bson.Marshal(bson.D{{Key: "_id", Value: id}})
+	idVal = bson.Raw(raw).Lookup("_id")
+
+	key := makeDocumentKey(idVal)
+	if key == nil {
+		t.Fatal("makeDocumentKey returned nil")
+	}
+	doc := bson.Raw(key)
+	got := doc.Lookup("_id")
+	if got.Type != bson.TypeObjectID {
+		t.Errorf("_id type = %v, want ObjectID", got.Type)
+	}
+}


### PR DESCRIPTION
Closes #127

## What
- New `EventBus` type (`internal/storage/event_bus.go`) with per-namespace ring buffers and fan-out via `sync.Cond.Broadcast`
- `Subscription` type with `Recv(ctx, maxWaitMS)` for blocked polling
- `InsertMany`, `UpdateOne/Many`, `ReplaceOne`, `DeleteOne/Many` publish `ChangeInsert`, `ChangeUpdate`, `ChangeReplace`, `ChangeDelete` events after transaction commit
- Phase 1 `UpdateDescription` placeholder (`{updatedFields:{}, removedFields:[], truncatedArrays:[]}`)
- `ErrBufOverflow` returned to subscribers that fall more than `bufSize` events behind (ring lapped)
- `BBoltEngine` initializes the bus in `NewBBoltEngine` and closes it in `Close()`

## Why
This is the foundational pub/sub layer for change streams (epic #15). Without the event bus, tailable cursors (#114) have nowhere to receive mutation notifications. The ring-buffer approach provides bounded memory use and O(1) publish regardless of subscriber count.

```yaml
agent:
  id: founder-agent-s1
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#127"]
```

*Posted by the founder agent on behalf of @inder*