### PR TITLE
feat(commands): implement droprole command

### DIFF
--- a/internal/commands/auth_cmds.go
+++ b/internal/commands/auth_cmds.go
@@ -541,6 +541,22 @@ func handleRolesInfo(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	}), nil
 }
 
+// handleDropRole handles the "dropRole" command.
+// Salvobase does not persist custom roles, so this command validates its
+// arguments and returns OK (a no-op drop of a role that was never stored).
+func handleDropRole(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
+	roleVal, err := cmd.LookupErr("dropRole")
+	if err != nil {
+		return nil, storage.Errorf(storage.ErrCodeBadValue, "dropRole: missing 'dropRole' field")
+	}
+	roleName, ok := roleVal.StringValueOK()
+	if !ok || roleName == "" {
+		return nil, storage.Errorf(storage.ErrCodeBadValue, "dropRole: role name must be a non-empty string")
+	}
+
+	return BuildOKResponse(), nil
+}
+
 // parseRolesFromCmd parses the "roles" array from a command document.
 // Each role can be a string (shorthand for role in current db) or a document
 // {"role": "roleName", "db": "dbName"}.

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -140,6 +140,7 @@ func (d *Dispatcher) registerAll() {
 	d.register("revokerolesfromuser", handleRevokeRolesFromUser)
 	d.register("rolesinfo", handleRolesInfo)
 	d.register("rolesInfo", handleRolesInfo)
+	d.register("droprole", handleDropRole)
 
 	// Server lifecycle
 	d.register("shutdown", handleShutdown)
@@ -256,7 +257,7 @@ func cmdNameToAction(cmdName string) string {
 	case "dbstats", "dbStats", "collstats", "collStats":
 		return "find"
 	case "createuser", "dropuser", "updateuser", "usersinfo",
-		"grantrolestouser", "revokerolesfromuser", "rolesinfo":
+		"grantrolestouser", "revokerolesfromuser", "rolesinfo", "droprole":
 		return "createUser"
 	default:
 		return "find"

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -5368,6 +5368,51 @@ func TestRolesInfoNonExistentRole(t *testing.T) {
 	}
 }
 
+// ─── dropRole ─────────────────────────────────────────────────────────────────
+
+// TestDropRoleCommandRegistered verifies that the dropRole command is
+// registered and not returning CommandNotFound (code 59).
+func TestDropRoleCommandRegistered(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	// dropRole with a valid role name should return ok:1 (no-op since
+	// Salvobase has no custom role store).
+	var result bson.M
+	err := client.Database("admin").RunCommand(ctx, bson.D{
+		{Key: "dropRole", Value: "testRole"},
+	}).Decode(&result)
+	if err != nil {
+		var cmdErr mongo.CommandError
+		if errors.As(err, &cmdErr) && cmdErr.Code == 59 {
+			t.Fatalf("dropRole command is not registered (CommandNotFound)")
+		}
+		t.Fatalf("dropRole: unexpected error: %v", err)
+	}
+	if ok, _ := result["ok"].(float64); ok != 1 {
+		t.Errorf("dropRole: expected ok:1, got %v", result["ok"])
+	}
+}
+
+// TestDropRoleMissingArg verifies that dropRole returns an error (not
+// CommandNotFound) when the role name argument is missing or invalid.
+func TestDropRoleMissingArg(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	// Pass an integer instead of a string — must be rejected before dropping.
+	err := client.Database("admin").RunCommand(ctx, bson.D{
+		{Key: "dropRole", Value: int32(0)},
+	}).Err()
+	if err == nil {
+		t.Fatal("dropRole with invalid arg: expected error, got nil")
+	}
+	var cmdErr mongo.CommandError
+	if errors.As(err, &cmdErr) && cmdErr.Code == 59 {
+		t.Errorf("dropRole command is not registered (CommandNotFound)")
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())


### PR DESCRIPTION
Closes #34

## What
- Added `handleDropRole` handler in `internal/commands/auth_cmds.go` that validates the `dropRole` argument (must be a non-empty string) and returns `ok: 1`
- Registered the handler under `droprole` in `internal/commands/dispatcher.go`
- Mapped `droprole` to the `createUser` auth action in `cmdNameToAction`
- Added two integration tests: `TestDropRoleCommandRegistered` and `TestDropRoleMissingArg`

## Why
The `dropRole` command is part of the MongoDB wire protocol but was missing from Salvobase's dispatcher, causing a `CommandNotFound` (code 59) error for any client that issued it. Since Salvobase has no persistent custom-role store, the handler is a validated no-op that returns success.

```yaml
agent:
  id: founder-agent-s1
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#34"]
```

*Posted by the founder agent on behalf of @inder*