### PR TITLE
feat(commands): implement killop command (#31)

### DIFF
--- a/internal/commands/diagnostic.go
+++ b/internal/commands/diagnostic.go
@@ -393,6 +393,33 @@ func handleCurrentOp(_ *Context, _ bson.Raw) (bson.Raw, error) {
 	}), nil
 }
 
+// handleKillOp handles the "killOp" command.
+// Terminates a running operation identified by its opid.
+// Salvobase does not track per-operation state, so this is a no-op that
+// returns success — matching MongoDB's behaviour when the op is not found.
+func handleKillOp(_ *Context, cmd bson.Raw) (bson.Raw, error) {
+	opVal, err := cmd.LookupErr("killOp")
+	if err != nil {
+		opVal, err = cmd.LookupErr("killop")
+	}
+	// The command value is the sentinel (always 1); the actual op to kill is in "op".
+	_ = opVal
+
+	// "op" field: the operation ID to terminate. Validate it is numeric if present.
+	opIDVal, err := cmd.LookupErr("op")
+	if err == nil {
+		switch opIDVal.Type {
+		case bson.TypeInt32, bson.TypeInt64, bson.TypeDouble:
+			// valid numeric op id — nothing to do since we have no op registry
+		default:
+			return nil, storage.Errorf(storage.ErrCodeBadValue,
+				"killOp: 'op' field must be a number")
+		}
+	}
+
+	return BuildOKResponse(), nil
+}
+
 // handleExplain handles the "explain" command.
 // It re-runs the wrapped command and adds explain output.
 func handleExplain(ctx *Context, cmd bson.Raw) (bson.Raw, error) {

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -119,6 +119,8 @@ func (d *Dispatcher) registerAll() {
 	d.register("explain", handleExplain)
 	d.register("currentop", handleCurrentOp)
 	d.register("currentOp", handleCurrentOp)
+	d.register("killop", handleKillOp)
+	d.register("killOp", handleKillOp)
 	d.register("hostinfo", handleHostInfo)
 	d.register("hostInfo", handleHostInfo)
 	d.register("getcmdlineopts", handleGetCmdLineOpts)
@@ -255,6 +257,8 @@ func cmdNameToAction(cmdName string) string {
 		return "renameCollection"
 	case "serverstatus":
 		return "serverStatus"
+	case "killop":
+		return "killop"
 	case "dbstats", "dbStats", "collstats", "collStats":
 		return "find"
 	case "createuser", "dropuser", "updateuser", "usersinfo",

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -3432,6 +3432,86 @@ func TestCurrentOpLowercase(t *testing.T) {
 	}
 }
 
+// ─── killOp command (#31) ─────────────────────────────────────────────────────
+
+func TestKillOp(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	var result bson.M
+	err := client.Database("admin").RunCommand(ctx, bson.D{
+		{Key: "killOp", Value: 1},
+		{Key: "op", Value: int32(12345)},
+	}).Decode(&result)
+	if err != nil {
+		t.Fatalf("killOp: %v", err)
+	}
+
+	ok64, _ := result["ok"].(float64)
+	if ok64 != 1 {
+		t.Errorf("killOp: expected ok=1, got %v", result["ok"])
+	}
+}
+
+func TestKillOpLowercase(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	var result bson.M
+	err := client.Database("admin").RunCommand(ctx, bson.D{
+		{Key: "killop", Value: 1},
+		{Key: "op", Value: int32(99)},
+	}).Decode(&result)
+	if err != nil {
+		t.Fatalf("killop (lowercase): %v", err)
+	}
+
+	ok64, _ := result["ok"].(float64)
+	if ok64 != 1 {
+		t.Errorf("killop lowercase: expected ok=1, got %v", result["ok"])
+	}
+}
+
+func TestKillOpNoOpField(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	// killOp without an "op" field should still succeed.
+	var result bson.M
+	err := client.Database("admin").RunCommand(ctx, bson.D{
+		{Key: "killOp", Value: 1},
+	}).Decode(&result)
+	if err != nil {
+		t.Fatalf("killOp without op field: %v", err)
+	}
+
+	ok64, _ := result["ok"].(float64)
+	if ok64 != 1 {
+		t.Errorf("killOp no op field: expected ok=1, got %v", result["ok"])
+	}
+}
+
+func TestKillOpInvalidOpType(t *testing.T) {
+	client := newClient(t)
+	ctx := context.Background()
+
+	// killOp with a non-numeric "op" field should return an error.
+	err := client.Database("admin").RunCommand(ctx, bson.D{
+		{Key: "killOp", Value: 1},
+		{Key: "op", Value: "not-a-number"},
+	}).Err()
+	if err == nil {
+		t.Fatal("killOp with string op: expected error, got nil")
+	}
+
+	var cmdErr mongo.CommandError
+	if errors.As(err, &cmdErr) {
+		if cmdErr.Code == 59 {
+			t.Errorf("killOp command is not registered (CommandNotFound)")
+		}
+	}
+}
+
 // ─── $type query operator (#8) ────────────────────────────────────────────────
 
 func TestTypeQueryOperator(t *testing.T) {


### PR DESCRIPTION
Closes #31

## What
- Added `handleKillOp` function to `internal/commands/diagnostic.go`
- Registered both `killOp` and `killop` command names in `dispatcher.go`
- Added auth action mapping for `killop`
- Added 4 integration tests covering: canonical form, lowercase alias, missing `op` field, and invalid `op` type

## Why
The `killop` command is part of the MongoDB wire protocol and is required for MongoDB-compatible client compatibility. It serves as the companion to `currentOp`, allowing clients to request termination of an in-flight operation. Since Salvobase does not maintain a per-operation registry, the handler validates input and returns success (matching MongoDB's behaviour when the targeted op is not found).

```yaml
agent:
  id: founder-agent-s1
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#31"]
```

*Posted by the founder agent on behalf of @inder*