### PR TITLE
feat(commands): implement createrole command

### DIFF
--- a/internal/commands/auth_cmds.go
+++ b/internal/commands/auth_cmds.go
@@ -557,6 +557,74 @@ func handleDropRole(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	return BuildOKResponse(), nil
 }
 
+// handleCreateRole handles the "createRole" command.
+// Custom roles are stored in admin.system.roles using the standard collection API.
+func handleCreateRole(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
+	roleNameVal, err := cmd.LookupErr("createRole")
+	if err != nil {
+		return nil, storage.Errorf(storage.ErrCodeBadValue, "createRole: missing 'createRole' field")
+	}
+	roleName, ok := roleNameVal.StringValueOK()
+	if !ok || roleName == "" {
+		return nil, storage.Errorf(storage.ErrCodeBadValue, "createRole: role name must be a non-empty string")
+	}
+
+	// Privileges are required (may be empty array).
+	privilegesVal, err := cmd.LookupErr("privileges")
+	if err != nil {
+		return nil, storage.Errorf(storage.ErrCodeBadValue, "createRole: missing 'privileges' field")
+	}
+	if _, ok := privilegesVal.ArrayOK(); !ok {
+		return nil, storage.Errorf(storage.ErrCodeBadValue, "createRole: 'privileges' must be an array")
+	}
+
+	// Inherited roles (may be empty array).
+	inheritedRoles := parseRolesFromCmd(cmd, ctx.DB)
+
+	// Roles in admin.system.roles are keyed by "<db>.<roleName>".
+	roleID := ctx.DB + "." + roleName
+
+	coll, err := ctx.Engine.Collection("admin", "system.roles")
+	if err != nil {
+		return nil, fmt.Errorf("createRole: %w", err)
+	}
+
+	// Check for duplicates.
+	idFilter, _ := bson.Marshal(bson.D{{Key: "_id", Value: roleID}})
+	existing, err := coll.FindOne(idFilter, storage.FindOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("createRole: %w", err)
+	}
+	if existing != nil {
+		return nil, storage.Errorf(storage.ErrCodeRoleAlreadyExists,
+			"Role \"%s@%s\" already exists", roleName, ctx.DB)
+	}
+
+	// Build inherited-roles subdocuments.
+	inheritedArr := make(bson.A, 0, len(inheritedRoles))
+	for _, r := range inheritedRoles {
+		inheritedArr = append(inheritedArr, bson.D{
+			{Key: "role", Value: r.Role},
+			{Key: "db", Value: r.DB},
+		})
+	}
+
+	// Store the raw privileges array as-is.
+	doc, _ := bson.Marshal(bson.D{
+		{Key: "_id", Value: roleID},
+		{Key: "role", Value: roleName},
+		{Key: "db", Value: ctx.DB},
+		{Key: "privileges", Value: privilegesVal},
+		{Key: "roles", Value: inheritedArr},
+	})
+
+	if _, err := coll.InsertOne(doc); err != nil {
+		return nil, fmt.Errorf("createRole: %w", err)
+	}
+
+	return BuildOKResponse(), nil
+}
+
 // parseRolesFromCmd parses the "roles" array from a command document.
 // Each role can be a string (shorthand for role in current db) or a document
 // {"role": "roleName", "db": "dbName"}.

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -141,6 +141,7 @@ func (d *Dispatcher) registerAll() {
 	d.register("rolesinfo", handleRolesInfo)
 	d.register("rolesInfo", handleRolesInfo)
 	d.register("droprole", handleDropRole)
+	d.register("createrole", handleCreateRole)
 
 	// Server lifecycle
 	d.register("shutdown", handleShutdown)
@@ -257,7 +258,7 @@ func cmdNameToAction(cmdName string) string {
 	case "dbstats", "dbStats", "collstats", "collStats":
 		return "find"
 	case "createuser", "dropuser", "updateuser", "usersinfo",
-		"grantrolestouser", "revokerolesfromuser", "rolesinfo", "droprole":
+		"grantrolestouser", "revokerolesfromuser", "rolesinfo", "droprole", "createrole":
 		return "createUser"
 	default:
 		return "find"
@@ -339,6 +340,10 @@ func mongoErrorCodeName(code int32) string {
 		return "DuplicateKey"
 	case 51003:
 		return "UserAlreadyExists"
+	case 51002:
+		return "RoleAlreadyExists"
+	case 31:
+		return "RoleNotFound"
 	case 43:
 		return "CursorNotFound"
 	case 125:

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -371,6 +371,8 @@ const (
 	ErrCodeAuthenticationFailed    = int32(18)
 	ErrCodeUserNotFound            = int32(11)
 	ErrCodeUserAlreadyExists       = int32(51003)
+	ErrCodeRoleAlreadyExists       = int32(51002)
+	ErrCodeRoleNotFound            = int32(31)
 	ErrCodeCursorNotFound           = int32(43)
 	ErrCodeCommandFailed            = int32(125)
 	ErrCodeNotImplemented           = int32(238)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -5413,6 +5413,94 @@ func TestDropRoleMissingArg(t *testing.T) {
 	}
 }
 
+// ─── createRole ───────────────────────────────────────────────────────────────
+
+// TestCreateRole verifies that the createRole command is registered and
+// returns a successful response when creating a new custom role.
+func TestCreateRole(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	// createRole must be run against the admin database.
+	adminDB := client.Database("admin")
+
+	roleName := fmt.Sprintf("testRole_%d", time.Now().UnixNano())
+
+	// Create a simple custom role with no privileges and no inherited roles.
+	res := adminDB.RunCommand(ctx, bson.D{
+		{Key: "createRole", Value: roleName},
+		{Key: "privileges", Value: bson.A{}},
+		{Key: "roles", Value: bson.A{}},
+	})
+	if err := res.Err(); err != nil {
+		t.Fatalf("createRole: unexpected error: %v", err)
+	}
+
+	var result bson.M
+	if err := res.Decode(&result); err != nil {
+		t.Fatalf("createRole: decode result: %v", err)
+	}
+	if ok, _ := result["ok"].(float64); ok != 1 {
+		t.Errorf("createRole: expected ok=1, got %v", result["ok"])
+	}
+}
+
+// TestCreateRoleDuplicate verifies that creating the same role twice returns an error.
+func TestCreateRoleDuplicate(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	adminDB := client.Database("admin")
+	roleName := fmt.Sprintf("dupRole_%d", time.Now().UnixNano())
+
+	createCmd := bson.D{
+		{Key: "createRole", Value: roleName},
+		{Key: "privileges", Value: bson.A{}},
+		{Key: "roles", Value: bson.A{}},
+	}
+
+	// First creation must succeed.
+	if err := adminDB.RunCommand(ctx, createCmd).Err(); err != nil {
+		t.Fatalf("first createRole: %v", err)
+	}
+
+	// Second creation must fail with RoleAlreadyExists (code 51002).
+	err := adminDB.RunCommand(ctx, createCmd).Err()
+	if err == nil {
+		t.Fatal("createRole duplicate: expected error, got nil")
+	}
+
+	var cmdErr mongo.CommandError
+	if errors.As(err, &cmdErr) {
+		if cmdErr.Code != 51002 {
+			t.Errorf("expected RoleAlreadyExists (51002), got code %d: %s", cmdErr.Code, cmdErr.Message)
+		}
+	}
+}
+
+// TestCreateRoleMissingPrivileges verifies that createRole rejects a command
+// without the required 'privileges' field.
+func TestCreateRoleMissingPrivileges(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	adminDB := client.Database("admin")
+	err := adminDB.RunCommand(ctx, bson.D{
+		{Key: "createRole", Value: "someRole"},
+		{Key: "roles", Value: bson.A{}},
+	}).Err()
+	if err == nil {
+		t.Fatal("createRole without privileges: expected error, got nil")
+	}
+
+	var cmdErr mongo.CommandError
+	if errors.As(err, &cmdErr) {
+		if cmdErr.Code == 59 {
+			t.Errorf("createRole command is not registered (CommandNotFound)")
+		}
+	}
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())


### PR DESCRIPTION
Closes #33

## What
- Registers `createrole` command handler in `internal/commands/dispatcher.go`
- Implements `handleCreateRole` in `internal/commands/auth_cmds.go`: stores custom roles in `admin.system.roles` collection as BSON documents
- Adds `ErrCodeRoleAlreadyExists` (51002) and `ErrCodeRoleNotFound` (31) error codes to `internal/storage/types.go`
- Maps `createrole` to the `createUser` auth action for permission checks
- Adds 3 integration tests: success case, duplicate rejection, and missing-privileges validation

## Why
`createRole` is part of the MongoDB wire protocol. Without it, clients attempting to create custom roles receive `CommandNotFound` (59), breaking MongoDB compatibility for auth-sensitive workflows.

```yaml
agent:
  id: founder-agent-s2
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#33"]
```

*Posted by the founder agent on behalf of @inder*