### PR TITLE
perf: O(log N) fast paths for findAndModify, update, delete, count (#265)

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -1503,6 +1503,24 @@ func (c *bboltCollection) updateDocs(filter, update bson.Raw, opts UpdateOptions
 				copy(dc, raw)
 				toUpdate = append(toUpdate, docToUpdate{key: kc, doc: bson.Raw(dc)})
 			}
+		} else if plan, planOK := c.chooseIndex(tx, filter); planOK {
+			// Secondary index scan within the write transaction.
+			so := scanOpts{}
+			if !multi {
+				so.limit = 1
+			}
+			idxDocs, scanErr := c.indexScanTx(tx, plan, filter, nil, so)
+			if scanErr != nil {
+				return scanErr
+			}
+			for _, doc := range idxDocs {
+				idKey := encodeIDValue(doc.Lookup("_id"))
+				kc := make([]byte, len(idKey))
+				copy(kc, idKey)
+				dc := make([]byte, len(doc))
+				copy(dc, doc)
+				toUpdate = append(toUpdate, docToUpdate{kc, dc})
+			}
 		} else if err := b.ForEach(func(k, v []byte) error {
 			raw, err := c.engine.decompress(v)
 			if err != nil {
@@ -1654,6 +1672,20 @@ func (c *bboltCollection) replaceDocs(filter, replacement bson.Raw, opts UpdateO
 				copy(matchKey, idKey)
 				matchDoc = make(bson.Raw, len(raw))
 				copy(matchDoc, raw)
+			}
+		} else if plan, planOK := c.chooseIndex(tx, filter); planOK {
+			// Secondary index scan within the write transaction.
+			idxDocs, scanErr := c.indexScanTx(tx, plan, filter, nil, scanOpts{limit: 1})
+			if scanErr != nil {
+				return scanErr
+			}
+			if len(idxDocs) > 0 {
+				doc := idxDocs[0]
+				idKey := encodeIDValue(doc.Lookup("_id"))
+				matchKey = make([]byte, len(idKey))
+				copy(matchKey, idKey)
+				matchDoc = make(bson.Raw, len(doc))
+				copy(matchDoc, doc)
 			}
 		} else if scanErr := b.ForEach(func(k, v []byte) error {
 			raw, err := c.engine.decompress(v)
@@ -1933,6 +1965,24 @@ func (c *bboltCollection) deleteDocs(filter bson.Raw, multi bool) (int64, error)
 				copy(dc, raw)
 				toDelete = append(toDelete, docInfo{key: kc, doc: bson.Raw(dc)})
 			}
+		} else if plan, planOK := c.chooseIndex(tx, filter); planOK {
+			// Secondary index scan within the write transaction.
+			so := scanOpts{}
+			if !multi {
+				so.limit = 1
+			}
+			idxDocs, scanErr := c.indexScanTx(tx, plan, filter, nil, so)
+			if scanErr != nil {
+				return scanErr
+			}
+			for _, doc := range idxDocs {
+				idKey := encodeIDValue(doc.Lookup("_id"))
+				kc := make([]byte, len(idKey))
+				copy(kc, idKey)
+				dc := make([]byte, len(doc))
+				copy(dc, doc)
+				toDelete = append(toDelete, docInfo{kc, dc})
+			}
 		} else if err := b.ForEach(func(k, v []byte) error {
 			raw, err := c.engine.decompress(v)
 			if err != nil {
@@ -2000,7 +2050,7 @@ func (c *bboltCollection) CountDocuments(filter bson.Raw) (int64, error) {
 		return 0, nil
 	}
 
-	// Optimize for empty filter
+	// Fast path 1: empty filter — derive count from bucket statistics (O(1)).
 	if len(filter) == 0 {
 		var n int64
 		_ = boltDB.View(func(tx *bolt.Tx) error {
@@ -2013,30 +2063,29 @@ func (c *bboltCollection) CountDocuments(filter bson.Raw) (int64, error) {
 		return n, nil
 	}
 
-	var count int64
-	if err := boltDB.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket([]byte(collBucket(c.coll)))
-		if b == nil {
-			return nil
-		}
-		return b.ForEach(func(k, v []byte) error {
-			raw, err := c.engine.decompress(v)
-			if err != nil {
-				return err
-			}
-			match, err := query.Filter(bson.Raw(raw), filter)
-			if err != nil {
-				return err
-			}
-			if match {
-				count++
+	// Fast path 2: {_id: <scalar>} equality — O(log N) direct key lookup.
+	if idVal, ok := extractIDEquality(filter); ok {
+		key := encodeIDValue(idVal)
+		var found bool
+		_ = boltDB.View(func(tx *bolt.Tx) error {
+			b := tx.Bucket([]byte(collBucket(c.coll)))
+			if b != nil && b.Get(key) != nil {
+				found = true
 			}
 			return nil
 		})
-	}); err != nil {
+		if found {
+			return 1, nil
+		}
+		return 0, nil
+	}
+
+	// General case: use scanFilter which leverages secondary indexes when available.
+	docs, err := c.scanFilter(filter, nil, scanOpts{})
+	if err != nil {
 		return 0, err
 	}
-	return count, nil
+	return int64(len(docs)), nil
 }
 
 // Distinct returns the unique values of field across all documents matching
@@ -2172,28 +2221,65 @@ func (c *bboltCollection) findAndModify(
 		}
 		var candidates []docInfo
 
-		scanErr := b.ForEach(func(k, v []byte) error {
-			raw, decompErr := c.engine.decompress(v)
-			if decompErr != nil {
-				return decompErr
+		if idVal, ok := extractIDEquality(filter); ok {
+			// Fast path 1: O(log N) direct _id key lookup.
+			idKey := encodeIDValue(idVal)
+			v := b.Get(idKey)
+			if v != nil {
+				raw, decompErr := c.engine.decompress(v)
+				if decompErr != nil {
+					return decompErr
+				}
+				kc := make([]byte, len(idKey))
+				copy(kc, idKey)
+				dc := make([]byte, len(raw))
+				copy(dc, raw)
+				candidates = append(candidates, docInfo{kc, bson.Raw(dc)})
 			}
-			doc := bson.Raw(raw)
-			match, filterErr := query.Filter(doc, filter)
-			if filterErr != nil {
-				return filterErr
+		} else if plan, planOK := c.chooseIndex(tx, filter); planOK {
+			// Fast path 2: secondary index scan within the write transaction.
+			so := scanOpts{}
+			if len(opts.Sort) == 0 {
+				// Without sort, only the first match is needed.
+				so.limit = 1
 			}
-			if !match {
+			idxDocs, idxErr := c.indexScanTx(tx, plan, filter, nil, so)
+			if idxErr != nil {
+				return idxErr
+			}
+			for _, doc := range idxDocs {
+				idKey := encodeIDValue(doc.Lookup("_id"))
+				kc := make([]byte, len(idKey))
+				copy(kc, idKey)
+				dc := make([]byte, len(doc))
+				copy(dc, doc)
+				candidates = append(candidates, docInfo{kc, dc})
+			}
+		} else {
+			// Fallback: full collection scan.
+			scanErr := b.ForEach(func(k, v []byte) error {
+				raw, decompErr := c.engine.decompress(v)
+				if decompErr != nil {
+					return decompErr
+				}
+				doc := bson.Raw(raw)
+				match, filterErr := query.Filter(doc, filter)
+				if filterErr != nil {
+					return filterErr
+				}
+				if !match {
+					return nil
+				}
+				kc := make([]byte, len(k))
+				copy(kc, k)
+				dc := make([]byte, len(doc))
+				copy(dc, doc)
+				candidates = append(candidates, docInfo{kc, bson.Raw(dc)})
 				return nil
+			})
+			if scanErr != nil {
+				return scanErr
 			}
-			kc := make([]byte, len(k))
-			copy(kc, k)
-			dc := make([]byte, len(doc))
-			copy(dc, doc)
-			candidates = append(candidates, docInfo{kc, bson.Raw(dc)})
-			return nil
-		})
-		if scanErr != nil {
-			return scanErr
 		}
 
 		// Apply sort if specified

--- a/internal/storage/fastpath_test.go
+++ b/internal/storage/fastpath_test.go
@@ -1,0 +1,280 @@
+package storage
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// TestFindAndModifyByIDFastPath verifies that findAndModify with an {_id: <val>}
+// filter uses the direct key lookup (O(log N)) rather than a full collection scan.
+func TestFindAndModifyByIDFastPath(t *testing.T) {
+	e := newTestEngine(t)
+	coll, err := e.Collection("testdb", "fam")
+	if err != nil {
+		t.Fatalf("Collection: %v", err)
+	}
+
+	// Insert documents with explicit _id values.
+	for i := int32(1); i <= 20; i++ {
+		doc := mustMarshal(bson.D{{Key: "_id", Value: i}, {Key: "val", Value: i * 10}})
+		if _, err := coll.InsertOne(doc); err != nil {
+			t.Fatalf("InsertOne(%d): %v", i, err)
+		}
+	}
+
+	bc := coll.(*bboltCollection)
+
+	filter := mustMarshal(bson.D{{Key: "_id", Value: int32(7)}})
+	update := mustMarshal(bson.D{{Key: "$set", Value: bson.D{{Key: "val", Value: int32(777)}}}})
+
+	prev, err := bc.FindOneAndUpdate(filter, update, FindAndModifyOptions{ReturnNew: false})
+	if err != nil {
+		t.Fatalf("FindOneAndUpdate: %v", err)
+	}
+	if prev == nil {
+		t.Fatal("expected previous document, got nil")
+	}
+	v := prev.Lookup("val")
+	if got, ok := v.Int32OK(); !ok || got != 70 {
+		t.Errorf("previous val: got %v, want 70", v)
+	}
+
+	// Confirm the value was updated.
+	cur, err := coll.Find(filter, FindOptions{})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	defer cur.Close() //nolint:errcheck
+	batch, _, err := cur.NextBatch(10)
+	if err != nil {
+		t.Fatalf("NextBatch: %v", err)
+	}
+	if len(batch) != 1 {
+		t.Fatalf("expected 1 doc, got %d", len(batch))
+	}
+	if got, ok := batch[0].Lookup("val").Int32OK(); !ok || got != 777 {
+		t.Errorf("updated val: got %v, want 777", batch[0].Lookup("val"))
+	}
+}
+
+// TestFindAndModifyByIDMissing verifies that findAndModify returns nil when the
+// document does not exist.
+func TestFindAndModifyByIDMissing(t *testing.T) {
+	e := newTestEngine(t)
+	coll, err := e.Collection("testdb", "fam")
+	if err != nil {
+		t.Fatalf("Collection: %v", err)
+	}
+	bc := coll.(*bboltCollection)
+
+	filter := mustMarshal(bson.D{{Key: "_id", Value: int32(999)}})
+	update := mustMarshal(bson.D{{Key: "$set", Value: bson.D{{Key: "x", Value: int32(1)}}}})
+
+	doc, err := bc.FindOneAndUpdate(filter, update, FindAndModifyOptions{})
+	if err != nil {
+		t.Fatalf("FindOneAndUpdate: %v", err)
+	}
+	if doc != nil {
+		t.Errorf("expected nil for missing doc, got %v", doc)
+	}
+}
+
+// TestFindAndModifyIndexScan verifies that findAndModify uses a secondary index
+// when the filter matches an indexed field.
+func TestFindAndModifyIndexScan(t *testing.T) {
+	e := newTestEngine(t)
+
+	// Create index on "score" field.
+	keysRaw, _ := bson.Marshal(bson.D{{Key: "score", Value: int32(1)}})
+	_, err := e.CreateIndex("testdb", "scores", IndexSpec{Name: "score_1", Keys: keysRaw})
+	if err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+
+	coll, err := e.Collection("testdb", "scores")
+	if err != nil {
+		t.Fatalf("Collection: %v", err)
+	}
+
+	for i := int32(1); i <= 10; i++ {
+		doc := mustMarshal(bson.D{{Key: "_id", Value: i}, {Key: "score", Value: i * 5}})
+		if _, err := coll.InsertOne(doc); err != nil {
+			t.Fatalf("InsertOne: %v", err)
+		}
+	}
+
+	bc := coll.(*bboltCollection)
+
+	// Query by indexed field (not _id).
+	filter := mustMarshal(bson.D{{Key: "score", Value: int32(25)}}) // _id == 5
+	update := mustMarshal(bson.D{{Key: "$set", Value: bson.D{{Key: "score", Value: int32(999)}}}})
+
+	prev, err := bc.FindOneAndUpdate(filter, update, FindAndModifyOptions{ReturnNew: false})
+	if err != nil {
+		t.Fatalf("FindOneAndUpdate: %v", err)
+	}
+	if prev == nil {
+		t.Fatal("expected previous document, got nil")
+	}
+	if got, ok := prev.Lookup("score").Int32OK(); !ok || got != 25 {
+		t.Errorf("previous score: got %v, want 25", prev.Lookup("score"))
+	}
+
+	// Confirm the document was updated.
+	idFilter := mustMarshal(bson.D{{Key: "_id", Value: int32(5)}})
+	cur, err := coll.Find(idFilter, FindOptions{})
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	defer cur.Close() //nolint:errcheck
+	batch, _, err := cur.NextBatch(1)
+	if err != nil {
+		t.Fatalf("NextBatch: %v", err)
+	}
+	if len(batch) != 1 {
+		t.Fatalf("expected 1 doc, got %d", len(batch))
+	}
+	if got, ok := batch[0].Lookup("score").Int32OK(); !ok || got != 999 {
+		t.Errorf("updated score: got %v, want 999", batch[0].Lookup("score"))
+	}
+}
+
+// TestCountDocumentsByIDFastPath verifies that CountDocuments with an {_id: <val>}
+// filter uses the direct key lookup rather than a full scan.
+func TestCountDocumentsByIDFastPath(t *testing.T) {
+	e := newTestEngine(t)
+	coll, err := e.Collection("testdb", "cnt")
+	if err != nil {
+		t.Fatalf("Collection: %v", err)
+	}
+
+	for i := int32(1); i <= 10; i++ {
+		doc := mustMarshal(bson.D{{Key: "_id", Value: i}, {Key: "v", Value: i}})
+		if _, err := coll.InsertOne(doc); err != nil {
+			t.Fatalf("InsertOne: %v", err)
+		}
+	}
+
+	// Existing doc.
+	n, err := coll.CountDocuments(mustMarshal(bson.D{{Key: "_id", Value: int32(3)}}))
+	if err != nil {
+		t.Fatalf("CountDocuments: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("count for existing _id: got %d, want 1", n)
+	}
+
+	// Missing doc.
+	n, err = coll.CountDocuments(mustMarshal(bson.D{{Key: "_id", Value: int32(999)}}))
+	if err != nil {
+		t.Fatalf("CountDocuments: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("count for missing _id: got %d, want 0", n)
+	}
+}
+
+// TestUpdateByIndexScan verifies that updateDocs uses a secondary index when available.
+func TestUpdateByIndexScan(t *testing.T) {
+	e := newTestEngine(t)
+
+	keysRaw, _ := bson.Marshal(bson.D{{Key: "category", Value: int32(1)}})
+	_, err := e.CreateIndex("testdb", "products", IndexSpec{Name: "category_1", Keys: keysRaw})
+	if err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+
+	coll, err := e.Collection("testdb", "products")
+	if err != nil {
+		t.Fatalf("Collection: %v", err)
+	}
+
+	for i := int32(1); i <= 20; i++ {
+		cat := int32(i % 3) // categories 0, 1, 2
+		doc := mustMarshal(bson.D{
+			{Key: "_id", Value: i},
+			{Key: "category", Value: cat},
+			{Key: "price", Value: i * 100},
+		})
+		if _, err := coll.InsertOne(doc); err != nil {
+			t.Fatalf("InsertOne: %v", err)
+		}
+	}
+
+	// Update all docs in category 1 using the secondary index.
+	filter := mustMarshal(bson.D{{Key: "category", Value: int32(1)}})
+	update := mustMarshal(bson.D{{Key: "$set", Value: bson.D{{Key: "price", Value: int32(0)}}}})
+
+	res, err := coll.UpdateMany(filter, update, UpdateOptions{})
+	if err != nil {
+		t.Fatalf("UpdateMany: %v", err)
+	}
+	if res.MatchedCount == 0 {
+		t.Error("expected at least one match for category=1")
+	}
+	if res.ModifiedCount != res.MatchedCount {
+		t.Errorf("ModifiedCount (%d) != MatchedCount (%d)", res.ModifiedCount, res.MatchedCount)
+	}
+
+	// Confirm docs were updated.
+	cur, err := coll.Find(filter, FindOptions{})
+	if err != nil {
+		t.Fatalf("Find after update: %v", err)
+	}
+	defer cur.Close() //nolint:errcheck
+	batch, _, err := cur.NextBatch(100)
+	if err != nil {
+		t.Fatalf("NextBatch: %v", err)
+	}
+	for _, doc := range batch {
+		if got, ok := doc.Lookup("price").Int32OK(); !ok || got != 0 {
+			t.Errorf("expected price=0 after update, got %v", doc.Lookup("price"))
+		}
+	}
+}
+
+// TestDeleteByIndexScan verifies that deleteDocs uses a secondary index when available.
+func TestDeleteByIndexScan(t *testing.T) {
+	e := newTestEngine(t)
+
+	keysRaw, _ := bson.Marshal(bson.D{{Key: "status", Value: int32(1)}})
+	_, err := e.CreateIndex("testdb", "jobs", IndexSpec{Name: "status_1", Keys: keysRaw})
+	if err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+
+	coll, err := e.Collection("testdb", "jobs")
+	if err != nil {
+		t.Fatalf("Collection: %v", err)
+	}
+
+	for i := int32(1); i <= 10; i++ {
+		status := "active"
+		if i%2 == 0 {
+			status = "done"
+		}
+		doc := mustMarshal(bson.D{{Key: "_id", Value: i}, {Key: "status", Value: status}})
+		if _, err := coll.InsertOne(doc); err != nil {
+			t.Fatalf("InsertOne: %v", err)
+		}
+	}
+
+	// Delete docs with status="done" using the secondary index.
+	filter := mustMarshal(bson.D{{Key: "status", Value: "done"}})
+	n, err := coll.DeleteMany(filter)
+	if err != nil {
+		t.Fatalf("DeleteMany: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("deleted: got %d, want 5", n)
+	}
+
+	total, err := coll.CountDocuments(nil)
+	if err != nil {
+		t.Fatalf("CountDocuments: %v", err)
+	}
+	if total != 5 {
+		t.Errorf("remaining: got %d, want 5", total)
+	}
+}


### PR DESCRIPTION
Closes #265

## What
Add `_id` direct-lookup and secondary-index scan paths to four mutation/count operations that previously always performed O(N) full-collection scans:

- **`findAndModify`**: add `{_id}` fast path (O(log N) direct key lookup) and secondary-index scan; falls back to `ForEach` only when no index matches
- **`updateDocs`**: insert secondary-index scan between the existing `_id` fast path and full-scan fallback
- **`replaceDocs`**: same
- **`deleteDocs`**: same
- **`CountDocuments`**: add `{_id}` fast path (O(log N) point-lookup) and delegate to `scanFilter` (which honours secondary indexes) for all other filtered counts

## Why
`findAndModify` had no `_id` fast path at all — every call scanned the entire collection even when the filter was a simple `{_id: v}`. YCSB Workload F (50% read-modify-write) exercises exactly this path, explaining its 24% throughput ratio. Workload A (50% updates) is similarly bottlenecked on write-transaction latency which is worsened by unnecessary decompression and filter evaluation on every document. Adding index-aware paths for update/delete/count/replace closes the gap for both keyed and indexed-field operations.

```yaml
agent:
  id: founder-agent-s1
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#265"]
```

*Posted by the founder agent on behalf of @inder*