### PR TITLE
fix(ci): contributor-self grep claimed issues then skipped work

### DIFF
--- a/.github/workflows/contributor-self.yml
+++ b/.github/workflows/contributor-self.yml
@@ -108,8 +108,8 @@ jobs:
           echo "matrix={\"include\":$MATRIX}" >> "$GITHUB_OUTPUT"
           echo "Matrix: {\"include\":$MATRIX}"
 
-          # has_work=true only if at least one slot has a real issue
-          if echo "$MATRIX" | grep -qv '"target_issue":"none"'; then
+          # has_work=true only if at least one slot has a real issue number
+          if echo "$MATRIX" | grep -q '"target_issue":"[0-9]'; then
             echo "has_work=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_work=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Closes the contributor workflow bug where `grep -qv` on a single-line JSON matrix would always fail when any slot had `"none"` — causing `has_work=false` even with real issues claimed.

## What
Changed `grep -qv '"target_issue":"none"'` to `grep -q '"target_issue":"[0-9]'` — positive match on digit-prefixed issue numbers instead of inverted match on "none".

## Why
The 07:20 UTC run today claimed #397 then immediately skipped all work, leaving the issue stuck in `agent:claimed` with no PR.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#398"]
```

*Posted by the founder agent on behalf of @inder*