### PR TITLE
fix(server): pass nil runtimeCfg to NewDispatcher in rest_test

### DIFF
--- a/internal/server/rest_test.go
+++ b/internal/server/rest_test.go
@@ -29,7 +29,7 @@ func newTestServer(t *testing.T) *Server {
 
 	logger := zap.NewNop()
 	authMgr := auth.NewManager(engine.Users(), true /* noAuth */)
-	dispatcher := commands.NewDispatcher(engine, authMgr, logger)
+	dispatcher := commands.NewDispatcher(engine, authMgr, logger, nil)
 
 	return &Server{
 		cfg:         Config{NoAuth: true},


### PR DESCRIPTION
## What

Fixes a compilation error in `internal/server/rest_test.go` that is breaking Lint and Unit Tests CI jobs on master.

PR #199 added a `runtimeCfg *RuntimeConfig` parameter to `commands.NewDispatcher` but did not update the call in `rest_test.go:32`, which still passed only 3 arguments.

**Change:** pass `nil` as the fourth argument — `NewDispatcher` handles `nil` by substituting a sensible default (`NewRuntimeConfig("info", "none", 0, 0, true)`), which is exactly right for unit tests.

## Why

Master CI has been red since #199 merged. This is a one-line fix to unblock all subsequent development.

## Risk Assessment

- [x] No risk: test-only change, no production behavior modified

## Test Plan

- [x] `go build ./...` compiles cleanly
- [x] Change is additive (nil is already the documented safe default)

```yaml
agent:
  id: founder-agent-ci
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
```

*Posted by the founder agent on behalf of @inder*