### PR TITLE
fix(storage): fix lint errors in event bus (misspellings, gofmt, ineffassign)

### DIFF
--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -874,9 +874,9 @@ func (e *BBoltEngine) getCollectionInfo(db, coll string) (CollectionInfo, bool) 
 
 // ─── Cursors / Users ──────────────────────────────────────────────────────────
 
-func (e *BBoltEngine) Cursors() CursorStore   { return e.cursors }
-func (e *BBoltEngine) Users() UserStore       { return e.users }
-func (e *BBoltEngine) EventBus() *EventBus    { return e.eventBus }
+func (e *BBoltEngine) Cursors() CursorStore { return e.cursors }
+func (e *BBoltEngine) Users() UserStore     { return e.users }
+func (e *BBoltEngine) EventBus() *EventBus  { return e.eventBus }
 
 // ─── Close ────────────────────────────────────────────────────────────────────
 

--- a/internal/storage/event_bus.go
+++ b/internal/storage/event_bus.go
@@ -171,7 +171,7 @@ func (b *EventBus) Publish(db, coll string, event ChangeEvent) {
 // Obtain via EventBus.Subscribe; release with EventBus.Unsubscribe.
 type Subscription struct {
 	stream  *nsStream
-	readSeq int64      // last consumed sequence number (0 = nothing consumed yet)
+	readSeq int64 // last consumed sequence number (0 = nothing consumed yet)
 	closed  atomic.Bool
 }
 
@@ -215,7 +215,7 @@ func (b *EventBus) Unsubscribe(sub *Subscription) {
 //     subscription has been closed.
 //   - Returns (nil, ErrBufOverflow) when the subscriber has fallen more than
 //     bufSize events behind (ring buffer has lapped the read position).
-//   - Returns (nil, ctx.Err()) when the context is cancelled.
+//   - Returns (nil, ctx.Err()) when the context is canceled.
 func (sub *Subscription) Recv(ctx context.Context, maxWaitMS int64) ([]ChangeEvent, error) {
 	if sub.closed.Load() {
 		return nil, nil
@@ -237,7 +237,7 @@ func (sub *Subscription) Recv(ctx context.Context, maxWaitMS int64) ([]ChangeEve
 	})
 	defer timer.Stop()
 
-	// Wake the cond if the context is cancelled, so we don't block forever.
+	// Wake the cond if the context is canceled, so we don't block forever.
 	watchDone := make(chan struct{})
 	defer close(watchDone)
 	go func() {
@@ -256,7 +256,7 @@ func (sub *Subscription) Recv(ctx context.Context, maxWaitMS int64) ([]ChangeEve
 			return nil, nil
 		}
 
-		// Check context cancelled.
+		// Check context canceled.
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/internal/storage/event_bus_test.go
+++ b/internal/storage/event_bus_test.go
@@ -195,7 +195,7 @@ func TestEventBusUnsubscribeWakesRecv(t *testing.T) {
 	}
 }
 
-// TestEventBusContextCancel verifies that a cancelled context unblocks Recv.
+// TestEventBusContextCancel verifies that a canceled context unblocks Recv.
 func TestEventBusContextCancel(t *testing.T) {
 	bus := NewEventBus(10)
 	sub := bus.Subscribe("db.ctx")
@@ -301,9 +301,8 @@ func TestEventBusHasStream(t *testing.T) {
 // TestEventBusMakeDocumentKey verifies the makeDocumentKey helper.
 func TestEventBusMakeDocumentKey(t *testing.T) {
 	id := bson.NewObjectID()
-	idVal := bson.RawValue{Type: bson.TypeObjectID}
 	raw, _ := bson.Marshal(bson.D{{Key: "_id", Value: id}})
-	idVal = bson.Raw(raw).Lookup("_id")
+	idVal := bson.Raw(raw).Lookup("_id")
 
 	key := makeDocumentKey(idVal)
 	if key == nil {


### PR DESCRIPTION
## What

CI is failing on master due to lint errors introduced by PR #165 (event bus implementation). This fixes them:

- `cancelled` → `canceled` (misspell linter) in 3 comments in `event_bus.go` and 1 in `event_bus_test.go`
- Remove ineffectual initial `bson.RawValue{Type: bson.TypeObjectID}` assignment in `TestEventBusMakeDocumentKey` (ineffassign linter)
- `gofmt` fixes: trailing alignment spaces in `Subscription` struct field comment and in `BBoltEngine` accessor stubs in `engine.go`

## Why

Master CI is red. All other jobs (unit tests, integration tests, builds) pass. Only the Lint job fails. This unblocks CI and clears the way for future PRs.

```yaml
agent:
  id: founder-agent-ci
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
```

*Posted by the founder agent on behalf of @inder*