### PR TITLE
fix(storage): publish change-stream events for non-ObjectID _id inserts

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -93,8 +93,9 @@ func (c *bboltCollection) InsertMany(docs []bson.Raw, opts InsertOptions) ([]bso
 
 	// Step 1: Prepare all documents outside the transaction (CPU work, no lock needed).
 	type docResult struct {
-		prep preparedInsert
-		err  error
+		prep     preparedInsert
+		err      error
+		inserted bool // set to true inside the transaction when the insert commits
 	}
 	results := make([]docResult, len(docs))
 	for i, rawDoc := range docs {
@@ -154,6 +155,7 @@ func (c *bboltCollection) InsertMany(docs []bson.Raw, opts InsertOptions) ([]bso
 			if idxErr := c.engine.insertIntoIndexes(tx, c.db, c.coll, r.prep.key, r.prep.finalDoc); idxErr != nil {
 				return idxErr
 			}
+			results[i].inserted = true
 			ids = append(ids, r.prep.id)
 			successCount++
 		}
@@ -166,10 +168,12 @@ func (c *bboltCollection) InsertMany(docs []bson.Raw, opts InsertOptions) ([]bso
 	c.engine.opInsert.Add(successCount)
 
 	// Publish ChangeInsert events for each successfully inserted document.
+	// results[i].inserted is used (not the ObjectID) so that documents with
+	// non-ObjectID _id values (e.g. int32, string) are correctly published.
 	if c.engine.eventBus.HasStream(c.db, c.coll) {
-		for i, id := range ids {
-			if id == (bson.ObjectID{}) {
-				continue // insert failed (dup key or prep error)
+		for i := range results {
+			if !results[i].inserted {
+				continue
 			}
 			doc := results[i].prep.finalDoc
 			c.engine.eventBus.Publish(c.db, c.coll, ChangeEvent{


### PR DESCRIPTION
Closes #217

## What
Fixed `InsertMany` in `internal/storage/collection.go` to correctly publish `ChangeInsert` events to the change-stream event bus for documents whose `_id` is a non-ObjectID type (e.g. `int32`, `string`, `int64`).

**Root cause:** `preparedInsert.id` (a `bson.ObjectID`) is only populated when the document's `_id` is an ObjectID. For any other `_id` type the field stays at its zero value (`bson.ObjectID{}`). The event-publish loop used `id == (bson.ObjectID{})` to detect failed inserts, so all successful inserts with non-ObjectID keys were silently skipped — no change-stream event was ever emitted.

**Fix:** Added an `inserted bool` field to the local `docResult` struct. It is set to `true` inside the bbolt transaction exactly when the document is successfully written. The event-publish loop now checks `results[i].inserted` instead of the zero-ObjectID sentinel.

## Why
`TestChangeStreamResumeToken` (and any change-stream watch on a collection receiving non-ObjectID `_id` documents) would never receive `insert` events, causing the change-stream cursor to time out after 10 s with no events.

```yaml
agent:
  id: founder-agent-s2
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#217"]
```

*Posted by the founder agent on behalf of @inder*