### PR TITLE
fix(storage): publish change events for inserts with non-ObjectID _id

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -93,8 +93,9 @@ func (c *bboltCollection) InsertMany(docs []bson.Raw, opts InsertOptions) ([]bso
 
 	// Step 1: Prepare all documents outside the transaction (CPU work, no lock needed).
 	type docResult struct {
-		prep preparedInsert
-		err  error
+		prep      preparedInsert
+		err       error
+		succeeded bool // true if the document was committed successfully
 	}
 	results := make([]docResult, len(docs))
 	for i, rawDoc := range docs {
@@ -154,6 +155,7 @@ func (c *bboltCollection) InsertMany(docs []bson.Raw, opts InsertOptions) ([]bso
 			if idxErr := c.engine.insertIntoIndexes(tx, c.db, c.coll, r.prep.key, r.prep.finalDoc); idxErr != nil {
 				return idxErr
 			}
+			results[i].succeeded = true
 			ids = append(ids, r.prep.id)
 			successCount++
 		}
@@ -167,8 +169,8 @@ func (c *bboltCollection) InsertMany(docs []bson.Raw, opts InsertOptions) ([]bso
 
 	// Publish ChangeInsert events for each successfully inserted document.
 	if c.engine.eventBus.HasStream(c.db, c.coll) {
-		for i, id := range ids {
-			if id == (bson.ObjectID{}) {
+		for i := range results {
+			if !results[i].succeeded {
 				continue // insert failed (dup key or prep error)
 			}
 			doc := results[i].prep.finalDoc


### PR DESCRIPTION
Closes #218

## What
`InsertMany` used `bson.ObjectID{}` (the zero value) as a sentinel for failed inserts in the change-event publishing loop. Documents inserted with a non-ObjectID `_id` (e.g. `int32`, `string`) legitimately produced a zero ObjectID in the tracking slice, causing change events to be silently skipped. The `TestChangeStreamNoResumeTokenOnFreshWatch` integration test inserts `{_id: 1}` (int32) and expects a change event — it never arrived, causing a 5-second timeout.

## Why
Change streams must fire for ALL successful inserts, regardless of `_id` type. The regression was latent since the event bus landed; it only became observable once integration tests were added.

**Root cause:** `results[i].prep.id` is zero for any non-ObjectID `_id`, and the publishing guard `if id == (bson.ObjectID{}) { continue }` was designed only to skip _failed_ inserts. It incorrectly skipped _successful_ inserts with non-ObjectID `_id` as well.

**Fix:** Added `succeeded bool` to the local `docResult` struct. The field is set to `true` only after the bbolt `Put` commits. Event publishing now tests `results[i].succeeded` instead of comparing against the zero ObjectID.

```yaml
agent:
  id: founder-agent-s1
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#218"]
```

*Posted by the founder agent on behalf of @inder*