### PR TITLE
feat(server): resume token support for change streams

### DIFF
--- a/internal/aggregation/change_stream_test.go
+++ b/internal/aggregation/change_stream_test.go
@@ -1,0 +1,305 @@
+package aggregation
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/inder/salvobase/internal/storage"
+)
+
+// ─── Minimal stubs for change stream pipeline tests ───────────────────────────
+
+// csTestEngine satisfies storage.Engine via nil embed (panics if any Engine method
+// is called) and also implements eventBusProvider so $changeStream works.
+type csTestEngine struct {
+	storage.Engine
+	bus *storage.EventBus
+}
+
+func (e *csTestEngine) EventBus() *storage.EventBus { return e.bus }
+
+// csTestCollection satisfies storage.Collection via nil embed and exposes Name().
+type csTestCollection struct {
+	storage.Collection
+	name string
+}
+
+func (c *csTestCollection) Name() string { return c.name }
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+func makeChangeStreamPipeline(t *testing.T, csOpts bson.D) []bson.Raw {
+	t.Helper()
+	stageRaw, err := bson.Marshal(bson.D{{Key: "$changeStream", Value: csOpts}})
+	if err != nil {
+		t.Fatalf("marshal $changeStream stage: %v", err)
+	}
+	return []bson.Raw{stageRaw}
+}
+
+func publishInsert(bus *storage.EventBus, db, coll string, id int32) {
+	docKey, _ := bson.Marshal(bson.D{{Key: "_id", Value: id}})
+	fullDoc, _ := bson.Marshal(bson.D{{Key: "_id", Value: id}})
+	bus.Publish(db, coll, storage.ChangeEvent{
+		OperationType: storage.ChangeInsert,
+		DocumentKey:   docKey,
+		FullDocument:  fullDoc,
+	})
+}
+
+// extractResumeTokenData returns the _data string from the _id field of a change event doc.
+func extractResumeTokenData(t *testing.T, eventDoc bson.Raw) string {
+	t.Helper()
+	idRaw, ok := eventDoc.Lookup("_id").DocumentOK()
+	if !ok {
+		t.Fatal("change event _id must be an embedded document")
+	}
+	dataStr, ok := idRaw.Lookup("_data").StringValueOK()
+	if !ok {
+		t.Fatal("change event _id._data must be a string")
+	}
+	return dataStr
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+// TestParseResumeAfterSeq verifies that parseResumeAfterSeq decodes a valid token.
+func TestParseResumeAfterSeq(t *testing.T) {
+	tok := storage.ResumeToken{TimestampNS: 1_234_567_890_000_000_000, Seq: 42}
+	encoded := storage.EncodeResumeToken(tok)
+
+	opts, _ := bson.Marshal(bson.D{
+		{Key: "resumeAfter", Value: bson.D{{Key: "_data", Value: encoded}}},
+	})
+
+	seq := parseResumeAfterSeq(bson.Raw(opts))
+	if seq != 42 {
+		t.Errorf("parseResumeAfterSeq: got %d, want 42", seq)
+	}
+}
+
+func TestParseResumeAfterSeqMissing(t *testing.T) {
+	opts, _ := bson.Marshal(bson.D{})
+	seq := parseResumeAfterSeq(bson.Raw(opts))
+	if seq != 0 {
+		t.Errorf("parseResumeAfterSeq (missing key): got %d, want 0", seq)
+	}
+}
+
+func TestParseResumeAfterSeqNil(t *testing.T) {
+	seq := parseResumeAfterSeq(nil)
+	if seq != 0 {
+		t.Errorf("parseResumeAfterSeq(nil): got %d, want 0", seq)
+	}
+}
+
+func TestParseResumeAfterSeqInvalidBase64(t *testing.T) {
+	opts, _ := bson.Marshal(bson.D{
+		{Key: "resumeAfter", Value: bson.D{{Key: "_data", Value: "not-valid!!!"}}},
+	})
+	seq := parseResumeAfterSeq(bson.Raw(opts))
+	if seq != 0 {
+		t.Errorf("parseResumeAfterSeq (invalid base64): got %d, want 0", seq)
+	}
+}
+
+// TestChangeStreamPipelineReturnsTailableCursor verifies that Execute with a
+// $changeStream stage returns a TailableCursor and that change events include
+// the required _id resume token field.
+func TestChangeStreamPipelineReturnsTailableCursor(t *testing.T) {
+	bus := storage.NewEventBus(100)
+	engine := &csTestEngine{bus: bus}
+	coll := &csTestCollection{name: "orders"}
+
+	cursor, err := Execute(coll, engine, "testdb", makeChangeStreamPipeline(t, bson.D{}), PipelineOptions{})
+	if err != nil {
+		t.Fatalf("Execute($changeStream): %v", err)
+	}
+	defer cursor.Close()
+
+	tc, ok := cursor.(storage.TailableCursor)
+	if !ok {
+		t.Fatal("$changeStream cursor must implement TailableCursor")
+	}
+
+	publishInsert(bus, "testdb", "orders", 1)
+
+	docs, exhausted, err := tc.NextBatchWait(context.Background(), 100, 500)
+	if err != nil {
+		t.Fatalf("NextBatchWait: %v", err)
+	}
+	if exhausted {
+		t.Error("expected exhausted=false")
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc, got %d", len(docs))
+	}
+
+	doc := bson.Raw(docs[0])
+	// _id must be an embedded document (the resume token).
+	if doc.Lookup("_id").Type != bson.TypeEmbeddedDocument {
+		t.Error("change event _id must be an embedded document (resume token)")
+	}
+	// operationType must be "insert".
+	if s, ok := doc.Lookup("operationType").StringValueOK(); !ok || s != "insert" {
+		t.Errorf("operationType = %q, want insert", s)
+	}
+	// ns.db and ns.coll must be correct.
+	nsDoc, ok := doc.Lookup("ns").DocumentOK()
+	if !ok {
+		t.Fatal("ns field missing")
+	}
+	if db, ok := nsDoc.Lookup("db").StringValueOK(); !ok || db != "testdb" {
+		t.Errorf("ns.db = %q, want testdb", db)
+	}
+	if c, ok := nsDoc.Lookup("coll").StringValueOK(); !ok || c != "orders" {
+		t.Errorf("ns.coll = %q, want orders", c)
+	}
+}
+
+// TestChangeStreamResumeAfterPipeline is the end-to-end integration scenario:
+// open a stream, consume some events, simulate a disconnect, reconnect using
+// the resume token, and verify no events are missed.
+func TestChangeStreamResumeAfterPipeline(t *testing.T) {
+	const (
+		db   = "resumedb"
+		coll = "events"
+	)
+
+	bus := storage.NewEventBus(100)
+	engine := &csTestEngine{bus: bus}
+	col := &csTestCollection{name: coll}
+
+	openStream := func(resumeTokenData string) storage.TailableCursor {
+		t.Helper()
+		csOpts := bson.D{}
+		if resumeTokenData != "" {
+			csOpts = bson.D{{
+				Key:   "resumeAfter",
+				Value: bson.D{{Key: "_data", Value: resumeTokenData}},
+			}}
+		}
+		cursor, err := Execute(col, engine, db, makeChangeStreamPipeline(t, csOpts), PipelineOptions{})
+		if err != nil {
+			t.Fatalf("Execute($changeStream): %v", err)
+		}
+		tc, ok := cursor.(storage.TailableCursor)
+		if !ok {
+			t.Fatal("$changeStream cursor must implement TailableCursor")
+		}
+		return tc
+	}
+
+	// Phase 1: Open stream, publish 3 events, read them all.
+	stream1 := openStream("")
+	publishInsert(bus, db, coll, 1)
+	publishInsert(bus, db, coll, 2)
+	publishInsert(bus, db, coll, 3)
+
+	docs, _, err := stream1.NextBatch(100)
+	if err != nil {
+		t.Fatalf("phase1 NextBatch: %v", err)
+	}
+	if len(docs) != 3 {
+		t.Fatalf("phase1: expected 3 docs, got %d", len(docs))
+	}
+
+	// Save the resume token from the 2nd event (simulates the client saving
+	// its position after processing event 2 before the disconnect).
+	tokenData := extractResumeTokenData(t, bson.Raw(docs[1]))
+
+	// "Disconnect" — close stream1.
+	if err := stream1.Close(); err != nil {
+		t.Fatalf("stream1.Close: %v", err)
+	}
+
+	// Publish 2 more events while "disconnected".
+	publishInsert(bus, db, coll, 4)
+	publishInsert(bus, db, coll, 5)
+
+	// Phase 2: Reconnect with the resume token from event 2.
+	// Should receive events 3, 4, 5 — no events missed.
+	stream2 := openStream(tokenData)
+	defer stream2.Close()
+
+	docs2, _, err := stream2.NextBatch(100)
+	if err != nil {
+		t.Fatalf("phase2 NextBatch: %v", err)
+	}
+	if len(docs2) != 3 {
+		t.Fatalf("phase2: expected 3 docs (events 3,4,5), got %d", len(docs2))
+	}
+
+	// Verify the event order by decoding documentKey._id.
+	wantIDs := []int32{3, 4, 5}
+	for i, raw := range docs2 {
+		doc := bson.Raw(raw)
+		dkRaw, ok := doc.Lookup("documentKey").DocumentOK()
+		if !ok {
+			t.Errorf("event %d: documentKey missing", i)
+			continue
+		}
+		id, ok := dkRaw.Lookup("_id").Int32OK()
+		if !ok {
+			t.Errorf("event %d: documentKey._id not an int32", i)
+			continue
+		}
+		if id != wantIDs[i] {
+			t.Errorf("event %d: got _id %d, want %d", i, id, wantIDs[i])
+		}
+	}
+
+	// PostBatchResumeToken must be non-nil and decodable after receiving events.
+	pbt := stream2.PostBatchResumeToken()
+	if pbt == nil {
+		t.Error("PostBatchResumeToken must be non-nil after receiving events")
+	}
+}
+
+// TestChangeStreamResumeAfterOverflow verifies that resuming with an expired token
+// (ring buffer overflowed) returns ErrCodeChangeStreamHistoryLost (error 286).
+func TestChangeStreamResumeAfterOverflow(t *testing.T) {
+	const bufSize = 5
+	bus := storage.NewEventBus(bufSize)
+	engine := &csTestEngine{bus: bus}
+	col := &csTestCollection{name: "col"}
+
+	// Open a stream to register the namespace.
+	bootstrap := bus.NewChangeStreamCursor("db", "col", 0)
+	defer bootstrap.Close()
+
+	// Overflow the ring buffer by publishing bufSize+2 events.
+	for i := int32(1); i <= int32(bufSize+2); i++ {
+		publishInsert(bus, "db", "col", i)
+	}
+
+	// Try to resume from seq=1, which is now overwritten.
+	tok := storage.ResumeToken{TimestampNS: 1, Seq: 1}
+	encoded := storage.EncodeResumeToken(tok)
+
+	csOpts := bson.D{{
+		Key:   "resumeAfter",
+		Value: bson.D{{Key: "_data", Value: encoded}},
+	}}
+	stageRaw, _ := bson.Marshal(bson.D{{Key: "$changeStream", Value: csOpts}})
+	cursor, err := Execute(col, engine, "db", []bson.Raw{stageRaw}, PipelineOptions{})
+	if err != nil {
+		t.Fatalf("Execute($changeStream with stale token): %v", err)
+	}
+	defer cursor.Close()
+
+	// NextBatch should return ErrBufOverflow / error 286.
+	_, _, err = cursor.NextBatch(100)
+	if err == nil {
+		t.Fatal("expected error for overflowed resume token, got nil")
+	}
+	me, ok := err.(*storage.MongoError)
+	if !ok {
+		t.Fatalf("expected *storage.MongoError, got %T: %v", err, err)
+	}
+	if me.Code != storage.ErrCodeChangeStreamHistoryLost {
+		t.Errorf("error code = %d, want %d (ChangeStreamHistoryLost)", me.Code, storage.ErrCodeChangeStreamHistoryLost)
+	}
+}

--- a/tests/change_stream_test.go
+++ b/tests/change_stream_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// TestChangeStreamResumeToken verifies the full resume-token lifecycle:
+//  1. Open a watch on a collection.
+//  2. Insert 3 documents and consume the first 2 events.
+//  3. Save the resume token from the 2nd event, then close the cursor (disconnect).
+//  4. Insert 2 more documents while disconnected.
+//  5. Reconnect using the saved resume token.
+//  6. Verify that events 3, 4, 5 are received — no events missed.
+func TestChangeStreamResumeToken(t *testing.T) {
+	client := newClient(t)
+	db := client.Database(testDB(t))
+	coll := db.Collection("orders")
+	ctx := context.Background()
+
+	// Open a change stream before any inserts so we catch all events.
+	cs, err := coll.Watch(ctx, bson.A{})
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	// Insert 3 documents asynchronously to avoid a deadlock where getMore
+	// blocks waiting for events while insertions haven't happened yet.
+	insertErrc := make(chan error, 1)
+	go func() {
+		time.Sleep(20 * time.Millisecond) // let watch initialise
+		for i := 1; i <= 3; i++ {
+			if _, err := coll.InsertOne(ctx, bson.D{{Key: "_id", Value: int32(i)}}); err != nil {
+				insertErrc <- err
+				return
+			}
+		}
+		close(insertErrc)
+	}()
+
+	// Consume the first 2 events, saving the resume token after the 2nd.
+	var resumeToken bson.Raw
+	for i := 0; i < 2; i++ {
+		tCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		if !cs.Next(tCtx) {
+			cancel()
+			if err := cs.Err(); err != nil {
+				t.Fatalf("cs.Next event %d: %v", i+1, err)
+			}
+			t.Fatalf("cs.Next event %d: returned false with no error (timeout?)", i+1)
+		}
+		cancel()
+		resumeToken = cs.ResumeToken()
+	}
+
+	if err := <-insertErrc; err != nil {
+		t.Fatalf("background inserts: %v", err)
+	}
+	if resumeToken == nil {
+		t.Fatal("expected non-nil resume token after 2 events")
+	}
+
+	// Close the stream — simulates a client disconnect.
+	if err := cs.Close(ctx); err != nil {
+		t.Fatalf("cs.Close: %v", err)
+	}
+
+	// Insert 2 more documents while "disconnected".
+	for i := 4; i <= 5; i++ {
+		if _, err := coll.InsertOne(ctx, bson.D{{Key: "_id", Value: int32(i)}}); err != nil {
+			t.Fatalf("InsertOne(%d): %v", i, err)
+		}
+	}
+
+	// Reconnect using the saved resume token.
+	cs2, err := coll.Watch(ctx, bson.A{}, options.ChangeStream().SetResumeAfter(resumeToken))
+	if err != nil {
+		t.Fatalf("Watch (resume): %v", err)
+	}
+	defer cs2.Close(ctx)
+
+	// Expect exactly 3 events: doc 3 (missed during disconnect) + docs 4, 5.
+	wantIDs := []int32{3, 4, 5}
+	for i, wantID := range wantIDs {
+		tCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		if !cs2.Next(tCtx) {
+			cancel()
+			if err := cs2.Err(); err != nil {
+				t.Fatalf("cs2.Next event %d: %v", i+1, err)
+			}
+			t.Fatalf("cs2.Next event %d: returned false with no error (timeout?)", i+1)
+		}
+		cancel()
+
+		var event struct {
+			DocumentKey bson.D `bson:"documentKey"`
+		}
+		if err := cs2.Decode(&event); err != nil {
+			t.Fatalf("Decode event %d: %v", i+1, err)
+		}
+
+		var gotID int32
+		for _, e := range event.DocumentKey {
+			if e.Key == "_id" {
+				if v, ok := e.Value.(int32); ok {
+					gotID = v
+				}
+			}
+		}
+		if gotID != wantID {
+			t.Errorf("event %d: got _id %d, want %d", i+1, gotID, wantID)
+		}
+	}
+}
+
+// TestChangeStreamNoResumeTokenOnFreshWatch verifies that a fresh watch (no
+// resumeAfter) only receives events published after it was opened.
+func TestChangeStreamNoResumeTokenOnFreshWatch(t *testing.T) {
+	client := newClient(t)
+	db := client.Database(testDB(t))
+	coll := db.Collection("fresh")
+	ctx := context.Background()
+
+	// Insert a document before the watch is opened — should NOT be received.
+	if _, err := coll.InsertOne(ctx, bson.D{{Key: "_id", Value: int32(0)}}); err != nil {
+		t.Fatalf("pre-watch insert: %v", err)
+	}
+
+	cs, err := coll.Watch(ctx, bson.A{})
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	defer cs.Close(ctx)
+
+	// Insert one document after the watch.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_, _ = coll.InsertOne(ctx, bson.D{{Key: "_id", Value: int32(1)}})
+	}()
+
+	tCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if !cs.Next(tCtx) {
+		t.Fatalf("cs.Next: %v", cs.Err())
+	}
+
+	var event struct {
+		DocumentKey bson.D `bson:"documentKey"`
+	}
+	if err := cs.Decode(&event); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	var gotID int32
+	for _, e := range event.DocumentKey {
+		if e.Key == "_id" {
+			if v, ok := e.Value.(int32); ok {
+				gotID = v
+			}
+		}
+	}
+	if gotID != 1 {
+		t.Errorf("expected _id=1 (post-watch insert), got %d", gotID)
+	}
+}


### PR DESCRIPTION
Closes #129

## What
- Added unit tests in `internal/aggregation/change_stream_test.go` covering:
  - `parseResumeAfterSeq`: decodes a valid token, handles missing/nil/invalid-base64 cases
  - `TestChangeStreamPipelineReturnsTailableCursor`: verifies the `$changeStream` aggregate stage returns a `TailableCursor` and that each event contains the required `_id` resume token field
  - `TestChangeStreamResumeAfterPipeline`: end-to-end disconnect/reconnect scenario — open a stream, consume 2 of 3 events, save the resume token, close the cursor (disconnect), publish 2 more events, reconnect with the token, verify events 3+4+5 arrive with no gaps
  - `TestChangeStreamResumeAfterOverflow`: stale token beyond the ring buffer returns error 286 (`ChangeStreamHistoryLost`)
- Added integration tests in `tests/change_stream_test.go` (build tag: `integration`) using the MongoDB Go driver, covering the full `Watch` + `SetResumeAfter` flow end-to-end against a live server

## Why
Issue #129 required proof that the resume-token implementation (storage ring buffer, `parseResumeAfterSeq`, `$changeStream` pipeline stage) correctly handles the disconnect/reconnect pattern with no missed events, and that overflow is surfaced as the correct MongoDB error code.

```yaml
agent:
  id: founder-agent-s1
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#129"]
```

*Posted by the founder agent on behalf of @inder*