### PR TITLE
perf: eliminate per-message bufio allocation + TCP_NODELAY

### DIFF
--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"net"
@@ -28,6 +29,7 @@ func newRequestID() int32 {
 type Connection struct {
 	id     int64
 	conn   net.Conn
+	br     *bufio.Reader // persistent read buffer — eliminates per-message allocation
 	server *Server
 	logger *zap.Logger
 
@@ -40,11 +42,16 @@ type Connection struct {
 	session *commands.Session
 }
 
+// connReadBufSize is the size of the per-connection read buffer.
+// 16 KiB covers the common case (OP_MSG + BSON doc) without a second syscall.
+const connReadBufSize = 16 * 1024
+
 // newConnection creates a new Connection wrapping the given net.Conn.
 func newConnection(id int64, conn net.Conn, srv *Server) *Connection {
 	return &Connection{
 		id:     id,
 		conn:   conn,
+		br:     bufio.NewReaderSize(conn, connReadBufSize),
 		server: srv,
 		logger: srv.logger.With(
 			zap.Int64("connID", id),
@@ -61,8 +68,9 @@ func (c *Connection) serve() {
 	c.logger.Debug("new connection")
 
 	for {
-		// Read the next message from the client.
-		msg, err := wire.ReadMessage(c.conn)
+		// Read the next message from the client using the persistent
+		// connection-level bufio.Reader (no per-message allocation).
+		msg, err := wire.ReadMessage(c.br)
 		if err != nil {
 			if err == io.EOF || isConnectionReset(err) {
 				c.logger.Debug("client disconnected")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -142,6 +142,14 @@ func (s *Server) Run() error {
 			continue
 		}
 
+		// Disable Nagle's algorithm: without TCP_NODELAY, small responses are
+		// held up to 40 ms waiting for more data. MongoDB clients send a request
+		// and immediately wait for the reply, so Nagle adds pure latency here.
+		if tc, ok := conn.(*net.TCPConn); ok {
+			_ = tc.SetNoDelay(true)
+			_ = tc.SetKeepAlive(true)
+		}
+
 		// Enforce max connections limit.
 		if s.cfg.MaxConnections > 0 && int(s.currentConns.Load()) >= s.cfg.MaxConnections {
 			s.logger.Warn("max connections reached, rejecting new connection",

--- a/internal/wire/op_msg.go
+++ b/internal/wire/op_msg.go
@@ -73,11 +73,20 @@ func readOpMsg(r io.Reader, hdr Header, bodyLen int) (*OpMsgMessage, error) {
 	// underlying *bufio.Reader's io.ByteReader interface is preserved,
 	// keeping readCString on the fast path (no per-byte allocation) inside
 	// OP_MSG section parsing.
+	//
+	// Three cases, in order of likelihood:
+	//   1. *boundedBufReader — ReadMessage passes this after the bufio PR.
+	//      Extract the underlying *bufio.Reader and re-bound to sectionBytes.
+	//   2. *bufio.Reader — direct bufio.Reader (legacy / unit-test paths).
+	//   3. anything else — fall back to io.LimitedReader (loses ByteReader fast path).
 	var sectionReader io.Reader
 	if sectionBytes > 0 {
-		if br, ok := r.(*bufio.Reader); ok {
-			sectionReader = &boundedBufReader{r: br, n: sectionBytes}
-		} else {
+		switch v := r.(type) {
+		case *boundedBufReader:
+			sectionReader = &boundedBufReader{r: v.r, n: sectionBytes}
+		case *bufio.Reader:
+			sectionReader = &boundedBufReader{r: v, n: sectionBytes}
+		default:
 			sectionReader = &io.LimitedReader{R: r, N: sectionBytes}
 		}
 	} else {

--- a/internal/wire/protocol.go
+++ b/internal/wire/protocol.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"net"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -168,9 +167,13 @@ func ReadHeader(r io.Reader) (Header, error) {
 	return hdr, nil
 }
 
-// ReadMessage reads one complete MongoDB wire protocol message from conn.
-// It reads the 16-byte header, then dispatches to the appropriate parser
-// based on the opcode. Returns one of:
+// ReadMessage reads one complete MongoDB wire protocol message from br.
+// br must be a persistent *bufio.Reader owned by the connection — it is NOT
+// created inside this function. Using a connection-level bufio.Reader eliminates
+// the per-message bufio.NewReader allocation (one 4 KiB alloc per request on the
+// hottest path) that the previous net.Conn-based signature incurred.
+//
+// Returns one of:
 //   - *OpMsgMessage
 //   - *OpQueryMessage
 //   - *OpGetMoreMessage
@@ -179,8 +182,8 @@ func ReadHeader(r io.Reader) (Header, error) {
 //
 // For unknown/unsupported opcodes, the remaining bytes are discarded and
 // nil is returned with no error.
-func ReadMessage(conn net.Conn) (interface{}, error) {
-	hdr, err := ReadHeader(conn)
+func ReadMessage(br *bufio.Reader) (interface{}, error) {
+	hdr, err := ReadHeader(br)
 	if err != nil {
 		return nil, fmt.Errorf("ReadMessage: read header: %w", err)
 	}
@@ -191,46 +194,42 @@ func ReadMessage(conn net.Conn) (interface{}, error) {
 		return nil, fmt.Errorf("ReadMessage: negative body length %d (messageLength=%d)", bodyLen, hdr.MessageLength)
 	}
 
-	// Use an io.LimitedReader so individual parsers cannot read past the
-	// declared message boundary, then wrap it in a bufio.Reader so that
-	// readCString and the fixed-width int readers pull from a 4 KiB in-memory
-	// buffer instead of making one syscall per byte / per field.
-	// The bufio.Reader also satisfies io.ByteReader, enabling the fast path in
-	// readCString that avoids the per-byte allocation.
-	lr := &io.LimitedReader{R: conn, N: int64(bodyLen)}
-	br := bufio.NewReaderSize(lr, 4096)
+	// Bound message body reads using the connection's existing bufio.Reader.
+	// boundedBufReader preserves io.ByteReader so readCString stays on its
+	// fast path (no per-byte allocation). No new bufio allocation per message.
+	bounded := &boundedBufReader{r: br, n: int64(bodyLen)}
 
 	switch hdr.OpCode {
 	case OpMsg:
-		msg, err := readOpMsg(br, hdr, bodyLen)
+		msg, err := readOpMsg(bounded, hdr, bodyLen)
 		if err != nil {
 			return nil, fmt.Errorf("ReadMessage OP_MSG: %w", err)
 		}
 		return msg, nil
 
 	case OpQuery:
-		msg, err := readOpQuery(br, hdr)
+		msg, err := readOpQuery(bounded, hdr)
 		if err != nil {
 			return nil, fmt.Errorf("ReadMessage OP_QUERY: %w", err)
 		}
 		return msg, nil
 
 	case OpGetMore:
-		msg, err := readOpGetMore(br, hdr)
+		msg, err := readOpGetMore(bounded, hdr)
 		if err != nil {
 			return nil, fmt.Errorf("ReadMessage OP_GETMORE: %w", err)
 		}
 		return msg, nil
 
 	case OpKillCursors:
-		msg, err := readOpKillCursors(br, hdr)
+		msg, err := readOpKillCursors(bounded, hdr)
 		if err != nil {
 			return nil, fmt.Errorf("ReadMessage OP_KILL_CURSORS: %w", err)
 		}
 		return msg, nil
 
 	case OpDelete:
-		msg, err := readOpDelete(br, hdr)
+		msg, err := readOpDelete(bounded, hdr)
 		if err != nil {
 			return nil, fmt.Errorf("ReadMessage OP_DELETE: %w", err)
 		}
@@ -239,8 +238,7 @@ func ReadMessage(conn net.Conn) (interface{}, error) {
 	default:
 		// Discard unknown message body so the connection stays in sync.
 		if bodyLen > 0 {
-			discard := make([]byte, bodyLen)
-			if _, err := io.ReadFull(conn, discard); err != nil {
+			if _, err := br.Discard(bodyLen); err != nil {
 				return nil, fmt.Errorf("ReadMessage: discard unknown opcode %d body: %w", hdr.OpCode, err)
 			}
 		}

--- a/internal/wire/read_message_test.go
+++ b/internal/wire/read_message_test.go
@@ -1,0 +1,118 @@
+package wire
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// buildRawOpMsgFrame returns a complete OP_MSG wire frame for body.
+func buildRawOpMsgFrame(tb testing.TB, body bson.Raw) []byte {
+	tb.Helper()
+	// Message layout: header (16) + flagBits (4) + sectionKind (1) + body
+	msgLen := int32(HeaderSize + 4 + 1 + len(body))
+	buf := make([]byte, int(msgLen))
+	binary.LittleEndian.PutUint32(buf[0:], uint32(msgLen))
+	binary.LittleEndian.PutUint32(buf[4:], 1)              // requestID
+	binary.LittleEndian.PutUint32(buf[8:], 0)              // responseTo
+	binary.LittleEndian.PutUint32(buf[12:], uint32(OpMsg)) // opCode
+	binary.LittleEndian.PutUint32(buf[16:], 0)             // flagBits
+	buf[20] = 0x00                                         // sectionKind = body
+	copy(buf[21:], body)
+	return buf
+}
+
+// TestReadMessageOpMsg verifies that ReadMessage correctly parses an OP_MSG
+// frame when given a persistent *bufio.Reader (the calling convention after
+// the per-message allocation fix).
+func TestReadMessageOpMsg(t *testing.T) {
+	original := bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "ordered", Value: true},
+	}
+	body, err := bson.Marshal(original)
+	if err != nil {
+		t.Fatalf("bson.Marshal: %v", err)
+	}
+
+	frame := buildRawOpMsgFrame(t, body)
+	br := bufio.NewReader(bytes.NewReader(frame))
+
+	msg, err := ReadMessage(br)
+	if err != nil {
+		t.Fatalf("ReadMessage: %v", err)
+	}
+	if msg == nil {
+		t.Fatal("ReadMessage returned nil message")
+	}
+
+	opMsg, ok := msg.(*OpMsgMessage)
+	if !ok {
+		t.Fatalf("expected *OpMsgMessage, got %T", msg)
+	}
+	if !bytes.Equal(opMsg.Body, body) {
+		t.Errorf("body mismatch:\n got  %x\n want %x", opMsg.Body, body)
+	}
+}
+
+// TestReadMessageMultipleOnSameReader verifies that a single persistent
+// *bufio.Reader correctly demarcates consecutive messages — validating that
+// boundedBufReader does not over-read and corrupt the stream.
+func TestReadMessageMultipleOnSameReader(t *testing.T) {
+	docs := []bson.D{
+		{{Key: "find", Value: "col"}},
+		{{Key: "insert", Value: "col"}},
+		{{Key: "delete", Value: "col"}},
+	}
+
+	var buf bytes.Buffer
+	for _, d := range docs {
+		body, err := bson.Marshal(d)
+		if err != nil {
+			t.Fatalf("bson.Marshal: %v", err)
+		}
+		buf.Write(buildRawOpMsgFrame(t, body))
+	}
+
+	br := bufio.NewReader(&buf)
+	for i, d := range docs {
+		msg, err := ReadMessage(br)
+		if err != nil {
+			t.Fatalf("ReadMessage[%d]: %v", i, err)
+		}
+		opMsg, ok := msg.(*OpMsgMessage)
+		if !ok {
+			t.Fatalf("ReadMessage[%d]: expected *OpMsgMessage, got %T", i, msg)
+		}
+
+		var got bson.D
+		if err := bson.Unmarshal(opMsg.Body, &got); err != nil {
+			t.Fatalf("Unmarshal[%d]: %v", i, err)
+		}
+		if len(got) != len(d) || got[0].Key != d[0].Key {
+			t.Errorf("ReadMessage[%d]: got %v, want %v", i, got, d)
+		}
+	}
+}
+
+// BenchmarkReadMessageAllocs measures per-call allocations for ReadMessage.
+// With the persistent-bufio fix the bufio.NewReader alloc (1 alloc, 4096 B)
+// is eliminated from the per-message hot path; this benchmark guards against
+// regression.
+func BenchmarkReadMessageAllocs(b *testing.B) {
+	body, _ := bson.Marshal(bson.D{{Key: "find", Value: "users"}, {Key: "filter", Value: bson.D{}}})
+	frame := buildRawOpMsgFrame(b, body)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		br := bufio.NewReader(bytes.NewReader(frame))
+		if _, err := ReadMessage(br); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #323

## What
Two focused hot-path improvements from perf Plan V3 Phase 0 (p0-b + p0-c):

**1. Persistent connection bufio.Reader (p0-b)**

`ReadMessage` previously called `bufio.NewReaderSize(lr, 4096)` on every single message — one 4 KiB allocation on the hottest read path. Fix:
- Move `*bufio.Reader` to `Connection` struct, initialized once in `newConnection` with 16 KiB buffer
- Change `ReadMessage` signature from `net.Conn` to `*bufio.Reader`
- Use `boundedBufReader{r: br, n: bodyLen}` to bound message body reads without a new allocation per message
- Update `readOpMsg` type switch to handle `*boundedBufReader`, preserving the `io.ByteReader` fast path for `readCString` inside OP_MSG section parsing

At 10K QPS this eliminates ~40 MB/s of short-lived allocations, reducing GC pause frequency proportionally.

**2. TCP_NODELAY + keepalive on accepted connections (p0-c)**

Without `TCP_NODELAY`, Nagle's algorithm holds small writes for up to 40 ms before flushing. MongoDB clients send a request and block on the reply — Nagle adds pure latency on every request/response pair. `SetNoDelay(true)` disables it. `SetKeepAlive(true)` detects dead connections faster.

## Why
Issue #323 tracks the performance gap (currently ~35% of MongoDB throughput vs 90% north star). These two changes address the highest-ROI Phase 0 items from the perf plan.

## Tests
- `TestReadMessageOpMsg`: single message parse via `*bufio.Reader`
- `TestReadMessageMultipleOnSameReader`: three consecutive messages on one reader — directly validates no over-read / stream corruption
- `BenchmarkReadMessageAllocs`: allocation regression guard

All existing tests pass (`go test ./...`).

```yaml
agent:
  id: founder-agent-ci
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#323"]
```

*Posted by the founder agent on behalf of @inder*