### PR TITLE
feat(commands): implement rolesInfo command

### DIFF
--- a/internal/commands/auth_cmds.go
+++ b/internal/commands/auth_cmds.go
@@ -410,6 +410,137 @@ func handleRevokeRolesFromUser(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	return BuildOKResponse(), nil
 }
 
+// handleRolesInfo handles the "rolesInfo" command.
+// Returns information about roles, both built-in and user-defined.
+func handleRolesInfo(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
+	rolesInfoVal, err := cmd.LookupErr("rolesInfo")
+	if err != nil {
+		return nil, storage.Errorf(storage.ErrCodeBadValue, "rolesInfo: missing 'rolesInfo' field")
+	}
+
+	showBuiltinRoles := lookupBoolField(cmd, "showBuiltinRoles")
+	showPrivileges := lookupBoolField(cmd, "showPrivileges")
+
+	// builtinRoleNames are the standard MongoDB built-in roles for a given database.
+	builtinRoleNames := []string{"read", "readWrite", "dbAdmin", "dbOwner", "userAdmin"}
+	adminOnlyRoleNames := []string{
+		"clusterAdmin", "clusterManager", "clusterMonitor", "hostManager",
+		"backup", "restore", "readAnyDatabase", "readWriteAnyDatabase",
+		"userAdminAnyDatabase", "dbAdminAnyDatabase", "root",
+	}
+
+	buildRoleDoc := func(roleName, db string, isBuiltin bool) bson.D {
+		d := bson.D{
+			{Key: "role", Value: roleName},
+			{Key: "db", Value: db},
+			{Key: "isBuiltin", Value: isBuiltin},
+			{Key: "roles", Value: bson.A{}},
+			{Key: "inheritedRoles", Value: bson.A{}},
+		}
+		if showPrivileges {
+			d = append(d,
+				bson.E{Key: "privileges", Value: bson.A{}},
+				bson.E{Key: "inheritedPrivileges", Value: bson.A{}},
+			)
+		}
+		return d
+	}
+
+	isBuiltinRole := func(roleName, db string) bool {
+		for _, r := range builtinRoleNames {
+			if r == roleName {
+				return true
+			}
+		}
+		if db == "admin" {
+			for _, r := range adminOnlyRoleNames {
+				if r == roleName {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	var roleDocs bson.A
+
+	switch rolesInfoVal.Type {
+	case bson.TypeString:
+		// Single role by name in current db.
+		roleName := rolesInfoVal.StringValue()
+		if isBuiltinRole(roleName, ctx.DB) {
+			roleDocs = append(roleDocs, buildRoleDoc(roleName, ctx.DB, true))
+		}
+		// No custom roles stored — nothing to add.
+
+	case bson.TypeEmbeddedDocument:
+		// {role: "name", db: "dbName"}
+		spec, _ := rolesInfoVal.DocumentOK()
+		roleName := lookupStringField(spec, "role")
+		db := lookupStringField(spec, "db")
+		if db == "" {
+			db = ctx.DB
+		}
+		if roleName == "" {
+			return nil, storage.Errorf(storage.ErrCodeBadValue, "rolesInfo: role name must not be empty")
+		}
+		if isBuiltinRole(roleName, db) {
+			roleDocs = append(roleDocs, buildRoleDoc(roleName, db, true))
+		}
+
+	case bson.TypeArray:
+		// Array of role specs.
+		arr, _ := rolesInfoVal.ArrayOK()
+		vals, _ := arr.Values()
+		for _, elem := range vals {
+			switch elem.Type {
+			case bson.TypeString:
+				roleName := elem.StringValue()
+				if isBuiltinRole(roleName, ctx.DB) {
+					roleDocs = append(roleDocs, buildRoleDoc(roleName, ctx.DB, true))
+				}
+			case bson.TypeEmbeddedDocument:
+				spec, _ := elem.DocumentOK()
+				roleName := lookupStringField(spec, "role")
+				db := lookupStringField(spec, "db")
+				if db == "" {
+					db = ctx.DB
+				}
+				if roleName != "" && isBuiltinRole(roleName, db) {
+					roleDocs = append(roleDocs, buildRoleDoc(roleName, db, true))
+				}
+			}
+		}
+
+	case bson.TypeInt32, bson.TypeInt64, bson.TypeDouble:
+		// 1 = all roles in current db (optionally including built-ins).
+		if showBuiltinRoles {
+			for _, r := range builtinRoleNames {
+				roleDocs = append(roleDocs, buildRoleDoc(r, ctx.DB, true))
+			}
+			if ctx.DB == "admin" {
+				for _, r := range adminOnlyRoleNames {
+					roleDocs = append(roleDocs, buildRoleDoc(r, ctx.DB, true))
+				}
+			}
+		}
+		// No custom roles stored.
+
+	default:
+		return nil, storage.Errorf(storage.ErrCodeBadValue,
+			"rolesInfo: argument must be a string, document, array, or 1")
+	}
+
+	if roleDocs == nil {
+		roleDocs = bson.A{}
+	}
+
+	return marshalResponse(bson.D{
+		{Key: "roles", Value: roleDocs},
+		{Key: "ok", Value: float64(1)},
+	}), nil
+}
+
 // parseRolesFromCmd parses the "roles" array from a command document.
 // Each role can be a string (shorthand for role in current db) or a document
 // {"role": "roleName", "db": "dbName"}.

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -138,6 +138,8 @@ func (d *Dispatcher) registerAll() {
 	d.register("usersinfo", handleUsersInfo)
 	d.register("grantrolestouser", handleGrantRolesToUser)
 	d.register("revokerolesfromuser", handleRevokeRolesFromUser)
+	d.register("rolesinfo", handleRolesInfo)
+	d.register("rolesInfo", handleRolesInfo)
 
 	// Server lifecycle
 	d.register("shutdown", handleShutdown)
@@ -254,7 +256,7 @@ func cmdNameToAction(cmdName string) string {
 	case "dbstats", "dbStats", "collstats", "collStats":
 		return "find"
 	case "createuser", "dropuser", "updateuser", "usersinfo",
-		"grantrolestouser", "revokerolesfromuser":
+		"grantrolestouser", "revokerolesfromuser", "rolesinfo":
 		return "createUser"
 	default:
 		return "find"

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -5237,6 +5237,137 @@ func TestShutdownCommandRegistered(t *testing.T) {
 	}
 }
 
+// ─── rolesInfo ────────────────────────────────────────────────────────────────
+
+func TestRolesInfoCommandRegistered(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	// rolesInfo: 1 should return ok:1, not CommandNotFound.
+	res := client.Database("admin").RunCommand(ctx, bson.D{{Key: "rolesInfo", Value: 1}})
+	if err := res.Err(); err != nil {
+		var cmdErr mongo.CommandError
+		if errors.As(err, &cmdErr) && cmdErr.Code == 59 {
+			t.Fatalf("rolesInfo command is not registered (CommandNotFound)")
+		}
+		t.Fatalf("rolesInfo returned unexpected error: %v", err)
+	}
+
+	var result bson.M
+	if err := res.Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result["ok"] != float64(1) {
+		t.Errorf("expected ok:1, got %v", result["ok"])
+	}
+}
+
+func TestRolesInfoShowBuiltinRoles(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	res := client.Database("admin").RunCommand(ctx, bson.D{
+		{Key: "rolesInfo", Value: 1},
+		{Key: "showBuiltinRoles", Value: true},
+	})
+	if err := res.Err(); err != nil {
+		t.Fatalf("rolesInfo with showBuiltinRoles: %v", err)
+	}
+
+	var result bson.M
+	if err := res.Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	roles, ok := result["roles"].(bson.A)
+	if !ok {
+		t.Fatalf("expected roles array, got %T", result["roles"])
+	}
+	if len(roles) == 0 {
+		t.Errorf("expected built-in roles in admin db, got empty array")
+	}
+}
+
+func TestRolesInfoSingleRole(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	res := client.Database("admin").RunCommand(ctx, bson.D{
+		{Key: "rolesInfo", Value: bson.D{
+			{Key: "role", Value: "read"},
+			{Key: "db", Value: "admin"},
+		}},
+	})
+	if err := res.Err(); err != nil {
+		t.Fatalf("rolesInfo single role: %v", err)
+	}
+
+	var result bson.M
+	if err := res.Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result["ok"] != float64(1) {
+		t.Errorf("expected ok:1, got %v", result["ok"])
+	}
+
+	roles, ok := result["roles"].(bson.A)
+	if !ok {
+		t.Fatalf("expected roles array, got %T", result["roles"])
+	}
+	if len(roles) != 1 {
+		t.Errorf("expected 1 role, got %d", len(roles))
+	}
+}
+
+func TestRolesInfoByString(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	res := client.Database("admin").RunCommand(ctx, bson.D{
+		{Key: "rolesInfo", Value: "read"},
+	})
+	if err := res.Err(); err != nil {
+		t.Fatalf("rolesInfo by string: %v", err)
+	}
+
+	var result bson.M
+	if err := res.Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	roles, ok := result["roles"].(bson.A)
+	if !ok {
+		t.Fatalf("expected roles array, got %T", result["roles"])
+	}
+	if len(roles) != 1 {
+		t.Errorf("expected 1 role for 'read', got %d", len(roles))
+	}
+}
+
+func TestRolesInfoNonExistentRole(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	// A non-existent custom role should return an empty array (not an error).
+	res := client.Database("admin").RunCommand(ctx, bson.D{
+		{Key: "rolesInfo", Value: "nonExistentCustomRole12345"},
+	})
+	if err := res.Err(); err != nil {
+		t.Fatalf("rolesInfo non-existent role: %v", err)
+	}
+
+	var result bson.M
+	if err := res.Decode(&result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	roles, ok := result["roles"].(bson.A)
+	if !ok {
+		t.Fatalf("expected roles array, got %T", result["roles"])
+	}
+	if len(roles) != 0 {
+		t.Errorf("expected empty array for non-existent role, got %d entries", len(roles))
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())


### PR DESCRIPTION
Closes #32

## What
- Added `handleRolesInfo` handler in `internal/commands/auth_cmds.go`
- Registered `rolesinfo` / `rolesInfo` in the dispatcher
- Added `rolesinfo` to the auth action mapping (`createUser` permission)
- Added 5 integration tests covering: command registration, `showBuiltinRoles`, single role lookup by document, lookup by string name, and non-existent role returning empty array

## Why
`rolesInfo` is part of the MongoDB wire protocol auth management surface. Without it, drivers and tools that call `rolesInfo` to inspect role definitions receive a `CommandNotFound` error. This completes the auth management command set alongside `usersInfo`, `createUser`, `dropUser`, etc.

```yaml
agent:
  id: founder-agent-s3
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#32"]
```

*Posted by the founder agent on behalf of @inder*