### PR TITLE
perf: eliminate per-call allocations in index key encoding

### DIFF
--- a/internal/storage/index.go
+++ b/internal/storage/index.go
@@ -13,149 +13,132 @@ import (
 
 // ─── _id key encoding ─────────────────────────────────────────────────────────
 
-// encodeIDValue encodes a BSON _id value into a sortable byte key.
-// ObjectID _id: 12 raw bytes (natural time-ordering).
-// String _id:   0x02 + UTF-8 bytes
-// Int32 _id:    0x10 + 4 LE bytes
-// Int64 _id:    0x12 + 8 LE bytes
-// Other:        BSON encoding of the value
-func encodeIDValue(v bson.RawValue) []byte {
+// appendIDKey appends the encoded _id key for v to dst and returns the extended slice.
+// Callers on hot paths should pass a stack-allocated buffer (e.g. buf[:0] where buf is [64]byte).
+func appendIDKey(dst []byte, v bson.RawValue) []byte {
 	switch v.Type {
 	case bson.TypeObjectID:
 		oid, ok := v.ObjectIDOK()
 		if !ok {
 			break
 		}
-		return oid[:]
+		return append(dst, oid[:]...)
 	case bson.TypeString:
 		s, ok := v.StringValueOK()
 		if !ok {
 			break
 		}
-		b := make([]byte, 1+len(s))
-		b[0] = 0x02
-		copy(b[1:], s)
-		return b
+		dst = append(dst, 0x02)
+		return append(dst, s...)
 	case bson.TypeInt32:
 		n, ok := v.Int32OK()
 		if !ok {
 			break
 		}
-		b := make([]byte, 5)
-		b[0] = 0x10
-		binary.LittleEndian.PutUint32(b[1:], uint32(n))
-		return b
+		dst = append(dst, 0x10, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint32(dst[len(dst)-4:], uint32(n))
+		return dst
 	case bson.TypeInt64:
 		n, ok := v.Int64OK()
 		if !ok {
 			break
 		}
-		b := make([]byte, 9)
-		b[0] = 0x12
-		binary.LittleEndian.PutUint64(b[1:], uint64(n))
-		return b
+		dst = append(dst, 0x12, 0, 0, 0, 0, 0, 0, 0, 0)
+		binary.LittleEndian.PutUint64(dst[len(dst)-8:], uint64(n))
+		return dst
 	}
-	// Fallback: use BSON type byte + value bytes
-	result := make([]byte, 1+len(v.Value))
-	result[0] = byte(v.Type)
-	copy(result[1:], v.Value)
-	return result
+	dst = append(dst, byte(v.Type))
+	return append(dst, v.Value...)
+}
+
+// encodeIDValue encodes a BSON _id value into a sortable byte key.
+func encodeIDValue(v bson.RawValue) []byte {
+	return appendIDKey(nil, v)
 }
 
 // ─── Index key encoding ───────────────────────────────────────────────────────
 
-// encodeFloat64Index encodes a float64 in a way that preserves sort order.
-// Uses IEEE 754 bit manipulation to make negative numbers sort before positive.
-func encodeFloat64Index(f float64) []byte {
+// appendFloat64Index appends a sort-order-preserving float64 encoding to dst.
+func appendFloat64Index(dst []byte, f float64) []byte {
 	bits := math.Float64bits(f)
-	// Flip sign bit; if negative, flip all bits
 	if bits>>63 == 0 {
 		bits ^= 0x8000000000000000
 	} else {
 		bits ^= 0xFFFFFFFFFFFFFFFF
 	}
-	b := make([]byte, 9)
-	b[0] = 0x20
-	binary.BigEndian.PutUint64(b[1:], bits)
-	return b
+	dst = append(dst, 0x20, 0, 0, 0, 0, 0, 0, 0, 0)
+	binary.BigEndian.PutUint64(dst[len(dst)-8:], bits)
+	return dst
+}
+
+// appendIndexKeyRaw appends the index key encoding of v to dst.
+func appendIndexKeyRaw(dst []byte, v bson.RawValue) []byte {
+	switch v.Type {
+	case 0, bson.TypeNull:
+		return append(dst, 0x00)
+	case bson.TypeBoolean:
+		if v.Boolean() {
+			return append(dst, 0x10, 0x01)
+		}
+		return append(dst, 0x10, 0x00)
+	case bson.TypeDouble:
+		f, _ := v.DoubleOK()
+		return appendFloat64Index(dst, f)
+	case bson.TypeInt32:
+		n, _ := v.Int32OK()
+		return appendFloat64Index(dst, float64(n))
+	case bson.TypeInt64:
+		n, _ := v.Int64OK()
+		return appendFloat64Index(dst, float64(n))
+	case bson.TypeString:
+		s, _ := v.StringValueOK()
+		dst = append(dst, 0x30)
+		return append(dst, s...)
+	case bson.TypeBinary:
+		_, binData, ok := v.BinaryOK()
+		if !ok {
+			return append(dst, 0x40)
+		}
+		dst = append(dst, 0x40)
+		return append(dst, binData...)
+	case bson.TypeObjectID:
+		oid, ok := v.ObjectIDOK()
+		if !ok {
+			return append(dst, 0x50)
+		}
+		dst = append(dst, 0x50)
+		return append(dst, oid[:]...)
+	case bson.TypeDateTime:
+		t, _ := v.DateTimeOK()
+		dst = append(dst, 0x60, 0, 0, 0, 0, 0, 0, 0, 0)
+		binary.BigEndian.PutUint64(dst[len(dst)-8:], uint64(t))
+		return dst
+	case bson.TypeTimestamp:
+		t, i, _ := v.TimestampOK()
+		dst = append(dst, 0x65, 0, 0, 0, 0, 0, 0, 0, 0)
+		binary.BigEndian.PutUint32(dst[len(dst)-8:], t)
+		binary.BigEndian.PutUint32(dst[len(dst)-4:], i)
+		return dst
+	case bson.TypeEmbeddedDocument:
+		dst = append(dst, 0x70)
+		return append(dst, v.Value...)
+	case bson.TypeArray:
+		dst = append(dst, 0x75)
+		return append(dst, v.Value...)
+	}
+	// Unknown type: 0xFE tag (0xFF reserved as separator in buildIndexKey)
+	dst = append(dst, 0xFE)
+	return append(dst, v.Value...)
+}
+
+// encodeFloat64Index encodes a float64 in a way that preserves sort order.
+func encodeFloat64Index(f float64) []byte {
+	return appendFloat64Index(nil, f)
 }
 
 // encodeIndexKeyFromRaw converts a bson.RawValue to an index key.
 func encodeIndexKeyFromRaw(v bson.RawValue) []byte {
-	switch v.Type {
-	case 0, bson.TypeNull:
-		return []byte{0x00}
-	case bson.TypeBoolean:
-		if v.Boolean() {
-			return []byte{0x10, 0x01}
-		}
-		return []byte{0x10, 0x00}
-	case bson.TypeDouble:
-		f, _ := v.DoubleOK()
-		return encodeFloat64Index(f)
-	case bson.TypeInt32:
-		n, _ := v.Int32OK()
-		return encodeFloat64Index(float64(n))
-	case bson.TypeInt64:
-		n, _ := v.Int64OK()
-		return encodeFloat64Index(float64(n))
-	case bson.TypeString:
-		s, _ := v.StringValueOK()
-		b := make([]byte, 1+len(s))
-		b[0] = 0x30
-		copy(b[1:], s)
-		return b
-	case bson.TypeBinary:
-		_, binData, ok := v.BinaryOK()
-		if !ok {
-			return []byte{0x40}
-		}
-		b := make([]byte, 1+len(binData))
-		b[0] = 0x40
-		copy(b[1:], binData)
-		return b
-	case bson.TypeObjectID:
-		oid, ok := v.ObjectIDOK()
-		if !ok {
-			return []byte{0x50}
-		}
-		b := make([]byte, 1+12)
-		b[0] = 0x50
-		copy(b[1:], oid[:])
-		return b
-	case bson.TypeDateTime:
-		t, _ := v.DateTimeOK()
-		b := make([]byte, 9)
-		b[0] = 0x60
-		binary.BigEndian.PutUint64(b[1:], uint64(t))
-		return b
-	case bson.TypeTimestamp:
-		t, i, _ := v.TimestampOK()
-		b := make([]byte, 9)
-		b[0] = 0x65
-		binary.BigEndian.PutUint32(b[1:], t)
-		binary.BigEndian.PutUint32(b[5:], i)
-		return b
-	case bson.TypeEmbeddedDocument:
-		// Use raw BSON bytes for doc comparison
-		b := make([]byte, 1+len(v.Value))
-		b[0] = 0x70
-		copy(b[1:], v.Value)
-		return b
-	case bson.TypeArray:
-		b := make([]byte, 1+len(v.Value))
-		b[0] = 0x75
-		copy(b[1:], v.Value)
-		return b
-	}
-	// Unknown type: use 0xFE as the type tag.
-	// 0xFF is reserved as the separator between encoded field keys and the _id suffix
-	// in non-unique index entries (buildIndexKey). Using 0xFF here would make the
-	// separator indistinguishable from a leading byte of an unknown-type field value.
-	b := make([]byte, 1+len(v.Value))
-	b[0] = 0xFE
-	copy(b[1:], v.Value)
-	return b
+	return appendIndexKeyRaw(nil, v)
 }
 
 // ─── Index insert/remove ──────────────────────────────────────────────────────
@@ -211,12 +194,10 @@ func (e *BBoltEngine) removeFromIndexes(tx *bolt.Tx, db, coll string, idBytes []
 
 // insertDocIntoIndex inserts a single document into one index bucket.
 func insertDocIntoIndex(idxB *bolt.Bucket, spec IndexSpec, doc bson.Raw, idBytes []byte) error {
-	indexKey := buildIndexKey(spec.Keys, doc, idBytes)
+	var buf [128]byte
 
 	if spec.Unique {
-		// For unique indexes, key = index fields only (no _id suffix)
-		// Value = _id bytes
-		uniqueKey := buildUniqueIndexKey(spec.Keys, doc)
+		uniqueKey := appendFieldKeys(buf[:0], spec.Keys, doc)
 		if existing := idxB.Get(uniqueKey); existing != nil {
 			if !bytes.Equal(existing, idBytes) {
 				return Errorf(ErrCodeDuplicateKey, "E11000 duplicate key error: index %s dup key", spec.Name)
@@ -225,73 +206,71 @@ func insertDocIntoIndex(idxB *bolt.Bucket, spec IndexSpec, doc bson.Raw, idBytes
 		return idxB.Put(uniqueKey, idBytes)
 	}
 
-	// Non-unique: key = index fields + _id suffix (ensures uniqueness within bucket)
-	// Value = empty
+	indexKey := appendFieldKeys(buf[:0], spec.Keys, doc)
+	indexKey = append(indexKey, 0xFF)
+	indexKey = append(indexKey, idBytes...)
 	return idxB.Put(indexKey, []byte{})
 }
 
 // removeDocFromIndex removes a document from one index bucket.
 func removeDocFromIndex(idxB *bolt.Bucket, spec IndexSpec, doc bson.Raw, idBytes []byte) {
+	var buf [128]byte
 	if spec.Unique {
-		uniqueKey := buildUniqueIndexKey(spec.Keys, doc)
+		uniqueKey := appendFieldKeys(buf[:0], spec.Keys, doc)
 		_ = idxB.Delete(uniqueKey)
 		return
 	}
-	indexKey := buildIndexKey(spec.Keys, doc, idBytes)
+	indexKey := appendFieldKeys(buf[:0], spec.Keys, doc)
+	indexKey = append(indexKey, 0xFF)
+	indexKey = append(indexKey, idBytes...)
 	_ = idxB.Delete(indexKey)
 }
 
 // buildIndexKey builds the composite index key: encoded field values + id bytes.
-// This ensures uniqueness even for non-unique indexes.
 func buildIndexKey(keys bson.Raw, doc bson.Raw, idBytes []byte) []byte {
-	fieldKeys := buildFieldKeys(keys, doc)
-	result := make([]byte, len(fieldKeys)+1+len(idBytes))
-	copy(result, fieldKeys)
-	result[len(fieldKeys)] = 0xFF // separator
-	copy(result[len(fieldKeys)+1:], idBytes)
+	result := appendFieldKeys(nil, keys, doc)
+	result = append(result, 0xFF)
+	result = append(result, idBytes...)
 	return result
 }
 
 // buildUniqueIndexKey builds the key for a unique index: encoded field values only.
 func buildUniqueIndexKey(keys bson.Raw, doc bson.Raw) []byte {
-	return buildFieldKeys(keys, doc)
+	return appendFieldKeys(nil, keys, doc)
 }
 
-// buildFieldKeys builds the encoded key for a compound index from a document.
-// Uses encodeIndexField for each field so that the encoding is identical to
+// appendFieldKeys appends the encoded compound index key for doc to dst.
+// Uses appendIndexField for each field so that the encoding is identical to
 // encodeEqualityPrefix — the two functions MUST produce the same bytes for the
 // same field value or index scans will silently miss documents.
-func buildFieldKeys(keys bson.Raw, doc bson.Raw) []byte {
+func appendFieldKeys(dst []byte, keys bson.Raw, doc bson.Raw) []byte {
 	if len(keys) == 0 {
-		return nil
+		return dst
 	}
 	elems, err := keys.Elements()
 	if err != nil {
-		return nil
+		return dst
 	}
 
-	var result []byte
 	for i, elem := range elems {
-		fieldVal := lookupIndexField(doc, elem.Key())
-		encoded := encodeIndexField(elem.Value(), fieldVal)
 		if i > 0 {
-			result = append(result, 0x01) // field separator
+			dst = append(dst, 0x01) // field separator
 		}
-		result = append(result, encoded...)
+		fieldVal := lookupIndexField(doc, elem.Key())
+		dst = appendIndexField(dst, elem.Value(), fieldVal)
 	}
-	return result
+	return dst
 }
 
-// encodeIndexField encodes a single index field value and applies the direction
-// flip for descending index specifications (dir < 0). This is the shared encoding
-// kernel used by both buildFieldKeys and encodeEqualityPrefix to guarantee that
-// the two functions produce identical byte sequences for the same input.
-//
-// dirVal is the direction element from the index key spec (e.g. Int32(1) or Int32(-1)).
-// fieldVal is the document field value to encode.
-func encodeIndexField(dirVal, fieldVal bson.RawValue) []byte {
-	encoded := encodeIndexKeyFromRaw(fieldVal)
+// buildFieldKeys builds the encoded key for a compound index from a document.
+func buildFieldKeys(keys bson.Raw, doc bson.Raw) []byte {
+	return appendFieldKeys(nil, keys, doc)
+}
 
+// appendIndexField appends a single encoded index field value to dst, applying
+// the direction flip for descending index specifications (dir < 0). This is the
+// shared encoding kernel used by both appendFieldKeys and encodeEqualityPrefix.
+func appendIndexField(dst []byte, dirVal, fieldVal bson.RawValue) []byte {
 	dir := float64(1)
 	switch dirVal.Type {
 	case bson.TypeDouble:
@@ -304,20 +283,28 @@ func encodeIndexField(dirVal, fieldVal bson.RawValue) []byte {
 		n, _ := dirVal.Int64OK()
 		dir = float64(n)
 	}
-	if dir < 0 {
-		flipped := make([]byte, len(encoded))
-		for i, b := range encoded {
-			flipped[i] = 0xFF ^ b
-		}
-		return flipped
+
+	if dir >= 0 {
+		return appendIndexKeyRaw(dst, fieldVal)
 	}
-	return encoded
+
+	// Descending: encode then flip all bits in-place
+	start := len(dst)
+	dst = appendIndexKeyRaw(dst, fieldVal)
+	for i := start; i < len(dst); i++ {
+		dst[i] = 0xFF ^ dst[i]
+	}
+	return dst
+}
+
+// encodeIndexField encodes a single index field value and applies the direction flip.
+func encodeIndexField(dirVal, fieldVal bson.RawValue) []byte {
+	return appendIndexField(nil, dirVal, fieldVal)
 }
 
 // encodeEqualityPrefix builds the index key prefix for a set of equality predicates.
-// It uses encodeIndexField (the same kernel as buildFieldKeys) to guarantee that
+// Uses appendIndexField (the same kernel as appendFieldKeys) to guarantee that
 // the generated prefix exactly matches the keys stored in the index bucket.
-// Encoding stops at the first index field not present in equalities.
 func encodeEqualityPrefix(keys bson.Raw, equalities map[string]bson.RawValue) []byte {
 	if len(keys) == 0 {
 		return nil
@@ -326,19 +313,25 @@ func encodeEqualityPrefix(keys bson.Raw, equalities map[string]bson.RawValue) []
 	if err != nil {
 		return nil
 	}
-	var result []byte
+	var buf [128]byte
+	result := buf[:0]
 	for i, elem := range elems {
 		val, ok := equalities[elem.Key()]
 		if !ok {
 			break
 		}
-		encoded := encodeIndexField(elem.Value(), val)
 		if i > 0 {
-			result = append(result, 0x01) // field separator (same as buildFieldKeys)
+			result = append(result, 0x01)
 		}
-		result = append(result, encoded...)
+		result = appendIndexField(result, elem.Value(), val)
 	}
-	return result
+	if len(result) == 0 {
+		return nil
+	}
+	// Return a copy so the stack buffer doesn't escape beyond this call
+	out := make([]byte, len(result))
+	copy(out, result)
+	return out
 }
 
 // lookupIndexField retrieves a field value from a document, supporting dot notation.

--- a/internal/storage/perf_test.go
+++ b/internal/storage/perf_test.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"bytes"
+	"encoding/binary"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -212,3 +214,208 @@ func benchmarkUpdateByIDN(b *testing.B, n int) {
 
 func BenchmarkUpdateByID_100(b *testing.B)  { benchmarkUpdateByIDN(b, 100) }
 func BenchmarkUpdateByID_1000(b *testing.B) { benchmarkUpdateByIDN(b, 1000) }
+
+// TestAppendIDKeyIdentity verifies that appendIDKey produces the same bytes as
+// the expected encoding for each _id type.
+func TestAppendIDKeyIdentity(t *testing.T) {
+	oid := bson.NewObjectID()
+
+	tests := []struct {
+		name string
+		val  bson.RawValue
+		want []byte
+	}{
+		{
+			name: "ObjectID",
+			val:  bson.RawValue{Type: bson.TypeObjectID, Value: oid[:]},
+			want: oid[:],
+		},
+		{
+			name: "Int32",
+			val: func() bson.RawValue {
+				b := make([]byte, 4)
+				binary.LittleEndian.PutUint32(b, 42)
+				return bson.RawValue{Type: bson.TypeInt32, Value: b}
+			}(),
+			want: func() []byte {
+				b := []byte{0x10, 0, 0, 0, 0}
+				binary.LittleEndian.PutUint32(b[1:], 42)
+				return b
+			}(),
+		},
+		{
+			name: "Int64",
+			val: func() bson.RawValue {
+				b := make([]byte, 8)
+				binary.LittleEndian.PutUint64(b, 99)
+				return bson.RawValue{Type: bson.TypeInt64, Value: b}
+			}(),
+			want: func() []byte {
+				b := []byte{0x12, 0, 0, 0, 0, 0, 0, 0, 0}
+				binary.LittleEndian.PutUint64(b[1:], 99)
+				return b
+			}(),
+		},
+		{
+			name: "String",
+			val:  bson.RawValue{Type: bson.TypeString, Value: func() []byte { b, _ := bson.AppendString(nil, "hello"); return b }()},
+			want: append([]byte{0x02}, "hello"...),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := encodeIDValue(tc.val)
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("encodeIDValue: got %x, want %x", got, tc.want)
+			}
+
+			var buf [64]byte
+			gotAppend := appendIDKey(buf[:0], tc.val)
+			if !bytes.Equal(gotAppend, tc.want) {
+				t.Errorf("appendIDKey: got %x, want %x", gotAppend, tc.want)
+			}
+		})
+	}
+}
+
+// TestAppendIndexKeyRawIdentity verifies that appendIndexKeyRaw produces correct
+// output for each BSON type, including the descending bit-flip path.
+func TestAppendIndexKeyRawIdentity(t *testing.T) {
+	oid := bson.NewObjectID()
+
+	tests := []struct {
+		name string
+		val  bson.RawValue
+		tag  byte // expected first byte
+	}{
+		{"Null", bson.RawValue{Type: bson.TypeNull}, 0x00},
+		{"BoolTrue", bson.RawValue{Type: bson.TypeBoolean, Value: []byte{1}}, 0x10},
+		{"BoolFalse", bson.RawValue{Type: bson.TypeBoolean, Value: []byte{0}}, 0x10},
+		{"ObjectID", bson.RawValue{Type: bson.TypeObjectID, Value: oid[:]}, 0x50},
+		{"String", bson.RawValue{Type: bson.TypeString, Value: func() []byte { b, _ := bson.AppendString(nil, "abc"); return b }()}, 0x30},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := encodeIndexKeyFromRaw(tc.val)
+			if got[0] != tc.tag {
+				t.Errorf("tag byte: got 0x%02x, want 0x%02x", got[0], tc.tag)
+			}
+
+			// Verify append variant produces identical bytes
+			var buf [64]byte
+			gotAppend := appendIndexKeyRaw(buf[:0], tc.val)
+			if !bytes.Equal(got, gotAppend) {
+				t.Errorf("appendIndexKeyRaw mismatch: wrapper=%x, append=%x", got, gotAppend)
+			}
+		})
+	}
+
+	// Test descending index bit-flip
+	t.Run("DescendingFlip", func(t *testing.T) {
+		dirAsc := bson.RawValue{Type: bson.TypeInt32, Value: func() []byte {
+			b := make([]byte, 4)
+			binary.LittleEndian.PutUint32(b, 1)
+			return b
+		}()}
+		dirDesc := bson.RawValue{Type: bson.TypeInt32, Value: func() []byte {
+			b := make([]byte, 4)
+			binary.LittleEndian.PutUint32(b, uint32(int32(-1)))
+			return b
+		}()}
+		fieldVal := bson.RawValue{Type: bson.TypeObjectID, Value: oid[:]}
+
+		asc := encodeIndexField(dirAsc, fieldVal)
+		desc := encodeIndexField(dirDesc, fieldVal)
+
+		if len(asc) != len(desc) {
+			t.Fatalf("length mismatch: asc=%d, desc=%d", len(asc), len(desc))
+		}
+		for i := range asc {
+			if desc[i] != 0xFF^asc[i] {
+				t.Errorf("byte %d: desc=0x%02x, want 0x%02x (0xFF ^ asc)", i, desc[i], 0xFF^asc[i])
+			}
+		}
+	})
+}
+
+// BenchmarkEncodeIDValue benchmarks _id key encoding for the most common types.
+func BenchmarkEncodeIDValue(b *testing.B) {
+	oid := bson.NewObjectID()
+	oidRaw := bson.RawValue{Type: bson.TypeObjectID, Value: oid[:]}
+	intRaw := bson.RawValue{Type: bson.TypeInt32}
+	intRaw.Value = make([]byte, 4)
+
+	b.Run("ObjectID", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = encodeIDValue(oidRaw)
+		}
+	})
+	b.Run("Int32", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = encodeIDValue(intRaw)
+		}
+	})
+}
+
+// BenchmarkBuildIndexKey benchmarks composite index key construction.
+func BenchmarkBuildIndexKey(b *testing.B) {
+	doc := mustMarshal(bson.D{
+		{Key: "_id", Value: bson.NewObjectID()},
+		{Key: "name", Value: "alice"},
+		{Key: "age", Value: int32(30)},
+	})
+	keys := mustMarshal(bson.D{{Key: "name", Value: int32(1)}})
+	idBytes := encodeIDValue(doc.Lookup("_id"))
+
+	b.Run("Single", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = buildIndexKey(keys, doc, idBytes)
+		}
+	})
+
+	compoundKeys := mustMarshal(bson.D{
+		{Key: "name", Value: int32(1)},
+		{Key: "age", Value: int32(-1)},
+	})
+	b.Run("Compound", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = buildIndexKey(compoundKeys, doc, idBytes)
+		}
+	})
+}
+
+// BenchmarkInsertWithIndex benchmarks insert into a collection with a secondary index.
+func BenchmarkInsertWithIndex(b *testing.B) {
+	dir := b.TempDir()
+	e, err := NewBBoltEngine(dir, "none", false)
+	if err != nil {
+		b.Fatalf("NewBBoltEngine: %v", err)
+	}
+	defer e.Close()
+
+	coll, err := e.Collection("bench", "indexed")
+	if err != nil {
+		b.Fatalf("Collection: %v", err)
+	}
+
+	// Create a secondary index on "name"
+	if err := coll.CreateIndex(IndexSpec{
+		Name: "name_1",
+		Keys: mustMarshal(bson.D{{Key: "name", Value: int32(1)}}),
+	}); err != nil {
+		b.Fatalf("CreateIndex: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		doc := mustMarshal(bson.D{
+			{Key: "name", Value: "user"},
+			{Key: "age", Value: int32(i)},
+		})
+		if _, err := coll.InsertOne(doc); err != nil {
+			b.Fatalf("InsertOne: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
Closes #401

## What
Convert index key encoding functions from allocating fresh `[]byte` slices per call to an append-to-dst pattern. Hot-path callers (`insertDocIntoIndex`, `removeDocFromIndex`, `encodeEqualityPrefix`) use stack-allocated `[128]byte` buffers, reducing allocation count from N per index operation to at most 1.

## Why
Index key encoding is called per-document on every insert, update, delete, and indexed query. The old code allocated 3-5 separate byte slices per index operation. This is a major contributor to GC pressure under YCSB workloads A/F (write-heavy). Part of the performance gap closure effort (#397).

## Changes
- `appendIDKey`, `appendFloat64Index`, `appendIndexKeyRaw`, `appendIndexField`, `appendFieldKeys`: new append-to-dst functions (standard Go pattern, like `strconv.AppendInt`)
- `insertDocIntoIndex` / `removeDocFromIndex`: use `var buf [128]byte` stack buffers
- Descending index bit-flip done in-place (eliminates separate `flipped` allocation)
- Golden-value tests for encoding identity (`TestAppendIDKeyIdentity`, `TestAppendIndexKeyRawIdentity`)
- Benchmarks for index key encoding and indexed inserts

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#401"]
```

*Posted by the founder agent on behalf of @inder*