### PR TITLE
fix(ci): resolve errcheck and gosimple lint failures in storage tests

### DIFF
--- a/internal/storage/change_stream_cursor_test.go
+++ b/internal/storage/change_stream_cursor_test.go
@@ -247,11 +247,7 @@ func TestChangeStreamCursorNextBatchWait(t *testing.T) {
 		})
 	}()
 
-	tc, ok := cur.(TailableCursor)
-	if !ok {
-		t.Fatal("cursor does not implement TailableCursor")
-	}
-	docs, exhausted, err := tc.NextBatchWait(context.Background(), 100, 500)
+	docs, exhausted, err := cur.NextBatchWait(context.Background(), 100, 500)
 	if err != nil {
 		t.Fatalf("NextBatchWait error: %v", err)
 	}
@@ -267,12 +263,8 @@ func TestChangeStreamCursorNextBatchWaitTimeout(t *testing.T) {
 	bus := NewEventBus(10)
 	cur := bus.NewChangeStreamCursor("db", "timecoll", 0)
 
-	tc, ok := cur.(TailableCursor)
-	if !ok {
-		t.Fatal("cursor does not implement TailableCursor")
-	}
 	start := time.Now()
-	docs, exhausted, err := tc.NextBatchWait(context.Background(), 100, 50) // 50ms
+	docs, exhausted, err := cur.NextBatchWait(context.Background(), 100, 50) // 50ms
 	elapsed := time.Since(start)
 
 	if err != nil {

--- a/internal/storage/fastpath_test.go
+++ b/internal/storage/fastpath_test.go
@@ -23,7 +23,10 @@ func TestFindAndModifyByIDFastPath(t *testing.T) {
 		}
 	}
 
-	bc := coll.(*bboltCollection)
+	bc, ok := coll.(*bboltCollection)
+	if !ok {
+		t.Fatal("collection is not a *bboltCollection")
+	}
 
 	filter := mustMarshal(bson.D{{Key: "_id", Value: int32(7)}})
 	update := mustMarshal(bson.D{{Key: "$set", Value: bson.D{{Key: "val", Value: int32(777)}}}})
@@ -66,7 +69,10 @@ func TestFindAndModifyByIDMissing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Collection: %v", err)
 	}
-	bc := coll.(*bboltCollection)
+	bc, ok := coll.(*bboltCollection)
+	if !ok {
+		t.Fatal("collection is not a *bboltCollection")
+	}
 
 	filter := mustMarshal(bson.D{{Key: "_id", Value: int32(999)}})
 	update := mustMarshal(bson.D{{Key: "$set", Value: bson.D{{Key: "x", Value: int32(1)}}}})
@@ -104,7 +110,10 @@ func TestFindAndModifyIndexScan(t *testing.T) {
 		}
 	}
 
-	bc := coll.(*bboltCollection)
+	bc, ok := coll.(*bboltCollection)
+	if !ok {
+		t.Fatal("collection is not a *bboltCollection")
+	}
 
 	// Query by indexed field (not _id).
 	filter := mustMarshal(bson.D{{Key: "score", Value: int32(25)}}) // _id == 5


### PR DESCRIPTION
Closes: CI lint failures (no issue — direct CI fix)

## What
- `internal/storage/fastpath_test.go`: convert 3 single-value type assertions (`bc := coll.(*bboltCollection)`) to comma-ok form to satisfy `errcheck`
- `internal/storage/change_stream_cursor_test.go`: remove 2 redundant `cur.(TailableCursor)` assertions (S1040) — `NewChangeStreamCursor` already returns `TailableCursor`, so the assertions are a no-op; use `cur` directly

## Why
CI has been red since #268 merged. These 5 lint violations block every subsequent merge. This is a minimal fix — no logic change, test behaviour is identical.

## Risk Assessment
- [x] No risk: test-only change, no production code modified

## Test Plan
- [x] `go test ./internal/storage/...` passes locally
- [x] Lint fixes confirmed against the exact errors from CI logs

```yaml
agent:
  id: founder-agent-ci
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
```

*Posted by the founder agent on behalf of @inder*