### PR TITLE
feat(commands): implement shutdown command

### DIFF
--- a/internal/commands/diagnostic.go
+++ b/internal/commands/diagnostic.go
@@ -16,6 +16,20 @@ import (
 // serverStartTime records when this process started.
 var serverStartTime = time.Now()
 
+// handleShutdown handles the "shutdown" command.
+// It initiates a graceful server shutdown after the response has been sent.
+// The command document must contain {"shutdown": 1}; any other value is an error.
+// Optional fields: force (bool), timeoutSecs (int, unused — shutdown is always graceful).
+func handleShutdown(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
+	if lookupInt64Field(cmd, "shutdown") != 1 {
+		return nil, storage.Errorf(storage.ErrCodeBadValue, "shutdown: field value must be 1")
+	}
+	if ctx.ShutdownFunc != nil {
+		ctx.ShutdownFunc()
+	}
+	return BuildOKResponse(), nil
+}
+
 // processObjectID is a stable ObjectID representing this server process.
 var processObjectID = bson.NewObjectID()
 

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -27,6 +27,9 @@ type Context struct {
 	NoAuth   bool
 	// RemoteAddr is the client's network address (for whatsmyuri).
 	RemoteAddr string
+	// ShutdownFunc, if non-nil, is called by the shutdown command handler to
+	// initiate a graceful server shutdown after the response has been sent.
+	ShutdownFunc func()
 }
 
 // Session represents a client session (for transactions and logical sessions).
@@ -138,6 +141,9 @@ func (d *Dispatcher) registerAll() {
 	d.register("usersinfo", handleUsersInfo)
 	d.register("grantrolestouser", handleGrantRolesToUser)
 	d.register("revokerolesfromuser", handleRevokeRolesFromUser)
+
+	// Server lifecycle
+	d.register("shutdown", handleShutdown)
 
 	// Cursors / Sessions
 	d.register("getmore", handleGetMore)
@@ -253,6 +259,8 @@ func cmdNameToAction(cmdName string) string {
 	case "createuser", "dropuser", "updateuser", "usersinfo",
 		"grantrolestouser", "revokerolesfromuser":
 		return "createUser"
+	case "shutdown":
+		return "shutdown"
 	default:
 		return "find"
 	}

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -264,14 +264,23 @@ func (c *Connection) handleOpDelete(msg *wire.OpDeleteMessage) error {
 
 // buildContext creates a command execution context for the current connection state.
 func (c *Connection) buildContext(db string) *commands.Context {
+	srv := c.server
 	ctx := &commands.Context{
 		DB:         db,
-		Engine:     c.server.engine,
-		Auth:       c.server.authMgr,
+		Engine:     srv.engine,
+		Auth:       srv.authMgr,
 		Logger:     c.logger,
 		ConnID:     c.id,
-		NoAuth:     c.server.cfg.NoAuth,
+		NoAuth:     srv.cfg.NoAuth,
 		RemoteAddr: c.conn.RemoteAddr().String(),
+		// ShutdownFunc triggers a graceful shutdown after the response is sent.
+		// The 200 ms delay ensures the response is flushed to the client first.
+		ShutdownFunc: func() {
+			go func() {
+				time.Sleep(200 * time.Millisecond)
+				srv.Shutdown() //nolint:errcheck
+			}()
+		},
 	}
 
 	if c.authed {

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -5186,6 +5186,25 @@ func TestCappedCollectionMaxDocs(t *testing.T) {
 	}
 }
 
+// TestShutdownCommandInvalidValue verifies that the shutdown command rejects
+// values other than 1 with a descriptive error.
+func TestShutdownCommandInvalidValue(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	// shutdown: 0 must be rejected.
+	res := client.Database("admin").RunCommand(ctx, bson.D{{Key: "shutdown", Value: int32(0)}})
+	if res.Err() == nil {
+		t.Fatal("expected error for shutdown:0, got nil")
+	}
+
+	// shutdown: 2 must also be rejected.
+	res = client.Database("admin").RunCommand(ctx, bson.D{{Key: "shutdown", Value: int32(2)}})
+	if res.Err() == nil {
+		t.Fatal("expected error for shutdown:2, got nil")
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())


### PR DESCRIPTION
Closes #36

## What
- Added `ShutdownFunc func()` callback field to `commands.Context`
- Registered `shutdown` command handler in `Dispatcher.registerAll()`
- Implemented `handleShutdown` in `internal/commands/diagnostic.go` — validates that the command value is `1`, then invokes `ctx.ShutdownFunc` if set
- Wired `ShutdownFunc` in `server/connection.go`'s `buildContext()` to call `srv.Shutdown()` after a 200 ms delay, ensuring the response is flushed before connections are closed
- Added integration tests for the invalid-value error path

## Why
The `shutdown` command is part of the MongoDB wire protocol. Without it, clients that call `db.adminCommand({shutdown:1})` receive "no such command" instead of a graceful shutdown, breaking standard MongoDB tooling.

```yaml
agent:
  id: founder-agent-s3
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#36"]
```

*Posted by the founder agent on behalf of @inder*