### PR TITLE
feat(commands): implement shutdown command

### DIFF
--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -27,6 +27,9 @@ type Context struct {
 	NoAuth   bool
 	// RemoteAddr is the client's network address (for whatsmyuri).
 	RemoteAddr string
+	// ShutdownFunc, if non-nil, is called by the shutdown command handler to
+	// initiate a graceful server shutdown. It is set by the server layer.
+	ShutdownFunc func()
 }
 
 // Session represents a client session (for transactions and logical sessions).
@@ -138,6 +141,9 @@ func (d *Dispatcher) registerAll() {
 	d.register("usersinfo", handleUsersInfo)
 	d.register("grantrolestouser", handleGrantRolesToUser)
 	d.register("revokerolesfromuser", handleRevokeRolesFromUser)
+
+	// Server lifecycle
+	d.register("shutdown", handleShutdown)
 
 	// Cursors / Sessions
 	d.register("getmore", handleGetMore)

--- a/internal/commands/shutdown.go
+++ b/internal/commands/shutdown.go
@@ -1,0 +1,56 @@
+package commands
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/inder/salvobase/internal/storage"
+)
+
+// handleShutdown handles the MongoDB "shutdown" command.
+// It initiates a graceful server shutdown and returns {"ok": 1}.
+// Per the MongoDB spec, the command must be run against the admin database.
+// The optional "timeoutSecs" parameter (default 10) is accepted but not used
+// beyond validation; Salvobase always attempts a graceful shutdown.
+// The optional "force" boolean is accepted for compatibility.
+func handleShutdown(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
+	if ctx.DB != "admin" {
+		return nil, storage.Errorf(storage.ErrCodeIllegalOperation,
+			"shutdown must be run against the admin database")
+	}
+
+	// Validate timeoutSecs if provided.
+	if val, err := cmd.LookupErr("timeoutSecs"); err == nil {
+		var secs int32
+		switch val.Type {
+		case bson.TypeInt32:
+			secs = val.Int32()
+		case bson.TypeInt64:
+			secs = int32(val.Int64())
+		case bson.TypeDouble:
+			secs = int32(val.Double())
+		default:
+			return nil, storage.Errorf(storage.ErrCodeBadValue,
+				"shutdown: 'timeoutSecs' must be a number")
+		}
+		if secs < 0 {
+			return nil, storage.Errorf(storage.ErrCodeBadValue,
+				"shutdown: 'timeoutSecs' must be non-negative")
+		}
+	}
+
+	ctx.Logger.Info("shutdown command received, initiating graceful shutdown")
+
+	if ctx.ShutdownFunc != nil {
+		// Fire shutdown in a goroutine so that the ok:1 response is flushed
+		// to the client before the server closes its listener and connections.
+		shutdownFn := ctx.ShutdownFunc
+		go func() {
+			time.Sleep(100 * time.Millisecond)
+			shutdownFn()
+		}()
+	}
+
+	return BuildOKResponse(), nil
+}

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -272,6 +272,9 @@ func (c *Connection) buildContext(db string) *commands.Context {
 		ConnID:     c.id,
 		NoAuth:     c.server.cfg.NoAuth,
 		RemoteAddr: c.conn.RemoteAddr().String(),
+		ShutdownFunc: func() {
+			_ = c.server.Shutdown()
+		},
 	}
 
 	if c.authed {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -5186,6 +5186,31 @@ func TestCappedCollectionMaxDocs(t *testing.T) {
 	}
 }
 
+// ─── Shutdown ─────────────────────────────────────────────────────────────────
+
+// TestZShutdownCommandErrors verifies error handling for the shutdown command
+// without triggering an actual server shutdown.
+// The "Z" prefix keeps it near the end of the alphabetical test order.
+func TestZShutdownCommandErrors(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	// Calling shutdown against a non-admin database must be rejected.
+	var result bson.M
+	err := client.Database("test").RunCommand(ctx, bson.D{{Key: "shutdown", Value: 1}}).Decode(&result)
+	if err == nil {
+		t.Fatal("expected error when running shutdown against non-admin database, got nil")
+	}
+
+	// Calling shutdown with a negative timeoutSecs must be rejected.
+	err = client.Database("admin").RunCommand(ctx,
+		bson.D{{Key: "shutdown", Value: 1}, {Key: "timeoutSecs", Value: int32(-1)}},
+	).Decode(&result)
+	if err == nil {
+		t.Fatal("expected error for negative timeoutSecs, got nil")
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())


### PR DESCRIPTION
Closes #36

## What
Implement the `shutdown` MongoDB wire protocol command:
- New `internal/commands/shutdown.go` handler that validates the request (must target `admin` DB, `timeoutSecs` must be non-negative) and returns `{"ok": 1}` before initiating graceful shutdown
- Added `ShutdownFunc func()` to `commands.Context` so the handler can trigger server-level shutdown without a circular import
- Wired `ShutdownFunc` in `server/connection.go buildContext` to call `server.Shutdown()`
- Registered `shutdown` in the command dispatcher
- Added integration tests for the error cases (non-admin DB, negative `timeoutSecs`)

## Why
The `shutdown` command is part of the MongoDB wire protocol spec and was missing from salvobase, preventing wire-protocol-level server lifecycle management.

```yaml
agent:
  id: founder-agent-s1
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#36"]
```

*Posted by the founder agent on behalf of @inder*