### PR TITLE
feat(aggregation): implement $changeStream stage and tailable cursor response

### DIFF
--- a/internal/aggregation/pipeline.go
+++ b/internal/aggregation/pipeline.go
@@ -19,7 +19,24 @@ type PipelineOptions struct {
 
 // Execute runs an aggregation pipeline against a collection.
 // Returns a Cursor over all result documents.
+//
+// If the first pipeline stage is $changeStream, Execute returns a
+// storage.TailableCursor (backed by the engine's event bus) without
+// scanning the collection. Subsequent stages in the pipeline are not
+// applied in Phase 1.
 func Execute(coll storage.Collection, engine storage.Engine, db string, pipeline []bson.Raw, opts PipelineOptions) (storage.Cursor, error) {
+	// Detect $changeStream as the first pipeline stage.
+	if len(pipeline) > 0 {
+		csOpts, isCS := parseChangeStreamStage(pipeline[0])
+		if isCS {
+			collName := ""
+			if coll != nil {
+				collName = coll.Name()
+			}
+			return storage.NewChangeStreamCursor(engine.EventBus(), db, collName, csOpts)
+		}
+	}
+
 	// Collect all documents from the collection.
 	var allDocs []bson.Raw
 	if coll != nil {
@@ -59,4 +76,55 @@ func Execute(coll storage.Collection, engine storage.Engine, db string, pipeline
 	}
 
 	return &memoryCursor{docs: current}, nil
+}
+
+// parseChangeStreamStage returns the ChangeStreamOptions and true if spec is a
+// $changeStream stage document. Returns false for any other stage.
+func parseChangeStreamStage(spec bson.Raw) (storage.ChangeStreamOptions, bool) {
+	elems, err := spec.Elements()
+	if err != nil || len(elems) == 0 {
+		return storage.ChangeStreamOptions{}, false
+	}
+	if elems[0].Key() != "$changeStream" {
+		return storage.ChangeStreamOptions{}, false
+	}
+
+	var opts storage.ChangeStreamOptions
+
+	stageVal := elems[0].Value()
+	doc, ok := stageVal.DocumentOK()
+	if !ok {
+		// $changeStream: {} or $changeStream: 1 — both valid; use defaults.
+		return opts, true
+	}
+
+	// resumeAfter
+	if ra, err := doc.LookupErr("resumeAfter"); err == nil {
+		if raw, ok := ra.DocumentOK(); ok {
+			opts.ResumeAfter = raw
+		}
+	}
+
+	// startAfter
+	if sa, err := doc.LookupErr("startAfter"); err == nil {
+		if raw, ok := sa.DocumentOK(); ok {
+			opts.StartAfter = raw
+		}
+	}
+
+	// startAtOperationTime (BSON Timestamp)
+	if ts, err := doc.LookupErr("startAtOperationTime"); err == nil {
+		if t, i, ok := ts.TimestampOK(); ok {
+			opts.StartAtOperationTime = &bson.Timestamp{T: t, I: i}
+		}
+	}
+
+	// fullDocument
+	if fd, err := doc.LookupErr("fullDocument"); err == nil {
+		if s, ok := fd.StringValueOK(); ok {
+			opts.FullDocument = s
+		}
+	}
+
+	return opts, true
 }

--- a/internal/commands/cursor_cmds.go
+++ b/internal/commands/cursor_cmds.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"time"
 
 	"github.com/google/uuid"
@@ -40,13 +41,51 @@ func handleGetMore(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 			"cursor id %d not found", cursorID)
 	}
 
+	ns := ctx.DB + "." + collName
+
+	// Tailable cursor (change stream): block until events arrive or timeout.
+	if tc, isTailable := cursor.(storage.TailableCursor); isTailable {
+		maxAwaitTimeMS := lookupInt64Field(cmd, "maxAwaitTimeMS")
+		if maxAwaitTimeMS <= 0 {
+			maxAwaitTimeMS = 1000
+		}
+
+		docs, postBatchResumeToken, err := tc.NextBatchWait(context.Background(), int(batchSize), maxAwaitTimeMS)
+		if err != nil {
+			me, isMongo := err.(*storage.MongoError)
+			if isMongo && me.Code == storage.ErrCodeChangeStreamHistoryLost {
+				ctx.Engine.Cursors().Delete(cursorID)
+			}
+			return nil, err
+		}
+
+		nextBatch := make(bson.A, len(docs))
+		for i, d := range docs {
+			nextBatch[i] = d
+		}
+
+		cursorDoc := bson.D{
+			{Key: "id", Value: cursorID},
+			{Key: "ns", Value: ns},
+			{Key: "nextBatch", Value: nextBatch},
+		}
+		if postBatchResumeToken != nil {
+			cursorDoc = append(cursorDoc, bson.E{Key: "postBatchResumeToken", Value: postBatchResumeToken})
+		}
+
+		return marshalResponse(bson.D{
+			{Key: "cursor", Value: cursorDoc},
+			{Key: "ok", Value: float64(1)},
+		}), nil
+	}
+
+	// Regular cursor.
 	docs, exhausted, err := cursor.NextBatch(int(batchSize))
 	if err != nil {
 		ctx.Engine.Cursors().Delete(cursorID)
 		return nil, err
 	}
 
-	ns := ctx.DB + "." + collName
 	var returnedCursorID int64
 
 	if exhausted {

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -342,6 +342,8 @@ func mongoErrorCodeName(code int32) string {
 		return "CommandFailed"
 	case 238:
 		return "NotImplemented"
+	case 286:
+		return "ChangeStreamHistoryLost"
 	default:
 		return "UnknownError"
 	}

--- a/internal/storage/change_stream_cursor.go
+++ b/internal/storage/change_stream_cursor.go
@@ -1,0 +1,278 @@
+package storage
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// ChangeStreamOptions are parsed from the $changeStream stage document.
+type ChangeStreamOptions struct {
+	// ResumeAfter is a resume token from a previous change event _id.
+	ResumeAfter bson.Raw
+	// StartAfter is like ResumeAfter but also returns the event matching the token.
+	StartAfter bson.Raw
+	// StartAtOperationTime is a BSON Timestamp to start streaming from.
+	StartAtOperationTime *bson.Timestamp
+	// FullDocument controls pre/post image lookup (Phase 1: "default" only).
+	FullDocument string
+}
+
+// changeStreamCursor is a tailable cursor over a collection's change stream.
+// It implements TailableCursor via a subscription to the EventBus.
+type changeStreamCursor struct {
+	mu   sync.Mutex
+	id   int64
+	ns   string
+	db   string
+	coll string
+	bus  *EventBus
+	sub  *Subscription
+	closed bool
+}
+
+// NewChangeStreamCursor creates a change stream cursor for db.coll.
+// The opts control where in the event history to start.
+func NewChangeStreamCursor(bus *EventBus, db, coll string, opts ChangeStreamOptions) (*changeStreamCursor, error) {
+	ns := db + "." + coll
+
+	var sub *Subscription
+	var err error
+
+	switch {
+	case opts.ResumeAfter != nil:
+		// Start after the event identified by the resume token.
+		afterSeq, tokenErr := seqFromTokenDoc(opts.ResumeAfter)
+		if tokenErr != nil {
+			return nil, fmt.Errorf("$changeStream: invalid resumeAfter token: %w", tokenErr)
+		}
+		sub, err = bus.SubscribeFrom(ns, afterSeq)
+		if err == ErrBufOverflow {
+			return nil, Errorf(ErrCodeChangeStreamHistoryLost, "change stream history lost")
+		}
+		if err != nil {
+			return nil, err
+		}
+
+	case opts.StartAfter != nil:
+		// StartAfter includes the event matching the token; position one before it.
+		afterSeq, tokenErr := seqFromTokenDoc(opts.StartAfter)
+		if tokenErr != nil {
+			return nil, fmt.Errorf("$changeStream: invalid startAfter token: %w", tokenErr)
+		}
+		startSeq := afterSeq - 1
+		if startSeq < 0 {
+			startSeq = 0
+		}
+		sub, err = bus.SubscribeFrom(ns, startSeq)
+		if err == ErrBufOverflow {
+			return nil, Errorf(ErrCodeChangeStreamHistoryLost, "change stream history lost")
+		}
+		if err != nil {
+			return nil, err
+		}
+
+	case opts.StartAtOperationTime != nil:
+		// Start at the given operation time (BSON Timestamp → nanoseconds).
+		tsNS := int64(opts.StartAtOperationTime.T) * int64(time.Second)
+		sub, err = bus.SubscribeFromTime(ns, tsNS)
+		if err == ErrBufOverflow {
+			return nil, Errorf(ErrCodeChangeStreamHistoryLost, "change stream history lost")
+		}
+		if err != nil {
+			return nil, err
+		}
+
+	default:
+		// No resume info: subscribe from current tail (only future events).
+		sub = bus.Subscribe(ns)
+	}
+
+	return &changeStreamCursor{
+		ns:   ns,
+		db:   db,
+		coll: coll,
+		bus:  bus,
+		sub:  sub,
+	}, nil
+}
+
+// NextBatch implements Cursor. Returns available events without blocking.
+// Change stream cursors are never exhausted; exhausted is always false.
+func (c *changeStreamCursor) NextBatch(batchSize int) ([]bson.Raw, bool, error) {
+	docs, _, err := c.NextBatchWait(context.Background(), batchSize, 0)
+	return docs, false, err
+}
+
+// NextBatchWait implements TailableCursor. Blocks up to maxWaitMS for events.
+// Returns the event documents and the post-batch resume token (or nil if no events).
+func (c *changeStreamCursor) NextBatchWait(ctx context.Context, batchSize int, maxWaitMS int64) ([]bson.Raw, bson.Raw, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, nil, nil
+	}
+	c.mu.Unlock()
+
+	if maxWaitMS < 0 {
+		maxWaitMS = 0
+	}
+	if maxWaitMS > 60000 {
+		maxWaitMS = 60000
+	}
+
+	events, err := c.sub.Recv(ctx, maxWaitMS)
+	if err == ErrBufOverflow {
+		return nil, nil, Errorf(ErrCodeChangeStreamHistoryLost, "change stream history lost")
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(events) == 0 {
+		return nil, nil, nil
+	}
+
+	if batchSize <= 0 {
+		batchSize = 101
+	}
+	if len(events) > batchSize {
+		events = events[:batchSize]
+	}
+
+	docs := make([]bson.Raw, 0, len(events))
+	for _, ev := range events {
+		doc, docErr := changeEventToDoc(ev)
+		if docErr != nil {
+			continue
+		}
+		docs = append(docs, doc)
+	}
+
+	// Compute the post-batch resume token from the last event.
+	last := events[len(events)-1]
+	tokenStr := encodeResumeToken(last.ResumeToken)
+	pbrt, marshalErr := bson.Marshal(bson.D{{Key: "_data", Value: tokenStr}})
+	if marshalErr != nil {
+		pbrt = nil
+	}
+
+	return docs, pbrt, nil
+}
+
+// Close implements Cursor. Unsubscribes from the event bus.
+func (c *changeStreamCursor) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	c.bus.Unsubscribe(c.sub)
+	return nil
+}
+
+// ID implements Cursor.
+func (c *changeStreamCursor) ID() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.id
+}
+
+// setID is called by cursorStore.Register to stamp the assigned cursor ID.
+func (c *changeStreamCursor) setID(id int64) {
+	c.mu.Lock()
+	c.id = id
+	c.mu.Unlock()
+}
+
+// ─── Change event document ────────────────────────────────────────────────────
+
+// changeEventToDoc serialises a ChangeEvent into a MongoDB change event document.
+func changeEventToDoc(ev ChangeEvent) (bson.Raw, error) {
+	tokenStr := encodeResumeToken(ev.ResumeToken)
+
+	db, coll := splitNS(ev.Namespace)
+
+	tSecs := uint32(time.Unix(0, ev.ResumeToken.TimestampNS).Unix())
+	tIncr := uint32(ev.ResumeToken.Seq & 0xFFFFFFFF)
+
+	d := bson.D{
+		{Key: "_id", Value: bson.D{{Key: "_data", Value: tokenStr}}},
+		{Key: "operationType", Value: string(ev.OperationType)},
+		{Key: "clusterTime", Value: bson.Timestamp{T: tSecs, I: tIncr}},
+		{Key: "ns", Value: bson.D{
+			{Key: "db", Value: db},
+			{Key: "coll", Value: coll},
+		}},
+		{Key: "documentKey", Value: ev.DocumentKey},
+	}
+
+	if ev.FullDocument != nil && (ev.OperationType == ChangeInsert || ev.OperationType == ChangeReplace) {
+		d = append(d, bson.E{Key: "fullDocument", Value: ev.FullDocument})
+	}
+
+	if ev.OperationType == ChangeUpdate && ev.UpdateDescription != nil {
+		d = append(d, bson.E{Key: "updateDescription", Value: ev.UpdateDescription})
+	}
+
+	return bson.Marshal(d)
+}
+
+func splitNS(ns string) (db, coll string) {
+	idx := strings.IndexByte(ns, '.')
+	if idx < 0 {
+		return ns, ""
+	}
+	return ns[:idx], ns[idx+1:]
+}
+
+// ─── Resume token encoding/decoding ──────────────────────────────────────────
+
+// encodeResumeToken encodes a ResumeToken as base64url (no padding).
+// Layout: 8 big-endian bytes (nanosecond timestamp) + 8 big-endian bytes (seq).
+func encodeResumeToken(rt ResumeToken) string {
+	var buf [16]byte
+	binary.BigEndian.PutUint64(buf[0:8], uint64(rt.TimestampNS))
+	binary.BigEndian.PutUint64(buf[8:16], uint64(rt.Seq))
+	return base64.RawURLEncoding.EncodeToString(buf[:])
+}
+
+// decodeResumeToken decodes a base64url-encoded resume token string.
+func decodeResumeToken(s string) (ResumeToken, error) {
+	buf, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		return ResumeToken{}, fmt.Errorf("invalid resume token: %w", err)
+	}
+	if len(buf) != 16 {
+		return ResumeToken{}, fmt.Errorf("resume token: expected 16 bytes, got %d", len(buf))
+	}
+	return ResumeToken{
+		TimestampNS: int64(binary.BigEndian.Uint64(buf[0:8])),
+		Seq:         int64(binary.BigEndian.Uint64(buf[8:16])),
+	}, nil
+}
+
+// seqFromTokenDoc extracts the sequence number from a resume token document
+// of the shape {"_data": "<base64url>"}.
+func seqFromTokenDoc(doc bson.Raw) (int64, error) {
+	dataVal, err := doc.LookupErr("_data")
+	if err != nil {
+		return 0, fmt.Errorf("resume token missing '_data' field")
+	}
+	s, ok := dataVal.StringValueOK()
+	if !ok {
+		return 0, fmt.Errorf("resume token '_data' must be a string")
+	}
+	rt, err := decodeResumeToken(s)
+	if err != nil {
+		return 0, err
+	}
+	return rt.Seq, nil
+}

--- a/internal/storage/change_stream_cursor_test.go
+++ b/internal/storage/change_stream_cursor_test.go
@@ -1,0 +1,259 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// TestResumeTokenRoundtrip verifies encode → decode round-trips correctly.
+func TestResumeTokenRoundtrip(t *testing.T) {
+	rt := ResumeToken{
+		TimestampNS: time.Now().UnixNano(),
+		Seq:         42,
+	}
+	encoded := encodeResumeToken(rt)
+	decoded, err := decodeResumeToken(encoded)
+	if err != nil {
+		t.Fatalf("decodeResumeToken: %v", err)
+	}
+	if decoded.TimestampNS != rt.TimestampNS {
+		t.Errorf("TimestampNS: got %d, want %d", decoded.TimestampNS, rt.TimestampNS)
+	}
+	if decoded.Seq != rt.Seq {
+		t.Errorf("Seq: got %d, want %d", decoded.Seq, rt.Seq)
+	}
+}
+
+// TestDecodeResumeTokenInvalid checks that invalid tokens return errors.
+func TestDecodeResumeTokenInvalid(t *testing.T) {
+	for _, bad := range []string{"", "abc", "!!!@@@"} {
+		_, err := decodeResumeToken(bad)
+		if err == nil {
+			t.Errorf("expected error for %q, got nil", bad)
+		}
+	}
+}
+
+// TestChangeStreamCursorReceivesEvents verifies that a cursor receives
+// events published after it was created.
+func TestChangeStreamCursorReceivesEvents(t *testing.T) {
+	bus := NewEventBus(100)
+	defer bus.Close()
+
+	docKey, _ := bson.Marshal(bson.D{{Key: "_id", Value: bson.NewObjectID()}})
+	fullDoc, _ := bson.Marshal(bson.D{{Key: "x", Value: 1}})
+
+	cur, err := NewChangeStreamCursor(bus, "testdb", "col", ChangeStreamOptions{})
+	if err != nil {
+		t.Fatalf("NewChangeStreamCursor: %v", err)
+	}
+	defer cur.Close()
+
+	// Publish one insert event.
+	bus.Publish("testdb", "col", ChangeEvent{
+		OperationType: ChangeInsert,
+		DocumentKey:   docKey,
+		FullDocument:  fullDoc,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	docs, pbrt, err := cur.NextBatchWait(ctx, 10, 500)
+	if err != nil {
+		t.Fatalf("NextBatchWait: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc, got %d", len(docs))
+	}
+	if pbrt == nil {
+		t.Error("expected non-nil postBatchResumeToken")
+	}
+
+	// Verify document shape.
+	doc := docs[0]
+	opType, err := doc.LookupErr("operationType")
+	if err != nil {
+		t.Fatalf("operationType missing: %v", err)
+	}
+	if s, _ := opType.StringValueOK(); s != "insert" {
+		t.Errorf("operationType: got %q, want %q", s, "insert")
+	}
+
+	// fullDocument should be present for inserts.
+	if _, err := doc.LookupErr("fullDocument"); err != nil {
+		t.Error("fullDocument missing from insert event")
+	}
+}
+
+// TestChangeStreamCursorTimeout verifies that NextBatchWait returns an empty
+// batch (no error) when no events arrive within maxWaitMS.
+func TestChangeStreamCursorTimeout(t *testing.T) {
+	bus := NewEventBus(100)
+	defer bus.Close()
+
+	cur, err := NewChangeStreamCursor(bus, "testdb", "col2", ChangeStreamOptions{})
+	if err != nil {
+		t.Fatalf("NewChangeStreamCursor: %v", err)
+	}
+	defer cur.Close()
+
+	start := time.Now()
+	docs, pbrt, err := cur.NextBatchWait(context.Background(), 10, 100)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Errorf("expected 0 docs on timeout, got %d", len(docs))
+	}
+	if pbrt != nil {
+		t.Error("expected nil postBatchResumeToken on timeout")
+	}
+	if elapsed < 80*time.Millisecond {
+		t.Errorf("returned too fast: %v (want >= 80ms)", elapsed)
+	}
+}
+
+// TestChangeStreamCursorResumeAfter verifies that a cursor opened with
+// resumeAfter picks up only events after the specified token.
+func TestChangeStreamCursorResumeAfter(t *testing.T) {
+	bus := NewEventBus(100)
+	defer bus.Close()
+
+	docKey, _ := bson.Marshal(bson.D{{Key: "_id", Value: 1}})
+	fullDoc, _ := bson.Marshal(bson.D{{Key: "n", Value: 1}})
+
+	// Subscribe first cursor to receive event A.
+	cur1, err := NewChangeStreamCursor(bus, "testdb", "col3", ChangeStreamOptions{})
+	if err != nil {
+		t.Fatalf("NewChangeStreamCursor: %v", err)
+	}
+
+	// Publish event A.
+	bus.Publish("testdb", "col3", ChangeEvent{
+		OperationType: ChangeInsert,
+		DocumentKey:   docKey,
+		FullDocument:  fullDoc,
+	})
+
+	// Drain event A from cur1 to get its resume token.
+	ctx := context.Background()
+	docs1, pbrt1, err := cur1.NextBatchWait(ctx, 10, 500)
+	if err != nil || len(docs1) != 1 {
+		t.Fatalf("expected 1 doc from cur1, got %d (err: %v)", len(docs1), err)
+	}
+	cur1.Close()
+
+	// Publish event B AFTER we have the resume token for A.
+	docKey2, _ := bson.Marshal(bson.D{{Key: "_id", Value: 2}})
+	fullDoc2, _ := bson.Marshal(bson.D{{Key: "n", Value: 2}})
+	bus.Publish("testdb", "col3", ChangeEvent{
+		OperationType: ChangeInsert,
+		DocumentKey:   docKey2,
+		FullDocument:  fullDoc2,
+	})
+
+	// Open cur2 with resumeAfter = pbrt1 (should see only event B).
+	cur2, err := NewChangeStreamCursor(bus, "testdb", "col3", ChangeStreamOptions{
+		ResumeAfter: pbrt1,
+	})
+	if err != nil {
+		t.Fatalf("NewChangeStreamCursor (resumeAfter): %v", err)
+	}
+	defer cur2.Close()
+
+	docs2, _, err := cur2.NextBatchWait(ctx, 10, 500)
+	if err != nil {
+		t.Fatalf("NextBatchWait (resumeAfter): %v", err)
+	}
+	if len(docs2) != 1 {
+		t.Fatalf("expected 1 doc from resumed cursor, got %d", len(docs2))
+	}
+
+	// Verify it's event B.
+	opType, _ := docs2[0].LookupErr("operationType")
+	if s, _ := opType.StringValueOK(); s != "insert" {
+		t.Errorf("expected insert, got %s", s)
+	}
+}
+
+// TestChangeStreamCursorBufOverflow verifies that a stale resumeAfter returns
+// ErrCodeChangeStreamHistoryLost.
+func TestChangeStreamCursorBufOverflow(t *testing.T) {
+	bus := NewEventBus(5) // tiny ring buffer
+
+	// Fill the ring buffer so seq=1 is overwritten.
+	docKey, _ := bson.Marshal(bson.D{{Key: "_id", Value: 0}})
+
+	// Subscribe to create the nsStream.
+	sub := bus.Subscribe("db.overflow")
+	bus.Unsubscribe(sub)
+
+	for i := 0; i < 10; i++ {
+		bus.Publish("db", "overflow", ChangeEvent{
+			OperationType: ChangeInsert,
+			DocumentKey:   docKey,
+		})
+	}
+
+	// Build a stale resume token pointing to seq=1.
+	staleToken := encodeResumeToken(ResumeToken{TimestampNS: 1, Seq: 1})
+	staleDoc, _ := bson.Marshal(bson.D{{Key: "_data", Value: staleToken}})
+
+	_, err := NewChangeStreamCursor(bus, "db", "overflow", ChangeStreamOptions{
+		ResumeAfter: staleDoc,
+	})
+	if err == nil {
+		t.Fatal("expected ChangeStreamHistoryLost error, got nil")
+	}
+	me, ok := err.(*MongoError)
+	if !ok || me.Code != ErrCodeChangeStreamHistoryLost {
+		t.Errorf("expected MongoError code %d, got: %v", ErrCodeChangeStreamHistoryLost, err)
+	}
+}
+
+// TestChangeEventDocShape verifies the BSON document shape of a change event.
+func TestChangeEventDocShape(t *testing.T) {
+	docKey, _ := bson.Marshal(bson.D{{Key: "_id", Value: bson.NewObjectID()}})
+	fullDoc, _ := bson.Marshal(bson.D{{Key: "x", Value: 42}})
+
+	ev := ChangeEvent{
+		ResumeToken:   ResumeToken{TimestampNS: 1000000000, Seq: 7},
+		Namespace:     "mydb.orders",
+		OperationType: ChangeInsert,
+		DocumentKey:   docKey,
+		FullDocument:  fullDoc,
+	}
+
+	doc, err := changeEventToDoc(ev)
+	if err != nil {
+		t.Fatalf("changeEventToDoc: %v", err)
+	}
+
+	for _, key := range []string{"_id", "operationType", "clusterTime", "ns", "documentKey", "fullDocument"} {
+		if _, err := doc.LookupErr(key); err != nil {
+			t.Errorf("missing field %q in change event document", key)
+		}
+	}
+
+	opType, _ := doc.LookupErr("operationType")
+	if s, _ := opType.StringValueOK(); s != "insert" {
+		t.Errorf("operationType: got %q, want %q", s, "insert")
+	}
+
+	ns, _ := doc.LookupErr("ns")
+	nsDoc, _ := ns.DocumentOK()
+	dbVal, _ := nsDoc.LookupErr("db")
+	collVal, _ := nsDoc.LookupErr("coll")
+	if db, _ := dbVal.StringValueOK(); db != "mydb" {
+		t.Errorf("ns.db: got %q, want %q", db, "mydb")
+	}
+	if coll, _ := collVal.StringValueOK(); coll != "orders" {
+		t.Errorf("ns.coll: got %q, want %q", coll, "orders")
+	}
+}

--- a/internal/storage/cursor.go
+++ b/internal/storage/cursor.go
@@ -34,6 +34,8 @@ func (s *cursorStore) Register(c Cursor) int64 {
 		sc.mu.Lock()
 		sc.id = id
 		sc.mu.Unlock()
+	case *changeStreamCursor:
+		sc.setID(id)
 	}
 
 	now := time.Now()

--- a/internal/storage/event_bus.go
+++ b/internal/storage/event_bus.go
@@ -198,6 +198,77 @@ func (b *EventBus) Subscribe(ns string) *Subscription {
 	}
 }
 
+// SubscribeFrom creates a subscription starting after the given sequence number.
+// If afterSeq == 0, equivalent to Subscribe (only future events are returned).
+// Returns ErrBufOverflow if afterSeq is older than the ring buffer's oldest event.
+func (b *EventBus) SubscribeFrom(ns string, afterSeq int64) (*Subscription, error) {
+	b.mu.Lock()
+	st, ok := b.streams[ns]
+	if !ok {
+		st = newNsStream(b.bufSize)
+		b.streams[ns] = st
+	}
+	b.mu.Unlock()
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	if afterSeq > 0 {
+		bufCap := int64(len(st.buf))
+		oldestSeq := st.seq - bufCap + 1
+		if oldestSeq < 1 {
+			oldestSeq = 1
+		}
+		if st.seq > 0 && afterSeq < oldestSeq-1 {
+			return nil, ErrBufOverflow
+		}
+	}
+
+	return &Subscription{
+		stream:  st,
+		readSeq: afterSeq,
+	}, nil
+}
+
+// SubscribeFromTime creates a subscription starting from the first event at or
+// after tsNS (a Unix nanosecond timestamp). Events older than tsNS are skipped.
+// Returns ErrBufOverflow if tsNS is older than the ring buffer's oldest event.
+func (b *EventBus) SubscribeFromTime(ns string, tsNS int64) (*Subscription, error) {
+	b.mu.Lock()
+	st, ok := b.streams[ns]
+	if !ok {
+		st = newNsStream(b.bufSize)
+		b.streams[ns] = st
+	}
+	b.mu.Unlock()
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	if st.seq == 0 {
+		// No events yet; subscribe from current tail (only future events).
+		return &Subscription{stream: st, readSeq: 0}, nil
+	}
+
+	bufCap := int64(len(st.buf))
+	oldestSeq := st.seq - bufCap + 1
+	if oldestSeq < 1 {
+		oldestSeq = 1
+	}
+
+	// Scan from oldest to newest to find first event at or after tsNS.
+	for s := oldestSeq; s <= st.seq; s++ {
+		pos := (s - 1) % bufCap
+		if st.buf[pos].ResumeToken.TimestampNS >= tsNS {
+			// Position before this event so Recv will include it.
+			return &Subscription{stream: st, readSeq: s - 1}, nil
+		}
+	}
+
+	// All events are older than tsNS; subscribe from current tail.
+	return &Subscription{stream: st, readSeq: st.seq}, nil
+}
+
 // Unsubscribe marks the subscription as closed and wakes any goroutine blocked
 // in Recv so it can return promptly.
 func (b *EventBus) Unsubscribe(sub *Subscription) {

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -3,6 +3,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -49,8 +50,21 @@ type Engine interface {
 	// RenameCollection renames a collection, optionally across databases.
 	RenameCollection(fromDB, fromColl, toDB, toColl string, dropTarget bool) error
 
+	// EventBus returns the engine's event bus for change stream subscriptions.
+	EventBus() *EventBus
+
 	// Close flushes and closes all open database files.
 	Close() error
+}
+
+// TailableCursor extends Cursor for change streams.
+// Implemented by changeStreamCursor in internal/storage/change_stream_cursor.go.
+type TailableCursor interface {
+	Cursor
+	// NextBatchWait blocks until at least one event is available or maxWaitMS
+	// elapses, then returns the next batch and the post-batch resume token.
+	// postBatchResumeToken is a BSON document {"_data": "<base64url>"} or nil.
+	NextBatchWait(ctx context.Context, batchSize int, maxWaitMS int64) (docs []bson.Raw, postBatchResumeToken bson.Raw, err error)
 }
 
 // ─── Collection interface ────────────────────────────────────────────────────
@@ -371,7 +385,8 @@ const (
 	ErrCodeAuthenticationFailed    = int32(18)
 	ErrCodeUserNotFound            = int32(11)
 	ErrCodeUserAlreadyExists       = int32(51003)
-	ErrCodeCursorNotFound          = int32(43)
-	ErrCodeCommandFailed           = int32(125)
-	ErrCodeNotImplemented          = int32(238)
+	ErrCodeCursorNotFound              = int32(43)
+	ErrCodeCommandFailed               = int32(125)
+	ErrCodeNotImplemented              = int32(238)
+	ErrCodeChangeStreamHistoryLost     = int32(286)
 )


### PR DESCRIPTION
Closes #128

## What
- Added `TailableCursor` interface to `storage` with `NextBatchWait(ctx, batchSize, maxWaitMS)` blocking semantics
- Added `EventBus() *EventBus` to the `Engine` interface
- Implemented `changeStreamCursor` in `internal/storage/change_stream_cursor.go` that subscribes to the `EventBus`, encodes change events to BSON, and implements resume token encoding/decoding (base64url 16-byte format: `[8-byte tsNS | 8-byte seq]`)
- Added `SubscribeFrom` and `SubscribeFromTime` to `EventBus` for reconnect-with-resume-token support
- Modified `aggregation.Execute` in `pipeline.go` to detect `$changeStream` as the first stage and return a `TailableCursor` (skipping the normal document scan)
- Modified `handleGetMore` in `cursor_cmds.go` to type-assert for `TailableCursor` and block up to `maxAwaitTimeMS` (default 1000 ms, max 60 000 ms); includes `postBatchResumeToken` in the response when events are returned
- Returns `ChangeStreamHistoryLost` (code 286) when a subscriber's ring-buffer read position has been lapped
- Added `ChangeStreamHistoryLost` to the dispatcher's error-code name table

## Why
Phase 1 change stream support is required for `db.collection.watch()` to work with the MongoDB Go driver. This wires together the event bus (merged in #127) with the wire protocol, enabling real-time change notifications without polling.

```yaml
agent:
  id: founder-agent-s3
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#128"]
```

*Posted by the founder agent on behalf of @inder*