### PR TITLE
feat(aggregation): implement $changeStream stage and tailable cursor response

### DIFF
--- a/internal/aggregation/pipeline.go
+++ b/internal/aggregation/pipeline.go
@@ -8,6 +8,31 @@ import (
 	"github.com/inder/salvobase/internal/storage"
 )
 
+// executeChangeStream handles a pipeline whose first stage is $changeStream.
+// It creates a tailable changeStreamCursor backed by the engine's EventBus.
+func executeChangeStream(coll storage.Collection, engine storage.Engine, db string, pipeline []bson.Raw) (storage.Cursor, error) {
+	if coll == nil {
+		return nil, fmt.Errorf("$changeStream requires a collection name")
+	}
+
+	// Extract the $changeStream options document from the first stage.
+	var csOpts bson.Raw
+	elems, err := pipeline[0].Elements()
+	if err == nil && len(elems) > 0 {
+		csOpts, _ = elems[0].Value().DocumentOK()
+	}
+
+	// Any stages after $changeStream are kept for future client-side filtering
+	// (Phase 1: stored on the cursor but not yet applied).
+	var remainingPipeline []bson.Raw
+	if len(pipeline) > 1 {
+		remainingPipeline = pipeline[1:]
+	}
+
+	cursor := storage.NewChangeStreamCursor(engine.EventBus(), db, coll.Name(), csOpts, remainingPipeline)
+	return cursor, nil
+}
+
 // PipelineOptions controls aggregation execution.
 type PipelineOptions struct {
 	AllowDiskUse bool
@@ -20,6 +45,14 @@ type PipelineOptions struct {
 // Execute runs an aggregation pipeline against a collection.
 // Returns a Cursor over all result documents.
 func Execute(coll storage.Collection, engine storage.Engine, db string, pipeline []bson.Raw, opts PipelineOptions) (storage.Cursor, error) {
+	// Detect $changeStream as the first stage and take the tailable cursor path.
+	if len(pipeline) > 0 {
+		elems, err := pipeline[0].Elements()
+		if err == nil && len(elems) > 0 && elems[0].Key() == "$changeStream" {
+			return executeChangeStream(coll, engine, db, pipeline)
+		}
+	}
+
 	// Collect all documents from the collection.
 	var allDocs []bson.Raw
 	if coll != nil {

--- a/internal/commands/aggregate.go
+++ b/internal/commands/aggregate.go
@@ -9,6 +9,11 @@ import (
 	"github.com/inder/salvobase/internal/storage"
 )
 
+// changeStreamEmptyResumeToken is the postBatchResumeToken returned when a
+// change stream opens with an empty firstBatch.
+// Drivers use this to determine the "start of stream" position.
+var changeStreamEmptyResumeToken = bson.D{{Key: "_data", Value: ""}}
+
 // handleAggregate handles the "aggregate" command.
 func handleAggregate(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	// The "aggregate" field is either a collection name string or 1 (for db-level).
@@ -109,12 +114,22 @@ func handleAggregate(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		firstBatch[i] = d
 	}
 
+	// For change stream cursors include postBatchResumeToken so drivers know
+	// the stream position even when firstBatch is empty.
+	cursorDoc := bson.D{
+		{Key: "id", Value: cursorID},
+		{Key: "ns", Value: ns},
+		{Key: "firstBatch", Value: firstBatch},
+	}
+	if _, isTailable := cursor.(storage.TailableCursor); isTailable {
+		cursorDoc = append(cursorDoc, bson.E{
+			Key:   "postBatchResumeToken",
+			Value: changeStreamEmptyResumeToken,
+		})
+	}
+
 	return marshalResponse(bson.D{
-		{Key: "cursor", Value: bson.D{
-			{Key: "id", Value: cursorID},
-			{Key: "ns", Value: ns},
-			{Key: "firstBatch", Value: firstBatch},
-		}},
+		{Key: "cursor", Value: cursorDoc},
 		{Key: "ok", Value: float64(1)},
 	}), nil
 }

--- a/internal/commands/cursor_cmds.go
+++ b/internal/commands/cursor_cmds.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -40,10 +42,34 @@ func handleGetMore(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 			"cursor id %d not found", cursorID)
 	}
 
-	docs, exhausted, err := cursor.NextBatch(int(batchSize))
-	if err != nil {
-		ctx.Engine.Cursors().Delete(cursorID)
-		return nil, err
+	var docs []bson.Raw
+	var exhausted bool
+
+	if tc, isTailable := cursor.(storage.TailableCursor); isTailable {
+		// Change stream: block until events arrive or maxAwaitTimeMS elapses.
+		maxWaitMS := lookupInt64Field(cmd, "maxAwaitTimeMS")
+		if maxWaitMS <= 0 {
+			maxWaitMS = 1000
+		}
+		var waitErr error
+		docs, exhausted, waitErr = tc.NextBatchWait(context.Background(), int(batchSize), maxWaitMS)
+		if waitErr != nil {
+			ctx.Engine.Cursors().Delete(cursorID)
+			if errors.Is(waitErr, storage.ErrBufOverflow) {
+				return nil, storage.Errorf(storage.ErrCodeChangeStreamHistoryLost,
+					"change stream history lost")
+			}
+			return nil, waitErr
+		}
+		// Tailable cursors are never exhausted by a normal getMore.
+		exhausted = false
+	} else {
+		var batchErr error
+		docs, exhausted, batchErr = cursor.NextBatch(int(batchSize))
+		if batchErr != nil {
+			ctx.Engine.Cursors().Delete(cursorID)
+			return nil, batchErr
+		}
 	}
 
 	ns := ctx.DB + "." + collName
@@ -61,12 +87,33 @@ func handleGetMore(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		nextBatch[i] = d
 	}
 
+	cursorDoc := bson.D{
+		{Key: "id", Value: returnedCursorID},
+		{Key: "ns", Value: ns},
+		{Key: "nextBatch", Value: nextBatch},
+	}
+
+	// For change stream cursors, attach a postBatchResumeToken so drivers can
+	// track stream position even on empty-batch (timeout) responses.
+	if _, isTailable := cursor.(storage.TailableCursor); isTailable {
+		var resumeToken bson.Raw
+		if len(docs) > 0 {
+			// Use the _id of the last event as the postBatchResumeToken.
+			lastDoc := docs[len(docs)-1]
+			if idVal, err := lastDoc.LookupErr("_id"); err == nil {
+				if raw, ok := idVal.DocumentOK(); ok {
+					resumeToken = raw
+				}
+			}
+		}
+		if resumeToken == nil {
+			resumeToken, _ = bson.Marshal(changeStreamEmptyResumeToken)
+		}
+		cursorDoc = append(cursorDoc, bson.E{Key: "postBatchResumeToken", Value: resumeToken})
+	}
+
 	return marshalResponse(bson.D{
-		{Key: "cursor", Value: bson.D{
-			{Key: "id", Value: returnedCursorID},
-			{Key: "ns", Value: ns},
-			{Key: "nextBatch", Value: nextBatch},
-		}},
+		{Key: "cursor", Value: cursorDoc},
 		{Key: "ok", Value: float64(1)},
 	}), nil
 }

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -342,6 +342,8 @@ func mongoErrorCodeName(code int32) string {
 		return "CommandFailed"
 	case 238:
 		return "NotImplemented"
+	case 286:
+		return "ChangeStreamHistoryLost"
 	default:
 		return "UnknownError"
 	}

--- a/internal/storage/change_stream_cursor.go
+++ b/internal/storage/change_stream_cursor.go
@@ -1,0 +1,282 @@
+package storage
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"strings"
+	"sync"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// changeStreamCursor is a tailable cursor backed by the EventBus.
+// It implements both storage.Cursor and storage.TailableCursor.
+type changeStreamCursor struct {
+	mu   sync.Mutex
+	id   int64
+	ns   string // "db.coll"
+	db   string
+	coll string
+	bus  *EventBus
+	sub  *Subscription
+	// post-$changeStream pipeline stages for optional client-side filtering.
+	pipeline []bson.Raw
+	closed   bool
+}
+
+// NewChangeStreamCursor creates a change stream cursor for db.coll.
+// opts is the $changeStream options document (may be nil or empty).
+// pipeline contains any stages that follow $changeStream in the aggregate pipeline.
+func NewChangeStreamCursor(bus *EventBus, db, coll string, opts bson.Raw, pipeline []bson.Raw) *changeStreamCursor {
+	ns := db + "." + coll
+
+	// Determine start position from resumeAfter / startAtOperationTime options.
+	var sub *Subscription
+
+	if opts != nil {
+		// resumeAfter: {_data: "<base64url-token>"}
+		if raVal, err := opts.LookupErr("resumeAfter"); err == nil {
+			if tokenDoc, ok := raVal.DocumentOK(); ok {
+				if dataVal, dErr := tokenDoc.LookupErr("_data"); dErr == nil {
+					if tokenStr, ok := dataVal.StringValueOK(); ok {
+						if seq := decodeResumeTokenSeq(tokenStr); seq > 0 {
+							sub = bus.SubscribeFrom(ns, seq)
+						}
+					}
+				}
+			}
+		}
+
+		// startAfter is treated identically to resumeAfter for Phase 1.
+		if sub == nil {
+			if saVal, err := opts.LookupErr("startAfter"); err == nil {
+				if tokenDoc, ok := saVal.DocumentOK(); ok {
+					if dataVal, dErr := tokenDoc.LookupErr("_data"); dErr == nil {
+						if tokenStr, ok := dataVal.StringValueOK(); ok {
+							if seq := decodeResumeTokenSeq(tokenStr); seq > 0 {
+								sub = bus.SubscribeFrom(ns, seq)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// startAtOperationTime: <BSONTimestamp>  — subscribe from events whose
+		// resume token timestamp >= the requested time.
+		if sub == nil {
+			if satVal, err := opts.LookupErr("startAtOperationTime"); err == nil {
+				if tSecs, _, ok := satVal.TimestampOK(); ok {
+					startNS := int64(tSecs) * 1_000_000_000
+					afterSeq := bus.findSeqBeforeTime(ns, startNS)
+					sub = bus.SubscribeFrom(ns, afterSeq)
+				}
+			}
+		}
+	}
+
+	if sub == nil {
+		sub = bus.Subscribe(ns)
+	}
+
+	return &changeStreamCursor{
+		ns:       ns,
+		db:       db,
+		coll:     coll,
+		bus:      bus,
+		sub:      sub,
+		pipeline: pipeline,
+	}
+}
+
+// ─── storage.Cursor ──────────────────────────────────────────────────────────
+
+// NextBatch returns any immediately-available events without blocking.
+// Change stream consumers should call NextBatchWait (via getMore) for
+// blocking reads.
+func (c *changeStreamCursor) NextBatch(batchSize int) ([]bson.Raw, bool, error) {
+	// Return empty immediately — the aggregate command calls this once to build
+	// the firstBatch; for change streams the firstBatch is always empty.
+	return nil, false, nil
+}
+
+// Close releases the subscription and marks the cursor closed.
+func (c *changeStreamCursor) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+	c.bus.Unsubscribe(c.sub)
+	return nil
+}
+
+// ID returns the cursor's registered ID (0 until Register is called).
+func (c *changeStreamCursor) ID() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.id
+}
+
+// ─── storage.TailableCursor ───────────────────────────────────────────────────
+
+// NextBatchWait blocks until at least one change event arrives or maxWaitMS
+// elapses.  It always returns exhausted=false for a healthy stream; it returns
+// ErrBufOverflow when the subscriber has fallen too far behind (ring-buffer
+// has wrapped), which the getMore handler converts to error code 286.
+func (c *changeStreamCursor) NextBatchWait(ctx context.Context, batchSize int, maxWaitMS int64) ([]bson.Raw, bool, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, true, nil
+	}
+	c.mu.Unlock()
+
+	// Clamp maxWaitMS to [0, 60000].
+	if maxWaitMS < 0 {
+		maxWaitMS = 0
+	}
+	if maxWaitMS > 60_000 {
+		maxWaitMS = 60_000
+	}
+
+	events, err := c.sub.Recv(ctx, maxWaitMS)
+	if err != nil {
+		if errors.Is(err, ErrBufOverflow) {
+			return nil, false, ErrBufOverflow
+		}
+		return nil, false, err
+	}
+
+	if len(events) == 0 {
+		return nil, false, nil
+	}
+
+	// Apply batchSize limit.
+	if batchSize > 0 && len(events) > batchSize {
+		events = events[:batchSize]
+	}
+
+	docs := make([]bson.Raw, 0, len(events))
+	for _, ev := range events {
+		doc, encErr := encodeChangeEvent(ev)
+		if encErr != nil {
+			continue
+		}
+		docs = append(docs, doc)
+	}
+	return docs, false, nil
+}
+
+// ─── Resume token helpers ─────────────────────────────────────────────────────
+
+// EncodeResumeToken encodes a ResumeToken as a base64url (no-padding) string.
+// Format: 16 big-endian bytes — 8-byte nanosecond timestamp + 8-byte sequence.
+func EncodeResumeToken(rt ResumeToken) string {
+	buf := make([]byte, 16)
+	binary.BigEndian.PutUint64(buf[0:8], uint64(rt.TimestampNS))
+	binary.BigEndian.PutUint64(buf[8:16], uint64(rt.Seq))
+	return base64.RawURLEncoding.EncodeToString(buf)
+}
+
+// decodeResumeTokenSeq decodes only the sequence number from a resume token string.
+// Returns 0 on any parse error.
+func decodeResumeTokenSeq(token string) int64 {
+	b, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(b) < 16 {
+		return 0
+	}
+	return int64(binary.BigEndian.Uint64(b[8:16]))
+}
+
+// ─── Change event encoding ───────────────────────────────────────────────────
+
+// encodeChangeEvent converts a ChangeEvent to the BSON change event document
+// shape expected by MongoDB drivers.
+func encodeChangeEvent(ev ChangeEvent) (bson.Raw, error) {
+	token := EncodeResumeToken(ev.ResumeToken)
+
+	// Split "db.coll" namespace.
+	parts := strings.SplitN(ev.Namespace, ".", 2)
+	dbName, collName := "", ev.Namespace
+	if len(parts) == 2 {
+		dbName = parts[0]
+		collName = parts[1]
+	}
+
+	// clusterTime is a BSON Timestamp: T = unix seconds, I = low-32 of seq.
+	tSecs := uint32(ev.ResumeToken.TimestampNS / 1_000_000_000)
+	tInc := uint32(ev.ResumeToken.Seq & 0xFFFF_FFFF)
+
+	d := bson.D{
+		{Key: "_id", Value: bson.D{{Key: "_data", Value: token}}},
+		{Key: "operationType", Value: string(ev.OperationType)},
+		{Key: "clusterTime", Value: bson.Timestamp{T: tSecs, I: tInc}},
+		{Key: "ns", Value: bson.D{
+			{Key: "db", Value: dbName},
+			{Key: "coll", Value: collName},
+		}},
+		{Key: "documentKey", Value: ev.DocumentKey},
+	}
+
+	switch ev.OperationType {
+	case ChangeInsert, ChangeReplace:
+		if ev.FullDocument != nil {
+			d = append(d, bson.E{Key: "fullDocument", Value: ev.FullDocument})
+		}
+	case ChangeUpdate:
+		if ev.UpdateDescription != nil {
+			d = append(d, bson.E{Key: "updateDescription", Value: ev.UpdateDescription})
+		}
+	}
+
+	return bson.Marshal(d)
+}
+
+// ─── EventBus helper for startAtOperationTime ─────────────────────────────────
+
+// findSeqBeforeTime scans the ring buffer for ns and returns the sequence
+// number of the last event whose timestamp is strictly before startNS.
+// Returns 0 if no such event is found (subscribe from the beginning of the buffer).
+func (b *EventBus) findSeqBeforeTime(ns string, startNS int64) int64 {
+	b.mu.RLock()
+	st, ok := b.streams[ns]
+	b.mu.RUnlock()
+	if !ok {
+		return 0
+	}
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	lastSeq := st.seq
+	if lastSeq == 0 {
+		return 0
+	}
+	cap := int64(len(st.buf))
+
+	// Walk events from oldest to newest and find the last one before startNS.
+	oldestSeq := lastSeq - cap + 1
+	if oldestSeq < 1 {
+		oldestSeq = 1
+	}
+
+	var beforeSeq int64
+	for s := oldestSeq; s <= lastSeq; s++ {
+		pos := (s - 1) % cap
+		ev := st.buf[pos]
+		if ev.ResumeToken.Seq != s {
+			// Slot has been overwritten or is empty.
+			continue
+		}
+		if ev.ResumeToken.TimestampNS < startNS {
+			beforeSeq = s
+		} else {
+			break
+		}
+	}
+	return beforeSeq
+}

--- a/internal/storage/change_stream_cursor_test.go
+++ b/internal/storage/change_stream_cursor_test.go
@@ -1,0 +1,324 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+func makeDocKey(id string) bson.Raw {
+	raw, _ := bson.Marshal(bson.D{{Key: "_id", Value: id}})
+	return raw
+}
+
+func makeFullDoc(id, name string) bson.Raw {
+	raw, _ := bson.Marshal(bson.D{{Key: "_id", Value: id}, {Key: "name", Value: name}})
+	return raw
+}
+
+// ─── ResumeToken encode/decode ────────────────────────────────────────────────
+
+func TestEncodeDecodeResumeToken(t *testing.T) {
+	rt := ResumeToken{TimestampNS: 1_700_000_000_000_000_000, Seq: 42}
+	token := EncodeResumeToken(rt)
+
+	seq := decodeResumeTokenSeq(token)
+	if seq != 42 {
+		t.Fatalf("expected seq=42, got %d", seq)
+	}
+}
+
+func TestDecodeResumeTokenSeq_invalid(t *testing.T) {
+	seq := decodeResumeTokenSeq("not-valid-base64!!!")
+	if seq != 0 {
+		t.Fatalf("expected 0 for invalid token, got %d", seq)
+	}
+	seq2 := decodeResumeTokenSeq("dG9vc2hvcnQ") // valid base64 but < 16 bytes
+	if seq2 != 0 {
+		t.Fatalf("expected 0 for short token, got %d", seq2)
+	}
+}
+
+// ─── encodeChangeEvent ────────────────────────────────────────────────────────
+
+func TestEncodeChangeEvent_insert(t *testing.T) {
+	ev := ChangeEvent{
+		ResumeToken:   ResumeToken{TimestampNS: 1_700_000_000_000_000_000, Seq: 1},
+		Namespace:     "mydb.orders",
+		OperationType: ChangeInsert,
+		DocumentKey:   makeDocKey("abc"),
+		FullDocument:  makeFullDoc("abc", "Alice"),
+	}
+
+	raw, err := encodeChangeEvent(ev)
+	if err != nil {
+		t.Fatalf("encodeChangeEvent: %v", err)
+	}
+
+	// _id._data must be present
+	idVal, err := raw.LookupErr("_id", "_data")
+	if err != nil {
+		t.Fatalf("missing _id._data: %v", err)
+	}
+	if idVal.Type != bson.TypeString {
+		t.Fatalf("expected string, got %v", idVal.Type)
+	}
+
+	opType, _ := raw.LookupErr("operationType")
+	if s, _ := opType.StringValueOK(); s != "insert" {
+		t.Fatalf("expected operationType=insert, got %q", s)
+	}
+
+	// fullDocument must be present for insert
+	if _, err := raw.LookupErr("fullDocument"); err != nil {
+		t.Fatalf("missing fullDocument for insert: %v", err)
+	}
+
+	// ns.db and ns.coll
+	if db, err := raw.LookupErr("ns", "db"); err != nil || db.StringValue() != "mydb" {
+		t.Fatalf("expected ns.db=mydb")
+	}
+	if coll, err := raw.LookupErr("ns", "coll"); err != nil || coll.StringValue() != "orders" {
+		t.Fatalf("expected ns.coll=orders")
+	}
+}
+
+func TestEncodeChangeEvent_update(t *testing.T) {
+	updateDesc, _ := bson.Marshal(bson.D{
+		{Key: "updatedFields", Value: bson.D{}},
+		{Key: "removedFields", Value: bson.A{}},
+		{Key: "truncatedArrays", Value: bson.A{}},
+	})
+	ev := ChangeEvent{
+		ResumeToken:       ResumeToken{TimestampNS: 1_700_000_000_000_000_000, Seq: 2},
+		Namespace:         "mydb.orders",
+		OperationType:     ChangeUpdate,
+		DocumentKey:       makeDocKey("abc"),
+		UpdateDescription: updateDesc,
+	}
+
+	raw, err := encodeChangeEvent(ev)
+	if err != nil {
+		t.Fatalf("encodeChangeEvent: %v", err)
+	}
+
+	if _, err := raw.LookupErr("updateDescription"); err != nil {
+		t.Fatalf("missing updateDescription for update: %v", err)
+	}
+	// fullDocument must NOT be present for update (Phase 1)
+	if _, err := raw.LookupErr("fullDocument"); err == nil {
+		t.Fatalf("unexpected fullDocument for update in Phase 1")
+	}
+}
+
+func TestEncodeChangeEvent_delete(t *testing.T) {
+	ev := ChangeEvent{
+		ResumeToken:   ResumeToken{TimestampNS: 1_700_000_000_000_000_000, Seq: 3},
+		Namespace:     "mydb.orders",
+		OperationType: ChangeDelete,
+		DocumentKey:   makeDocKey("abc"),
+	}
+
+	raw, err := encodeChangeEvent(ev)
+	if err != nil {
+		t.Fatalf("encodeChangeEvent: %v", err)
+	}
+	// Neither fullDocument nor updateDescription for delete
+	if _, err := raw.LookupErr("fullDocument"); err == nil {
+		t.Fatalf("unexpected fullDocument for delete")
+	}
+	if _, err := raw.LookupErr("updateDescription"); err == nil {
+		t.Fatalf("unexpected updateDescription for delete")
+	}
+}
+
+// ─── changeStreamCursor ───────────────────────────────────────────────────────
+
+func TestChangeStreamCursor_NextBatchAlwaysEmpty(t *testing.T) {
+	bus := NewEventBus(100)
+	c := NewChangeStreamCursor(bus, "db", "coll", nil, nil)
+
+	docs, exhausted, err := c.NextBatch(10)
+	if err != nil || exhausted || len(docs) != 0 {
+		t.Fatalf("NextBatch should return empty immediately: docs=%v exhausted=%v err=%v", docs, exhausted, err)
+	}
+	_ = c.Close()
+}
+
+func TestChangeStreamCursor_NextBatchWait_receivesEvent(t *testing.T) {
+	bus := NewEventBus(100)
+	c := NewChangeStreamCursor(bus, "testdb", "col", nil, nil)
+	defer c.Close()
+
+	// Publish an event asynchronously after a short delay.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		bus.Publish("testdb", "col", ChangeEvent{
+			OperationType: ChangeInsert,
+			DocumentKey:   makeDocKey("id1"),
+			FullDocument:  makeFullDoc("id1", "Bob"),
+		})
+	}()
+
+	docs, exhausted, err := c.NextBatchWait(context.Background(), 10, 500)
+	if err != nil {
+		t.Fatalf("NextBatchWait error: %v", err)
+	}
+	if exhausted {
+		t.Fatal("change stream should not be exhausted")
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc, got %d", len(docs))
+	}
+
+	// Verify the document shape.
+	opType, err := docs[0].LookupErr("operationType")
+	if err != nil || opType.StringValue() != "insert" {
+		t.Fatalf("expected operationType=insert, got %v", opType)
+	}
+}
+
+func TestChangeStreamCursor_NextBatchWait_timeout(t *testing.T) {
+	bus := NewEventBus(100)
+	// Subscribe before publishing anything.
+	c := NewChangeStreamCursor(bus, "db2", "col2", nil, nil)
+	defer c.Close()
+
+	start := time.Now()
+	docs, exhausted, err := c.NextBatchWait(context.Background(), 10, 50)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exhausted {
+		t.Fatal("should not be exhausted on timeout")
+	}
+	if len(docs) != 0 {
+		t.Fatalf("expected empty batch on timeout, got %d docs", len(docs))
+	}
+	if elapsed < 40*time.Millisecond {
+		t.Fatalf("waited only %v, expected ~50ms", elapsed)
+	}
+}
+
+func TestChangeStreamCursor_NextBatchWait_contextCancel(t *testing.T) {
+	bus := NewEventBus(100)
+	c := NewChangeStreamCursor(bus, "db3", "col3", nil, nil)
+	defer c.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, _, err := c.NextBatchWait(ctx, 10, 10_000)
+	if err == nil {
+		t.Fatal("expected context cancellation error, got nil")
+	}
+}
+
+func TestChangeStreamCursor_Close(t *testing.T) {
+	bus := NewEventBus(100)
+	c := NewChangeStreamCursor(bus, "db4", "col4", nil, nil)
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Second Close should be idempotent.
+	if err := c.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+
+	// NextBatchWait after close should return exhausted.
+	docs, exhausted, err := c.NextBatchWait(context.Background(), 10, 50)
+	if err != nil {
+		t.Fatalf("unexpected error after close: %v", err)
+	}
+	if !exhausted {
+		t.Fatalf("expected exhausted=true after close, docs=%v", docs)
+	}
+}
+
+func TestChangeStreamCursor_BufOverflow(t *testing.T) {
+	const bufSize = 10
+	bus := NewEventBus(bufSize)
+	c := NewChangeStreamCursor(bus, "db5", "col5", nil, nil)
+	defer c.Close()
+
+	// Publish bufSize+1 events without consuming any — this should overflow.
+	for i := 0; i <= bufSize; i++ {
+		bus.Publish("db5", "col5", ChangeEvent{
+			OperationType: ChangeInsert,
+			DocumentKey:   makeDocKey("x"),
+		})
+	}
+
+	_, _, err := c.NextBatchWait(context.Background(), 100, 100)
+	if err != ErrBufOverflow {
+		t.Fatalf("expected ErrBufOverflow, got %v", err)
+	}
+}
+
+func TestChangeStreamCursor_ResumeAfter(t *testing.T) {
+	bus := NewEventBus(100)
+
+	// Pre-publish two events into the namespace.
+	bus.Subscribe("resumedb.col") // create the stream
+	bus.Publish("resumedb", "col", ChangeEvent{
+		OperationType: ChangeInsert,
+		DocumentKey:   makeDocKey("a"),
+	})
+	bus.Publish("resumedb", "col", ChangeEvent{
+		OperationType: ChangeInsert,
+		DocumentKey:   makeDocKey("b"),
+	})
+
+	// Build a resumeAfter token pointing to seq=1 (before the second event).
+	token := EncodeResumeToken(ResumeToken{TimestampNS: 0, Seq: 1})
+	optsDoc, _ := bson.Marshal(bson.D{
+		{Key: "resumeAfter", Value: bson.D{{Key: "_data", Value: token}}},
+	})
+
+	c := NewChangeStreamCursor(bus, "resumedb", "col", optsDoc, nil)
+	defer c.Close()
+
+	// Should receive only seq=2 (the second event).
+	docs, _, err := c.NextBatchWait(context.Background(), 10, 200)
+	if err != nil {
+		t.Fatalf("NextBatchWait: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc after resumeAfter seq=1, got %d", len(docs))
+	}
+}
+
+func TestChangeStreamCursor_MultipleEvents(t *testing.T) {
+	bus := NewEventBus(100)
+	c := NewChangeStreamCursor(bus, "dbm", "colm", nil, nil)
+	defer c.Close()
+
+	// Publish 5 events.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		for i := 0; i < 5; i++ {
+			bus.Publish("dbm", "colm", ChangeEvent{
+				OperationType: ChangeInsert,
+				DocumentKey:   makeDocKey("x"),
+			})
+		}
+	}()
+
+	docs, _, err := c.NextBatchWait(context.Background(), 10, 500)
+	if err != nil {
+		t.Fatalf("NextBatchWait: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least 1 doc")
+	}
+}

--- a/internal/storage/cursor.go
+++ b/internal/storage/cursor.go
@@ -34,6 +34,10 @@ func (s *cursorStore) Register(c Cursor) int64 {
 		sc.mu.Lock()
 		sc.id = id
 		sc.mu.Unlock()
+	case *changeStreamCursor:
+		sc.mu.Lock()
+		sc.id = id
+		sc.mu.Unlock()
 	}
 
 	now := time.Now()

--- a/internal/storage/event_bus.go
+++ b/internal/storage/event_bus.go
@@ -198,6 +198,33 @@ func (b *EventBus) Subscribe(ns string) *Subscription {
 	}
 }
 
+// SubscribeFrom creates a subscription that starts after the given sequence
+// number (events with seq > afterSeq are delivered first). Use this to
+// implement resumeAfter: the caller decodes a resume token to its sequence
+// number and passes it here.
+//
+// If afterSeq <= 0, this behaves like Subscribe (start from the current tail).
+func (b *EventBus) SubscribeFrom(ns string, afterSeq int64) *Subscription {
+	b.mu.Lock()
+	st, ok := b.streams[ns]
+	if !ok {
+		st = newNsStream(b.bufSize)
+		b.streams[ns] = st
+	}
+	b.mu.Unlock()
+
+	if afterSeq <= 0 {
+		st.mu.Lock()
+		afterSeq = st.seq
+		st.mu.Unlock()
+	}
+
+	return &Subscription{
+		stream:  st,
+		readSeq: afterSeq,
+	}
+}
+
 // Unsubscribe marks the subscription as closed and wakes any goroutine blocked
 // in Recv so it can return promptly.
 func (b *EventBus) Unsubscribe(sub *Subscription) {

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -3,6 +3,7 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -42,6 +43,9 @@ type Engine interface {
 
 	// Cursor store (shared across all collections/connections)
 	Cursors() CursorStore
+
+	// EventBus returns the engine-wide change-event bus used by change streams.
+	EventBus() *EventBus
 
 	// User management (backed by admin.$users bucket)
 	Users() UserStore
@@ -104,6 +108,17 @@ type Cursor interface {
 
 	// ID returns the cursor's unique integer ID (0 means exhausted/closed).
 	ID() int64
+}
+
+// TailableCursor extends Cursor for change streams.
+// GetMore calls NextBatchWait instead of NextBatch so the goroutine parks
+// until events arrive (or maxWaitMS elapses).
+type TailableCursor interface {
+	Cursor
+	// NextBatchWait blocks until at least one event is available or maxWaitMS
+	// elapses, then returns the batch.  exhausted is always false for a healthy
+	// change stream; errors include ErrBufOverflow (code 286).
+	NextBatchWait(ctx context.Context, batchSize int, maxWaitMS int64) (docs []bson.Raw, exhausted bool, err error)
 }
 
 // CursorStore manages long-lived server-side cursors for getMore requests.
@@ -371,7 +386,8 @@ const (
 	ErrCodeAuthenticationFailed    = int32(18)
 	ErrCodeUserNotFound            = int32(11)
 	ErrCodeUserAlreadyExists       = int32(51003)
-	ErrCodeCursorNotFound          = int32(43)
-	ErrCodeCommandFailed           = int32(125)
-	ErrCodeNotImplemented          = int32(238)
+	ErrCodeCursorNotFound              = int32(43)
+	ErrCodeCommandFailed               = int32(125)
+	ErrCodeNotImplemented              = int32(238)
+	ErrCodeChangeStreamHistoryLost     = int32(286)
 )


### PR DESCRIPTION
Closes #128

## What
- `$changeStream` aggregation stage detected in `Execute`; skips document scan and returns a tailable `changeStreamCursor`
- `TailableCursor` interface added to `storage` with `NextBatchWait(ctx, batchSize, maxWaitMS)` — `getMore` handler blocks the goroutine until events arrive
- `changeStreamCursor` backed by `EventBus.Subscription`; encodes `ChangeEvent` to the MongoDB change event document shape (`_id._data` resume token, `operationType`, `clusterTime`, `ns`, `documentKey`, `fullDocument`)
- Resume token: 16-byte big-endian (8-byte nanosecond timestamp + 8-byte sequence), base64url encoded
- `resumeAfter`, `startAfter`, `startAtOperationTime` options parsed; `SubscribeFrom` added to `EventBus` for rewind support
- `ErrBufOverflow` surfaced as MongoDB error code 286 (`ChangeStreamHistoryLost`)
- `postBatchResumeToken` included in aggregate `firstBatch` and `getMore` `nextBatch` responses
- 9 new unit tests covering event delivery, timeout, context cancel, close idempotency, buf overflow, and `resumeAfter`

## Why
Part of epic #15 — Phase 1 change streams. Unblocked by event bus (#127) and design doc (#126). Enables `db.collection.watch()` via the Go driver.

```yaml
agent:
  id: founder-agent-s2
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#128"]
```

*Posted by the founder agent on behalf of @inder*