### PR TITLE
fix(ci): re-enable compat/benchmark triggers + deduplicate failure issue filing

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,18 +1,12 @@
 name: Nightly Benchmark
 
-# Adaptive cadence — runs every 3 hours but a gate job skips the expensive
-# YCSB run based on current performance gap:
-#
-#   gap > 50pp  (ratio <40%)  →  throttle 3h   (crisis mode)
-#   gap > 25pp  (ratio <65%)  →  throttle 6h   (active sprint)
-#   gap > 10pp  (ratio <80%)  →  throttle 12h  (tuning phase)
-#   gap ≤ 10pp  (ratio ≥80%)  →  throttle 24h  (original cadence)
-#
+# Daily benchmark — perf gap is closed, so once per day is sufficient.
+# The gate job still skips the expensive YCSB run if the gap is small enough.
 # workflow_dispatch always bypasses the gate.
 
 on:
-  # schedule:
-  #   - cron: '0 */3 * * *'   # every 3 hours; gate skips most runs adaptively
+  schedule:
+    - cron: '0 4 * * *'   # once daily at 04:00 UTC; perf gap closed, reduced cadence
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1,10 +1,8 @@
 name: Compatibility Matrix
 
 on:
-  # pull_request:
-  #   branches: [master]
-  # push:
-  #   branches: [master]
+  push:
+    branches: [master]
   workflow_dispatch:
 
 permissions:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -119,7 +119,7 @@ If eligible, opens a promotion PR modifying `registry.yml` (labeled `agent:promo
 ---
 
 ### `compat.yml` — Compatibility Matrix
-**Trigger:** Push to master, PR, manual
+**Trigger:** Push to master + manual
 **What it does:**
 1. Runs the compat probe tool against a live Salvobase instance, writes results to `docs/compat_report.json`
 2. Compares against the previous commit — files a regression issue immediately if any probe regresses (pass → fail/partial)
@@ -133,7 +133,7 @@ If eligible, opens a promotion PR modifying `registry.yml` (labeled `agent:promo
 ---
 
 ### `benchmark.yml` — Adaptive Benchmark
-**Trigger:** Every 3 hours (`0 */3 * * *`) + manual — but a gate job skips the expensive YCSB run based on current gap:
+**Trigger:** Daily at 04:00 UTC (`0 4 * * *`) + manual — a gate job skips the expensive YCSB run based on current gap:
 
 | Gap | Effective cadence |
 |-----|------------------|
@@ -237,8 +237,8 @@ If eligible, opens a promotion PR modifying `registry.yml` (labeled `agent:promo
 | `agent-promotion-v2.yml` | PR merged | Tier promotion check |
 | `promotion-celebration.yml` | Promotion PR merged | Celebration post |
 | `ci.yml` | Push/PR | Build + test + lint |
-| `compat.yml` | Push/PR/manual | Compat score + regression + gap issues |
-| `benchmark.yml` | Every 3h (adaptive gate) | Perf vs MongoDB + north star |
+| `compat.yml` | Push/manual | Compat score + regression + gap issues |
+| `benchmark.yml` | Daily 04:00 UTC (adaptive gate) | Perf vs MongoDB + north star |
 | `orchestrator.yml` | Every 15min | Claim expiry + stale PR warnings |
 | `stale-pr-cleanup.yml` | Daily | Close 7d+ stale PRs |
 | `spec-gap-analyzer-v2.yml` | *(retired)* | Superseded by compat.yml |

--- a/scripts/bench/file_failure_issue.py
+++ b/scripts/bench/file_failure_issue.py
@@ -19,6 +19,27 @@ import sys
 from datetime import datetime, timezone
 
 
+def has_open_failure_issue(repo: str, search_term: str) -> bool:
+    """Check if there's already an open failure issue matching search_term."""
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--repo", repo,
+                "--state", "open",
+                "--label", "bug",
+                "--search", search_term,
+                "--json", "number",
+                "--jq", "length",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        return int(result.stdout.strip()) > 0
+    except (OSError, ValueError, AttributeError):
+        return False
+
+
 def main() -> None:
     repo = os.environ.get("GITHUB_REPOSITORY", "inder/salvobase")
     run_url = os.environ.get("RUN_URL", "")
@@ -26,6 +47,10 @@ def main() -> None:
     commit_url = os.environ.get("COMMIT_URL", "")
 
     date_str = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+
+    if has_open_failure_issue(repo, "nightly benchmark failed"):
+        print(f"Open failure issue already exists for {repo} — skipping duplicate.")
+        return
 
     body = f"""\
 ## Nightly Benchmark Failed

--- a/scripts/contributor/file_failure_issue.py
+++ b/scripts/contributor/file_failure_issue.py
@@ -19,6 +19,27 @@ import sys
 from datetime import datetime, timezone
 
 
+def has_open_failure_issue(repo: str, search_term: str) -> bool:
+    """Check if there's already an open failure issue matching search_term."""
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--repo", repo,
+                "--state", "open",
+                "--label", "bug",
+                "--search", search_term,
+                "--json", "number",
+                "--jq", "length",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        return int(result.stdout.strip()) > 0
+    except (OSError, ValueError, AttributeError):
+        return False
+
+
 def main() -> None:
     repo = os.environ.get("GITHUB_REPOSITORY", "")
     run_url = os.environ.get("RUN_URL", "")
@@ -28,6 +49,10 @@ def main() -> None:
     operator = os.environ.get("OPERATOR_HANDLE", "unknown-operator")
 
     date_str = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+
+    if has_open_failure_issue(repo, "contributor agent cycle failed"):
+        print(f"Open failure issue already exists for {repo} — skipping duplicate.")
+        return
 
     body = f"""\
 ## Contributor Agent Cycle Failed

--- a/scripts/founder/file_failure_issue.py
+++ b/scripts/founder/file_failure_issue.py
@@ -19,6 +19,27 @@ import sys
 from datetime import datetime, timezone
 
 
+def has_open_failure_issue(repo: str, search_term: str) -> bool:
+    """Check if there's already an open failure issue matching search_term."""
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--repo", repo,
+                "--state", "open",
+                "--label", "bug",
+                "--search", search_term,
+                "--json", "number",
+                "--jq", "length",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        return int(result.stdout.strip()) > 0
+    except (OSError, ValueError, AttributeError):
+        return False
+
+
 def main() -> None:
     repo = os.environ.get("GITHUB_REPOSITORY", "inder/salvobase")
     run_url = os.environ.get("RUN_URL", "")
@@ -26,6 +47,11 @@ def main() -> None:
     commit_url = os.environ.get("COMMIT_URL", "")
 
     date_str = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+
+    # Deduplicate: skip if there's already an open failure issue
+    if has_open_failure_issue(repo, "headless founder cycle failed"):
+        print(f"Open failure issue already exists for {repo} — skipping duplicate.")
+        return
 
     body = f"""\
 ## Headless Founder Agent Failed

--- a/scripts/introspector/file_failure_issue.py
+++ b/scripts/introspector/file_failure_issue.py
@@ -19,6 +19,27 @@ import sys
 from datetime import datetime, timezone
 
 
+def has_open_failure_issue(repo: str, search_term: str) -> bool:
+    """Check if there's already an open failure issue matching search_term."""
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--repo", repo,
+                "--state", "open",
+                "--label", "bug",
+                "--search", search_term,
+                "--json", "number",
+                "--jq", "length",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        return int(result.stdout.strip()) > 0
+    except (OSError, ValueError, AttributeError):
+        return False
+
+
 def main() -> None:
     repo = os.environ.get("GITHUB_REPOSITORY", "inder/salvobase")
     run_url = os.environ.get("RUN_URL", "")
@@ -26,6 +47,10 @@ def main() -> None:
     commit_url = os.environ.get("COMMIT_URL", "")
 
     date_str = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+
+    if has_open_failure_issue(repo, "headless introspector cycle failed"):
+        print(f"Open failure issue already exists for {repo} — skipping duplicate.")
+        return
 
     body = f"""\
 ## Headless Introspector Agent Failed

--- a/tools/compat/file_regression_issue.py
+++ b/tools/compat/file_regression_issue.py
@@ -22,11 +22,36 @@ import sys
 from datetime import datetime, timezone
 
 
+def has_open_failure_issue(repo: str, search_term: str) -> bool:
+    """Check if there's already an open failure issue matching search_term."""
+    try:
+        result = subprocess.run(
+            [
+                "gh", "issue", "list",
+                "--repo", repo,
+                "--state", "open",
+                "--label", "bug",
+                "--search", search_term,
+                "--json", "number",
+                "--jq", "length",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        return int(result.stdout.strip()) > 0
+    except (OSError, ValueError, AttributeError):
+        return False
+
+
 def main() -> None:
     repo = os.environ.get("GITHUB_REPOSITORY", "inder/salvobase")
     regression_output = os.environ.get("REGRESSION_OUTPUT", "(no output captured)")
     commit_sha = os.environ.get("COMMIT_SHA", "")[:7]
     commit_url = os.environ.get("COMMIT_URL", "")
+
+    if has_open_failure_issue(repo, "compatibility regression detected"):
+        print(f"Open regression issue already exists for {repo} — skipping duplicate.")
+        return
     pr_number = os.environ.get("PR_NUMBER", "")
     pr_url = os.environ.get("PR_URL", "")
 


### PR DESCRIPTION
Closes #349

## What
- Re-enables compat.yml push trigger on master (was commented out since 2026-03-21)
- Re-enables benchmark.yml on daily schedule at 04:00 UTC (was 3h adaptive, then disabled)
- Adds dedup logic to all 5 issue-filing scripts so they skip filing when an open issue already exists
- Updates docs/workflows.md to match new trigger descriptions

## Why
21 days without automated regression detection. Meanwhile the failure-filing scripts had no dedup guard, which caused 30+ duplicate "founder cycle failed" issues when the headless founder workflow broke.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#349"]
```

*Posted by the founder agent on behalf of @inder*