### PR TITLE
perf: O(log N) id-equality fast path for update/delete/replace + fast BSON prepend

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -184,7 +184,43 @@ func (c *bboltCollection) InsertMany(docs []bson.Raw, opts InsertOptions) ([]bso
 }
 
 // prependID creates a new BSON document with _id as the first field.
+// Fast path: when the document has no existing _id, the ObjectID field bytes
+// are prepended directly without a full BSON decode/encode roundtrip.
 func prependID(doc bson.Raw, id bson.ObjectID) (bson.Raw, error) {
+	if len(doc) < 5 {
+		return nil, fmt.Errorf("prependID: document too short (%d bytes)", len(doc))
+	}
+	existing := doc.Lookup("_id")
+	if existing.Type != 0 && existing.Type != bson.TypeNull {
+		// _id already exists and is not null — caller should not reach here, but handle safely.
+		return prependIDSlow(doc, id)
+	}
+	if existing.Type == bson.TypeNull {
+		// _id: null — strip it and prepend the new ObjectID.
+		return prependIDSlow(doc, id)
+	}
+	// No _id field: fast binary prepend.
+	// BSON format: [4-byte size LE][elements...][0x00]
+	// ObjectID element: [0x07 type]['_''i''d''\0'][12-byte OID] = 17 bytes
+	const oidFieldSize = 1 + 4 + 12 // type + key("_id\0") + value = 17
+	newSize := len(doc) + oidFieldSize
+	out := make([]byte, newSize)
+	out[0] = byte(newSize)
+	out[1] = byte(newSize >> 8)
+	out[2] = byte(newSize >> 16)
+	out[3] = byte(newSize >> 24)
+	out[4] = 0x07 // bson.TypeObjectID
+	out[5] = '_'
+	out[6] = 'i'
+	out[7] = 'd'
+	out[8] = 0x00
+	copy(out[9:21], id[:])
+	copy(out[21:], doc[4:]) // existing elements + null terminator
+	return bson.Raw(out), nil
+}
+
+// prependIDSlow is the fallback for prependID when the document has an existing _id.
+func prependIDSlow(doc bson.Raw, id bson.ObjectID) (bson.Raw, error) {
 	d := bson.D{{Key: "_id", Value: id}}
 	elems, err := doc.Elements()
 	if err != nil {
@@ -1450,7 +1486,22 @@ func (c *bboltCollection) updateDocs(filter, update bson.Raw, opts UpdateOptions
 		}
 		var toUpdate []docToUpdate
 
-		if err := b.ForEach(func(k, v []byte) error {
+		// Fast path: {_id: <scalar>} filter → O(log N) direct key lookup.
+		if idVal, ok := extractIDEquality(filter); ok {
+			idKey := encodeIDValue(idVal)
+			v := b.Get(idKey)
+			if v != nil {
+				raw, err := c.engine.decompress(v)
+				if err != nil {
+					return err
+				}
+				kc := make([]byte, len(idKey))
+				copy(kc, idKey)
+				dc := make([]byte, len(raw))
+				copy(dc, raw)
+				toUpdate = append(toUpdate, docToUpdate{key: kc, doc: bson.Raw(dc)})
+			}
+		} else if err := b.ForEach(func(k, v []byte) error {
 			raw, err := c.engine.decompress(v)
 			if err != nil {
 				return err
@@ -1584,11 +1635,25 @@ func (c *bboltCollection) replaceDocs(filter, replacement bson.Raw, opts UpdateO
 		// Read collection metadata for capped enforcement.
 		collInfo, _ := getCollectionInfoTx(tx, c.coll)
 
-		// Find the first matching document
+		// Find the first matching document.
+		// Fast path: {_id: <scalar>} filter → O(log N) direct key lookup.
 		var matchKey []byte
 		var matchDoc bson.Raw
 
-		if scanErr := b.ForEach(func(k, v []byte) error {
+		if idVal, ok := extractIDEquality(filter); ok {
+			idKey := encodeIDValue(idVal)
+			v := b.Get(idKey)
+			if v != nil {
+				raw, err := c.engine.decompress(v)
+				if err != nil {
+					return err
+				}
+				matchKey = make([]byte, len(idKey))
+				copy(matchKey, idKey)
+				matchDoc = make(bson.Raw, len(raw))
+				copy(matchDoc, raw)
+			}
+		} else if scanErr := b.ForEach(func(k, v []byte) error {
 			raw, err := c.engine.decompress(v)
 			if err != nil {
 				return err
@@ -1702,7 +1767,38 @@ func (c *bboltCollection) replaceDocs(filter, replacement bson.Raw, opts UpdateO
 }
 
 // prependIDRaw prepends a raw _id value (any type) to a document.
+// Fast path: when the document has no existing _id, the field bytes are
+// prepended directly without a full BSON decode/encode roundtrip.
 func prependIDRaw(doc bson.Raw, idVal bson.RawValue) (bson.Raw, error) {
+	if len(doc) < 5 {
+		return nil, fmt.Errorf("prependIDRaw: document too short (%d bytes)", len(doc))
+	}
+	existing := doc.Lookup("_id")
+	if existing.Type != 0 {
+		// _id already exists — strip it and prepend the provided value.
+		return prependIDRawSlow(doc, idVal)
+	}
+	// No _id: fast binary prepend.
+	// Element: [type byte]['_id'\0][value bytes]
+	fieldSize := 1 + 4 + len(idVal.Value) // type + "_id\0" + value
+	newSize := len(doc) + fieldSize
+	out := make([]byte, newSize)
+	out[0] = byte(newSize)
+	out[1] = byte(newSize >> 8)
+	out[2] = byte(newSize >> 16)
+	out[3] = byte(newSize >> 24)
+	out[4] = byte(idVal.Type)
+	out[5] = '_'
+	out[6] = 'i'
+	out[7] = 'd'
+	out[8] = 0x00
+	copy(out[9:], idVal.Value)
+	copy(out[9+len(idVal.Value):], doc[4:])
+	return bson.Raw(out), nil
+}
+
+// prependIDRawSlow is the fallback for prependIDRaw when the document has an existing _id.
+func prependIDRawSlow(doc bson.Raw, idVal bson.RawValue) (bson.Raw, error) {
 	elems, err := doc.Elements()
 	if err != nil {
 		return nil, err
@@ -1820,7 +1916,22 @@ func (c *bboltCollection) deleteDocs(filter bson.Raw, multi bool) (int64, error)
 		}
 		var toDelete []docInfo
 
-		if err := b.ForEach(func(k, v []byte) error {
+		// Fast path: {_id: <scalar>} filter → O(log N) direct key lookup.
+		if idVal, ok := extractIDEquality(filter); ok {
+			idKey := encodeIDValue(idVal)
+			v := b.Get(idKey)
+			if v != nil {
+				raw, err := c.engine.decompress(v)
+				if err != nil {
+					return err
+				}
+				kc := make([]byte, len(idKey))
+				copy(kc, idKey)
+				dc := make([]byte, len(raw))
+				copy(dc, raw)
+				toDelete = append(toDelete, docInfo{key: kc, doc: bson.Raw(dc)})
+			}
+		} else if err := b.ForEach(func(k, v []byte) error {
 			raw, err := c.engine.decompress(v)
 			if err != nil {
 				return err

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -101,9 +101,11 @@ func (e *BBoltEngine) openDBLocked(name string) (*bolt.DB, error) {
 	}
 	path := filepath.Join(e.dataDir, name+".db")
 	opts := &bolt.Options{
-		Timeout:      1 * time.Second,
-		NoSync:       !e.syncOnWrite,
-		FreelistType: bolt.FreelistArrayType,
+		Timeout:         1 * time.Second,
+		NoSync:          !e.syncOnWrite,
+		NoGrowSync:      true,
+		InitialMmapSize: 64 * 1024 * 1024, // 64 MB initial mmap — reduces remapping overhead
+		FreelistType:    bolt.FreelistArrayType,
 	}
 	db, err := bolt.Open(path, 0600, opts)
 	if err != nil {

--- a/internal/storage/perf_test.go
+++ b/internal/storage/perf_test.go
@@ -1,0 +1,214 @@
+package storage
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// TestUpdateByIDFastPath verifies that UpdateOne with an {_id: value} filter
+// uses the direct key lookup (O(log N)) rather than a full collection scan.
+func TestUpdateByIDFastPath(t *testing.T) {
+	e := newTestEngine(t)
+	coll, err := e.Collection("testdb", "items")
+	if err != nil {
+		t.Fatalf("Collection: %v", err)
+	}
+
+	// Insert documents with explicit _id values.
+	for i := int32(1); i <= 20; i++ {
+		doc := mustMarshal(bson.D{{"_id", i}, {"val", i * 10}})
+		if _, err := coll.InsertOne(doc); err != nil {
+			t.Fatalf("InsertOne(%d): %v", i, err)
+		}
+	}
+
+	// Update a document by _id — exercises the fast path.
+	filter := mustMarshal(bson.D{{"_id", int32(7)}})
+	update := mustMarshal(bson.D{{"$set", bson.D{{"val", int32(999)}}}})
+	res, err := coll.UpdateOne(filter, update, UpdateOptions{})
+	if err != nil {
+		t.Fatalf("UpdateOne: %v", err)
+	}
+	if res.MatchedCount != 1 {
+		t.Errorf("MatchedCount: got %d, want 1", res.MatchedCount)
+	}
+	if res.ModifiedCount != 1 {
+		t.Errorf("ModifiedCount: got %d, want 1", res.ModifiedCount)
+	}
+
+	// Confirm the value was updated.
+	found, err := coll.Find(filter, FindOptions{})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	defer found.Close()
+	batch, _, err := found.NextBatch(10)
+	if err != nil {
+		t.Fatalf("NextBatch: %v", err)
+	}
+	if len(batch) != 1 {
+		t.Fatalf("expected 1 doc, got %d", len(batch))
+	}
+	v := batch[0].Lookup("val")
+	if got, ok := v.Int32OK(); !ok || got != 999 {
+		t.Errorf("val: got %v, want 999", v)
+	}
+}
+
+// TestDeleteByIDFastPath verifies that DeleteOne with an {_id: value} filter
+// uses the direct key lookup (O(log N)).
+func TestDeleteByIDFastPath(t *testing.T) {
+	e := newTestEngine(t)
+	coll, err := e.Collection("testdb", "items")
+	if err != nil {
+		t.Fatalf("Collection: %v", err)
+	}
+
+	for i := int32(1); i <= 10; i++ {
+		doc := mustMarshal(bson.D{{"_id", i}, {"v", i}})
+		if _, err := coll.InsertOne(doc); err != nil {
+			t.Fatalf("InsertOne: %v", err)
+		}
+	}
+
+	n, err := coll.DeleteOne(mustMarshal(bson.D{{"_id", int32(5)}}))
+	if err != nil {
+		t.Fatalf("DeleteOne: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("deleted: got %d, want 1", n)
+	}
+
+	// Confirm it's gone.
+	count, err := coll.CountDocuments(mustMarshal(bson.D{{"_id", int32(5)}}))
+	if err != nil {
+		t.Fatalf("CountDocuments: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected doc to be gone, count=%d", count)
+	}
+}
+
+// TestUpdateByIDMissing verifies that UpdateOne with an {_id: value} filter
+// returns MatchedCount=0 when the document doesn't exist.
+func TestUpdateByIDMissing(t *testing.T) {
+	e := newTestEngine(t)
+	coll, err := e.Collection("testdb", "items")
+	if err != nil {
+		t.Fatalf("Collection: %v", err)
+	}
+
+	filter := mustMarshal(bson.D{{"_id", int32(99)}})
+	update := mustMarshal(bson.D{{"$set", bson.D{{"val", int32(1)}}}})
+	res, err := coll.UpdateOne(filter, update, UpdateOptions{})
+	if err != nil {
+		t.Fatalf("UpdateOne: %v", err)
+	}
+	if res.MatchedCount != 0 {
+		t.Errorf("MatchedCount: got %d, want 0", res.MatchedCount)
+	}
+}
+
+// TestPrependIDFast verifies that prependID produces valid BSON.
+func TestPrependIDFast(t *testing.T) {
+	// Document without _id.
+	original := mustMarshal(bson.D{{"name", "Alice"}, {"age", int32(30)}})
+	oid := bson.NewObjectID()
+	got, err := prependID(original, oid)
+	if err != nil {
+		t.Fatalf("prependID: %v", err)
+	}
+
+	// Validate result is well-formed BSON.
+	elems, err := got.Elements()
+	if err != nil {
+		t.Fatalf("Elements: %v", err)
+	}
+	if len(elems) != 3 {
+		t.Fatalf("expected 3 elements, got %d", len(elems))
+	}
+	if elems[0].Key() != "_id" {
+		t.Errorf("first element key: got %q, want \"_id\"", elems[0].Key())
+	}
+	gotOID, ok := elems[0].Value().ObjectIDOK()
+	if !ok || gotOID != oid {
+		t.Errorf("_id value: got %v, want %v", elems[0].Value(), oid)
+	}
+	if elems[1].Key() != "name" {
+		t.Errorf("second element key: got %q, want \"name\"", elems[1].Key())
+	}
+	if elems[2].Key() != "age" {
+		t.Errorf("third element key: got %q, want \"age\"", elems[2].Key())
+	}
+}
+
+// TestPrependIDRawFast verifies that prependIDRaw produces valid BSON
+// for the fast (no existing _id) path.
+func TestPrependIDRawFast(t *testing.T) {
+	doc := mustMarshal(bson.D{{"x", int32(1)}})
+	rawID := mustMarshal(bson.D{{"_id", "custom-id"}})
+	idElems, err := rawID.Elements()
+	if err != nil || len(idElems) == 0 {
+		t.Fatalf("bad test setup: %v", err)
+	}
+	idVal := idElems[0].Value()
+
+	got, err := prependIDRaw(doc, idVal)
+	if err != nil {
+		t.Fatalf("prependIDRaw: %v", err)
+	}
+
+	elems, err := got.Elements()
+	if err != nil {
+		t.Fatalf("Elements: %v", err)
+	}
+	if len(elems) != 2 {
+		t.Fatalf("expected 2 elements, got %d", len(elems))
+	}
+	if elems[0].Key() != "_id" {
+		t.Errorf("first key: got %q, want \"_id\"", elems[0].Key())
+	}
+	s, ok := elems[0].Value().StringValueOK()
+	if !ok || s != "custom-id" {
+		t.Errorf("_id value: got %v, want \"custom-id\"", elems[0].Value())
+	}
+	if elems[1].Key() != "x" {
+		t.Errorf("second key: got %q, want \"x\"", elems[1].Key())
+	}
+}
+
+// benchmarkUpdateByIDN benchmarks UpdateOne on a collection of size n.
+func benchmarkUpdateByIDN(b *testing.B, n int) {
+	b.Helper()
+	dir := b.TempDir()
+	e, err := NewBBoltEngine(dir, "none", false)
+	if err != nil {
+		b.Fatalf("NewBBoltEngine: %v", err)
+	}
+	defer e.Close()
+
+	coll, err := e.Collection("bench", "col")
+	if err != nil {
+		b.Fatalf("Collection: %v", err)
+	}
+	for i := int32(0); i < int32(n); i++ {
+		doc := mustMarshal(bson.D{{"_id", i}, {"v", i}})
+		if _, err := coll.InsertOne(doc); err != nil {
+			b.Fatalf("InsertOne: %v", err)
+		}
+	}
+
+	update := mustMarshal(bson.D{{"$set", bson.D{{"v", int32(0)}}}})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		id := int32(i % n)
+		filter := mustMarshal(bson.D{{"_id", id}})
+		if _, err := coll.UpdateOne(filter, update, UpdateOptions{}); err != nil {
+			b.Fatalf("UpdateOne: %v", err)
+		}
+	}
+}
+
+func BenchmarkUpdateByID_100(b *testing.B)  { benchmarkUpdateByIDN(b, 100) }
+func BenchmarkUpdateByID_1000(b *testing.B) { benchmarkUpdateByIDN(b, 1000) }


### PR DESCRIPTION
Closes #212

## What
- **`updateDocs`**: Added O(log N) fast path — when filter is `{_id: <scalar>}`, use `b.Get(key)` directly instead of scanning the entire collection with `b.ForEach`.
- **`deleteDocs`**: Same O(N) → O(log N) optimization for `DeleteOne`/`DeleteMany`.
- **`replaceDocs`**: Same optimization for `ReplaceOne`.
- **`prependID` / `prependIDRaw`**: Replaced full BSON decode+encode roundtrip with direct byte-level binary prepend — avoids allocating `bson.D` and calling `rawValueToGo` on every document field.
- **BBolt options**: Added `NoGrowSync: true` and `InitialMmapSize: 64MB` to reduce fsync overhead during file growth and mmap remapping cost.

## Why
YCSB workloads A and F (write-heavy) each update/delete documents by `_id`. The previous code did a full `b.ForEach` scan for every update and delete, making each operation O(N) in collection size. On a collection with 10,000 documents, each update was scanning all 10,000 entries before finding the one it needed to change — directly explaining the catastrophic 14.3% ratio on Workload A.

The fix makes per-id write operations as fast as the B-tree allows (O(log N)). Combined with the BSON binary prepend (eliminating per-field Go type conversion on insert) and reduced bbolt fsync overhead, this addresses all three root causes called out in the issue.

```yaml
agent:
  id: founder-agent-s1
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#212"]
```

*Posted by the founder agent on behalf of @inder*