### PR TITLE
fix(ci): stop compat probe filing threshold-achieved issues at 100% ceiling

### DIFF
--- a/tools/compat/check_compat_gap.py
+++ b/tools/compat/check_compat_gap.py
@@ -291,14 +291,22 @@ def handle_condition_1(score: float, threshold: float, per_cat: dict, dry_run: b
         create_issue(title, LABEL_C1, body)
 
 
+_THRESHOLD_CEILING = 1.0  # Compatibility cannot exceed 100%; stop advancing here.
+
+
 def handle_condition_2(score: float, threshold: float, dry_run: bool):
-    """Threshold hit — file achievement issue, close p0."""
+    """Threshold hit — file achievement issue (or note ceiling), close p0."""
     existing_p0 = find_open_issue("close gap to threshold", "priority:critical")
     if existing_p0:
         if not dry_run:
             close_issue(existing_p0["number"], "Compatibility threshold achieved. Closing.")
         else:
             print(f"[DRY RUN] Would close p0 #{existing_p0['number']}")
+
+    if threshold >= _THRESHOLD_CEILING:
+        print(f"  Threshold is already at the ceiling ({_THRESHOLD_CEILING*100:.0f}%) — "
+              "no achievement issue filed and no further bumps needed.")
+        return
 
     existing_ach = find_open_issue("threshold achieved", "area:compat")
     if existing_ach:


### PR DESCRIPTION
Closes #335
Closes #334

## What
Add a `_THRESHOLD_CEILING = 1.0` guard in `check_compat_gap.py`. When `threshold >= 1.0`, `handle_condition_2` now logs a note and returns early — it does **not** file a "threshold achieved" issue and does not suggest bumping to 1.02.

## Why
Compatibility cannot exceed 100%, so a threshold of 1.02 is unreachable and would make CI always fail. The probe fired on every push after reaching 100%, filing duplicate maintainer-only issues each run (#331, #332, #334, #335). PR #333 set `configs/compat_threshold` to `1.00` to stop the loop, but the probe itself wasn't patched — it still fires `handle_condition_2` whenever `score >= threshold`, creating new issues on the next run.

This one-line guard permanently fixes the root cause: once the threshold is at the ceiling, the probe silently acknowledges success and does nothing.

```yaml
agent:
  id: founder-agent-ci
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#334", "#335"]
```

*Posted by the founder agent on behalf of @inder*