### PR TITLE
docs(storage): add Go doc comments to exported storage interfaces

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -21,11 +21,17 @@ type bboltCollection struct {
 	engine *BBoltEngine
 }
 
-func (c *bboltCollection) Name() string     { return c.coll }
+// Name returns the collection name within its database.
+func (c *bboltCollection) Name() string { return c.coll }
+
+// Database returns the name of the database that owns this collection.
 func (c *bboltCollection) Database() string { return c.db }
 
 // ─── Insert ───────────────────────────────────────────────────────────────────
 
+// InsertOne inserts a single document and returns its _id. If the document has
+// no _id field a new ObjectID is generated and prepended. Returns
+// ErrCodeDuplicateKey if a document with the same _id already exists.
 func (c *bboltCollection) InsertOne(doc bson.Raw) (bson.ObjectID, error) {
 	ids, err := c.InsertMany([]bson.Raw{doc}, InsertOptions{Ordered: true})
 	if err != nil {
@@ -367,6 +373,21 @@ func (c *bboltCollection) cappedEvict(tx *bolt.Tx, b *bolt.Bucket, newDoc bson.R
 
 // ─── Find ─────────────────────────────────────────────────────────────────────
 
+// Find returns a Cursor over documents that match filter. The caller is
+// responsible for closing the cursor when done.
+//
+// Query planning:
+//   - If a sort is requested, all matching documents are materialized in memory
+//     and sorted before the cursor is returned.
+//   - If filter is a simple {_id: <scalar>} equality, a direct bbolt key lookup
+//     is performed (O(log N)).
+//   - Otherwise, the planner inspects available secondary indexes. If a suitable
+//     index is found an index scan is used; otherwise a full collection scan is
+//     performed using a streaming cursor that pages through the bucket on demand,
+//     keeping only one batch in memory at a time.
+//
+// Thread-safety: safe to call concurrently. Each call opens an independent
+// bbolt read transaction (MVCC snapshot).
 func (c *bboltCollection) Find(filter bson.Raw, opts FindOptions) (Cursor, error) {
 	hasSort := len(opts.Sort) > 0
 
@@ -1374,14 +1395,23 @@ func tryFastSetOnly(doc bson.Raw, update bson.Raw) (bson.Raw, bool) {
 	return bson.Raw(dst), true
 }
 
+// UpdateOne applies update to the first document that matches filter. If
+// opts.Upsert is true and no document matches, an upsert is performed.
+// Returns a summary of matched, modified, and upserted document counts.
 func (c *bboltCollection) UpdateOne(filter, update bson.Raw, opts UpdateOptions) (UpdateResult, error) {
 	return c.updateDocs(filter, update, opts, false)
 }
 
+// UpdateMany applies update to all documents that match filter. If
+// opts.Upsert is true and no documents match, a single upsert is performed.
+// Returns a summary of matched, modified, and upserted document counts.
 func (c *bboltCollection) UpdateMany(filter, update bson.Raw, opts UpdateOptions) (UpdateResult, error) {
 	return c.updateDocs(filter, update, opts, true)
 }
 
+// ReplaceOne replaces the first document matching filter with the given
+// replacement document (which must not contain update operators). If
+// opts.Upsert is true and no document matches, the replacement is inserted.
 func (c *bboltCollection) ReplaceOne(filter, replacement bson.Raw, opts UpdateOptions) (UpdateResult, error) {
 	// A replacement is an update without operators
 	return c.replaceDocs(filter, replacement, opts)
@@ -1750,10 +1780,16 @@ func hasOpPrefix(s string) bool {
 
 // ─── Delete ───────────────────────────────────────────────────────────────────
 
+// DeleteOne removes the first document that matches filter and returns the
+// number of documents deleted (0 or 1). Returns ErrCodeIllegalOperation for
+// capped collections, which do not support explicit deletion.
 func (c *bboltCollection) DeleteOne(filter bson.Raw) (int64, error) {
 	return c.deleteDocs(filter, false)
 }
 
+// DeleteMany removes all documents that match filter and returns the count of
+// deleted documents. Returns ErrCodeIllegalOperation for capped collections,
+// which do not support explicit deletion.
 func (c *bboltCollection) DeleteMany(filter bson.Raw) (int64, error) {
 	return c.deleteDocs(filter, true)
 }
@@ -1841,6 +1877,10 @@ func (c *bboltCollection) deleteDocs(filter bson.Raw, multi bool) (int64, error)
 
 // ─── Count / Distinct ─────────────────────────────────────────────────────────
 
+// CountDocuments returns the number of documents in the collection that match
+// filter. A nil or empty filter counts all documents. When filter is empty the
+// count is derived from bbolt bucket statistics (O(1)); otherwise a full
+// collection scan is performed.
 func (c *bboltCollection) CountDocuments(filter bson.Raw) (int64, error) {
 	boltDB, err := c.engine.getDB(c.db)
 	if err != nil {
@@ -1886,6 +1926,9 @@ func (c *bboltCollection) CountDocuments(filter bson.Raw) (int64, error) {
 	return count, nil
 }
 
+// Distinct returns the unique values of field across all documents matching
+// filter. Nested fields can be addressed with dot notation (e.g. "address.city").
+// The result slice is unordered and each value appears at most once.
 func (c *bboltCollection) Distinct(field string, filter bson.Raw) ([]interface{}, error) {
 	boltDB, err := c.engine.getDB(c.db)
 	if err != nil {

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -131,11 +131,17 @@ func (e *BBoltEngine) getDB(name string) (*bolt.DB, error) {
 
 // ─── Engine interface implementation ─────────────────────────────────────────
 
+// CreateDatabase ensures the named database exists by opening (or creating) its
+// underlying bbolt file. It is safe to call concurrently; the first call wins
+// and subsequent calls are no-ops if the file already exists.
 func (e *BBoltEngine) CreateDatabase(name string) error {
 	_, err := e.openDB(name)
 	return err
 }
 
+// DropDatabase closes and removes the database file for name. Any in-flight
+// reads or writes against the database may fail with an error after this call
+// returns. If the database does not exist the call is a no-op (no error).
 func (e *BBoltEngine) DropDatabase(name string) error {
 	e.mu.Lock()
 	db, ok := e.dbs[name]
@@ -156,6 +162,9 @@ func (e *BBoltEngine) DropDatabase(name string) error {
 	return nil
 }
 
+// ListDatabases returns metadata for every database whose .db file exists in
+// the data directory. Databases that have no collections are reported with
+// Empty=true. The list is unordered.
 func (e *BBoltEngine) ListDatabases() ([]DatabaseInfo, error) {
 	entries, err := os.ReadDir(e.dataDir)
 	if err != nil {
@@ -181,12 +190,17 @@ func (e *BBoltEngine) ListDatabases() ([]DatabaseInfo, error) {
 	return result, nil
 }
 
+// HasDatabase reports whether the named database exists on disk. It does not
+// require the database to be currently open.
 func (e *BBoltEngine) HasDatabase(name string) bool {
 	path := filepath.Join(e.dataDir, name+".db")
 	_, err := os.Stat(path)
 	return err == nil
 }
 
+// CreateCollection explicitly creates collection coll in database db with the
+// given options. Returns ErrCodeCollectionAlreadyExists if the collection
+// already exists. The database is opened (or created) implicitly.
 func (e *BBoltEngine) CreateCollection(db, coll string, opts CreateCollectionOptions) error {
 	boltDB, err := e.openDB(db)
 	if err != nil {
@@ -219,6 +233,8 @@ func (e *BBoltEngine) CreateCollection(db, coll string, opts CreateCollectionOpt
 	})
 }
 
+// DropCollection removes collection coll and all of its indexes from database
+// db. If the collection does not exist the call succeeds silently.
 func (e *BBoltEngine) DropCollection(db, coll string) error {
 	boltDB, err := e.getDB(db)
 	if err != nil {
@@ -264,6 +280,9 @@ func (e *BBoltEngine) DropCollection(db, coll string) error {
 	})
 }
 
+// ListCollections returns the CollectionInfo for every collection registered in
+// database db. Returns an empty (nil) slice — not an error — if the database
+// does not exist or has no collections.
 func (e *BBoltEngine) ListCollections(db string) ([]CollectionInfo, error) {
 	boltDB, err := e.getDB(db)
 	if err != nil {
@@ -290,6 +309,7 @@ func (e *BBoltEngine) ListCollections(db string) ([]CollectionInfo, error) {
 	})
 }
 
+// HasCollection reports whether collection coll exists in database db.
 func (e *BBoltEngine) HasCollection(db, coll string) bool {
 	boltDB, err := e.getDB(db)
 	if err != nil {
@@ -557,6 +577,11 @@ func renameBucket(tx *bolt.Tx, from, to string) error {
 
 // ─── Index management ─────────────────────────────────────────────────────────
 
+// CreateIndex builds a secondary index on collection coll in database db
+// according to spec. If spec.Name is empty an index name is derived from the
+// key pattern. Existing documents are back-filled into the index within the
+// same write transaction that registers the spec. Returns the final index name.
+// The operation is idempotent — calling it twice with the same name is safe.
 func (e *BBoltEngine) CreateIndex(db, coll string, spec IndexSpec) (string, error) {
 	boltDB, err := e.openDB(db)
 	if err != nil {
@@ -647,6 +672,9 @@ func (e *BBoltEngine) CreateIndex(db, coll string, spec IndexSpec) (string, erro
 	return spec.Name, nil
 }
 
+// DropIndex removes the named secondary index from collection coll in database
+// db. Returns ErrCodeIllegalOperation if the caller attempts to drop the
+// built-in _id_ index, and ErrCodeIndexNotFound if the index does not exist.
 func (e *BBoltEngine) DropIndex(db, coll, indexName string) error {
 	boltDB, err := e.getDB(db)
 	if err != nil {
@@ -667,6 +695,9 @@ func (e *BBoltEngine) DropIndex(db, coll, indexName string) error {
 	})
 }
 
+// ListIndexes returns all indexes for collection coll in database db. The
+// built-in _id_ index is always included as the first element. If the database
+// or collection does not yet exist, only the _id_ index descriptor is returned.
 func (e *BBoltEngine) ListIndexes(db, coll string) ([]IndexInfo, error) {
 	boltDB, err := e.getDB(db)
 	if err != nil {
@@ -725,6 +756,8 @@ func defaultIndexes(db, coll string) []IndexInfo {
 
 // ─── Stats ────────────────────────────────────────────────────────────────────
 
+// DatabaseStats returns storage statistics for database db. If the database
+// does not exist an empty stats struct is returned with no error.
 func (e *BBoltEngine) DatabaseStats(db string) (DatabaseStats, error) {
 	boltDB, err := e.getDB(db)
 	if err != nil {
@@ -773,6 +806,9 @@ func (e *BBoltEngine) DatabaseStats(db string) (DatabaseStats, error) {
 	return stats, nil
 }
 
+// CollectionStats returns storage statistics for collection coll in database
+// db. If the database does not exist an empty stats struct is returned with no
+// error. The IndexSizes map is always non-nil.
 func (e *BBoltEngine) CollectionStats(db, coll string) (CollectionStats, error) {
 	boltDB, err := e.getDB(db)
 	if err != nil {
@@ -832,6 +868,10 @@ func (e *BBoltEngine) CollectionStats(db, coll string) (CollectionStats, error) 
 	return cs, nil
 }
 
+// ServerStats returns a snapshot of server-wide counters and system information
+// including uptime, operation counters (insert/query/update/delete/getMore/command),
+// and basic memory statistics. The returned struct is safe to read without
+// further synchronisation — all counters are read from atomic integers.
 func (e *BBoltEngine) ServerStats() (ServerStats, error) {
 	hostname, _ := os.Hostname()
 	uptime := int64(time.Since(e.startTime).Seconds())
@@ -874,12 +914,22 @@ func (e *BBoltEngine) getCollectionInfo(db, coll string) (CollectionInfo, bool) 
 
 // ─── Cursors / Users ──────────────────────────────────────────────────────────
 
+// Cursors returns the engine-wide CursorStore used to register and retrieve
+// server-side cursors across getMore commands. Thread-safe.
 func (e *BBoltEngine) Cursors() CursorStore { return e.cursors }
-func (e *BBoltEngine) Users() UserStore     { return e.users }
-func (e *BBoltEngine) EventBus() *EventBus  { return e.eventBus }
+
+// Users returns the UserStore backed by the admin database. Thread-safe.
+func (e *BBoltEngine) Users() UserStore { return e.users }
+
+// EventBus returns the engine-wide EventBus used to fan out change-stream
+// events to registered watchers. Thread-safe.
+func (e *BBoltEngine) EventBus() *EventBus { return e.eventBus }
 
 // ─── Close ────────────────────────────────────────────────────────────────────
 
+// Close flushes and closes all open bbolt databases. After Close returns the
+// engine must not be used. Any subsequent method call will likely panic or
+// return an error. Returns the first close error encountered, if any.
 func (e *BBoltEngine) Close() error {
 	if e.eventBus != nil {
 		e.eventBus.Close()


### PR DESCRIPTION
Closes #11

## What
Added comprehensive Go doc comments to all exported functions in `internal/storage/engine.go` and `internal/storage/collection.go`.

**engine.go** — documented: `CreateDatabase`, `DropDatabase`, `ListDatabases`, `HasDatabase`, `CreateCollection`, `DropCollection`, `ListCollections`, `HasCollection`, `CreateIndex`, `DropIndex`, `ListIndexes`, `DatabaseStats`, `CollectionStats`, `ServerStats`, `Cursors`, `Users`, `EventBus`, `Close`.

**collection.go** — documented: `Name`, `Database`, `InsertOne`, `Find`, `UpdateOne`, `UpdateMany`, `ReplaceOne`, `DeleteOne`, `DeleteMany`, `CountDocuments`, `Distinct`.

## Why
Exported symbols without doc comments make the storage package opaque to contributors. The new comments describe behavior, error conditions (duplicate key, illegal operation, not found), and thread-safety guarantees, satisfying the acceptance criteria in #11.

```yaml
agent:
  id: founder-agent-s3
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#11"]
```

*Posted by the founder agent on behalf of @inder*