### PR TITLE
perf(storage): early-exit scanFilter for limited queries + decompress buffer pool

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -206,7 +206,11 @@ func rawDocToD(doc bson.Raw) bson.D {
 // ─── Find ─────────────────────────────────────────────────────────────────────
 
 func (c *bboltCollection) Find(filter bson.Raw, opts FindOptions) (Cursor, error) {
-	docs, err := c.scanFilter(filter, opts.Projection)
+	so := scanOpts{
+		limit:   opts.Limit,
+		hasSort: len(opts.Sort) > 0,
+	}
+	docs, err := c.scanFilter(filter, opts.Projection, so)
 	if err != nil {
 		return nil, err
 	}
@@ -283,10 +287,18 @@ func extractIDEquality(filter bson.Raw) (bson.RawValue, bool) {
 	return v, true
 }
 
-// scanFilter does a full collection scan and applies filter + projection.
-// When the filter is a simple {_id: value} equality, it uses a direct key
-// lookup instead of scanning the entire collection.
-func (c *bboltCollection) scanFilter(filter bson.Raw, projection bson.Raw) ([]bson.Raw, error) {
+// scanOpts controls early-exit behaviour during a collection scan.
+// When limit > 0 and hasSort is false, the scan stops as soon as limit
+// matching documents have been collected, avoiding a full collection walk.
+type scanOpts struct {
+	limit   int64 // 0 = no limit
+	hasSort bool  // true = all docs must be visited to sort correctly
+}
+
+// scanFilter does a full (or limited) collection scan and applies filter + projection.
+// When the filter is a simple {_id: value} equality, it uses a direct key lookup.
+// When so.limit > 0 and so.hasSort is false, the scan stops after so.limit matches.
+func (c *bboltCollection) scanFilter(filter bson.Raw, projection bson.Raw, so scanOpts) ([]bson.Raw, error) {
 	boltDB, err := c.engine.getDB(c.db)
 	if err != nil {
 		return nil, err
@@ -354,9 +366,13 @@ func (c *bboltCollection) scanFilter(filter bson.Raw, projection bson.Raw) ([]bs
 			cp := make([]byte, len(doc))
 			copy(cp, doc)
 			docs = append(docs, bson.Raw(cp))
+			// Early exit: stop scanning once we have enough docs (only safe without a sort).
+			if !so.hasSort && so.limit > 0 && int64(len(docs)) >= so.limit {
+				return errStopIteration
+			}
 			return nil
 		})
-	}); err != nil {
+	}); err != nil && err != errStopIteration {
 		return nil, err
 	}
 	return docs, nil

--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -207,8 +207,14 @@ func rawDocToD(doc bson.Raw) bson.D {
 
 func (c *bboltCollection) Find(filter bson.Raw, opts FindOptions) (Cursor, error) {
 	so := scanOpts{
-		limit:   opts.Limit,
 		hasSort: len(opts.Sort) > 0,
+	}
+	// When limit is set, pass a scan ceiling to scanFilter so it can stop early.
+	// When skip is also set, inflate the ceiling: scanFilter must collect
+	// limit+skip matching docs so that Find()'s post-scan skip has enough
+	// documents to discard before returning the real window.
+	if opts.Limit > 0 {
+		so.limit = opts.Limit + opts.Skip
 	}
 	docs, err := c.scanFilter(filter, opts.Projection, so)
 	if err != nil {

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -877,6 +877,16 @@ func (e *BBoltEngine) decompress(data []byte) ([]byte, error) {
 	return decompress(data, e.compression)
 }
 
+// snappyDstPool holds reusable decode-destination buffers for snappy decompression.
+// snappy.Decode writes into the provided dst slice when it is large enough, avoiding
+// a new allocation on each call. The pool entry is updated when snappy grows it.
+var snappyDstPool = sync.Pool{
+	New: func() interface{} {
+		b := make([]byte, 0, 8192)
+		return &b
+	},
+}
+
 func compress(data []byte, alg string) ([]byte, error) {
 	switch alg {
 	case "snappy":
@@ -889,7 +899,21 @@ func compress(data []byte, alg string) ([]byte, error) {
 func decompress(data []byte, alg string) ([]byte, error) {
 	switch alg {
 	case "snappy":
-		return snappy.Decode(nil, data)
+		dstPtr := snappyDstPool.Get().(*[]byte)
+		decoded, err := snappy.Decode(*dstPtr, data)
+		if err != nil {
+			snappyDstPool.Put(dstPtr)
+			return nil, err
+		}
+		// decoded may point into dstPtr's backing array (reused) or a new allocation
+		// if the compressed payload is larger than the pool buffer. Either way we must
+		// return a caller-owned copy because the pool buffer will be reused.
+		result := make([]byte, len(decoded))
+		copy(result, decoded)
+		// Update the pool entry so it grows over time to fit typical document sizes.
+		*dstPtr = decoded[:0]
+		snappyDstPool.Put(dstPtr)
+		return result, nil
 	default:
 		return data, nil
 	}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -343,6 +343,47 @@ func TestSortSkipLimit(t *testing.T) {
 	}
 }
 
+// TestSkipLimitNoSort verifies that skip+limit without a sort returns the correct
+// document window. This is a regression test for a bug where scanFilter's early-exit
+// optimisation would stop after `limit` matches before skip was applied, causing
+// paginated queries to return empty or incorrect results.
+func TestSkipLimitNoSort(t *testing.T) {
+	client := newClient(t)
+	coll := client.Database(testDB(t)).Collection("docs")
+	ctx := context.Background()
+
+	// Insert 20 documents with n=0..19.
+	for i := 0; i < 20; i++ {
+		_, err := coll.InsertOne(ctx, bson.D{{Key: "n", Value: i}})
+		if err != nil {
+			t.Fatalf("InsertOne %d: %v", i, err)
+		}
+	}
+
+	// skip=10, limit=5, no sort → expect 5 docs (insertion order docs 10-14).
+	findOpts := options.Find().SetSkip(10).SetLimit(5)
+	cursor, err := coll.Find(ctx, bson.D{}, findOpts)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	var results []bson.M
+	if err := cursor.All(ctx, &results); err != nil {
+		t.Fatalf("cursor.All: %v", err)
+	}
+
+	if len(results) != 5 {
+		t.Fatalf("skip+limit: expected 5 results, got %d", len(results))
+	}
+	// bbolt iterates in key order (ObjectID insertion order = n=10..14).
+	for i, r := range results {
+		got := int(r["n"].(int32))
+		want := 10 + i
+		if got != want {
+			t.Errorf("result[%d]: expected n=%d, got n=%d", i, want, got)
+		}
+	}
+}
+
 // ─── Aggregation ─────────────────────────────────────────────────────────────
 
 func TestAggregateMatch(t *testing.T) {


### PR DESCRIPTION
## What
Two storage-layer optimizations:
1. Early-exit in `scanFilter` when a limit is reached (stops scanning once enough documents found)
2. A `sync.Pool` for decompression buffers to reduce per-document allocations

## Why
Without early-exit, a `find({ }, {limit: 10})` on a 100K document collection still scans all documents. This is a correctness-affecting performance bug. The decompress pool reduces GC pressure for compressed-at-rest workloads.

## Risk Assessment
- [x] Medium risk: modifies existing storage scan behavior, regression test added

## Test Plan
- [x] Regression test for skip+limit early-exit interaction added
- [x] Existing integration tests pass

```yaml
agent:
  id: founder-agent-ci
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  perf_branch: perf/69-scan-limit-decomp-pool
```

*Posted by the founder agent on behalf of @inder*