### PR TITLE
fix: resolve build errors in storage perf_test.go

### DIFF
--- a/internal/storage/perf_test.go
+++ b/internal/storage/perf_test.go
@@ -8,6 +8,17 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
+// bsonStringBytes returns BSON-encoded string bytes (int32 length + data + \x00)
+// suitable for use in bson.RawValue{Type: bson.TypeString, Value: ...}.
+func bsonStringBytes(s string) []byte {
+	l := len(s) + 1
+	b := make([]byte, 4+l)
+	binary.LittleEndian.PutUint32(b, uint32(l))
+	copy(b[4:], s)
+	// trailing null already zero
+	return b
+}
+
 // TestUpdateByIDFastPath verifies that UpdateOne with an {_id: value} filter
 // uses the direct key lookup (O(log N)) rather than a full collection scan.
 func TestUpdateByIDFastPath(t *testing.T) {
@@ -258,7 +269,7 @@ func TestAppendIDKeyIdentity(t *testing.T) {
 		},
 		{
 			name: "String",
-			val:  bson.RawValue{Type: bson.TypeString, Value: func() []byte { b, _ := bson.AppendString(nil, "hello"); return b }()},
+			val:  bson.RawValue{Type: bson.TypeString, Value: bsonStringBytes("hello")},
 			want: append([]byte{0x02}, "hello"...),
 		},
 	}
@@ -293,7 +304,7 @@ func TestAppendIndexKeyRawIdentity(t *testing.T) {
 		{"BoolTrue", bson.RawValue{Type: bson.TypeBoolean, Value: []byte{1}}, 0x10},
 		{"BoolFalse", bson.RawValue{Type: bson.TypeBoolean, Value: []byte{0}}, 0x10},
 		{"ObjectID", bson.RawValue{Type: bson.TypeObjectID, Value: oid[:]}, 0x50},
-		{"String", bson.RawValue{Type: bson.TypeString, Value: func() []byte { b, _ := bson.AppendString(nil, "abc"); return b }()}, 0x30},
+		{"String", bson.RawValue{Type: bson.TypeString, Value: bsonStringBytes("abc")}, 0x30},
 	}
 
 	for _, tc := range tests {
@@ -321,7 +332,7 @@ func TestAppendIndexKeyRawIdentity(t *testing.T) {
 		}()}
 		dirDesc := bson.RawValue{Type: bson.TypeInt32, Value: func() []byte {
 			b := make([]byte, 4)
-			binary.LittleEndian.PutUint32(b, uint32(int32(-1)))
+			binary.LittleEndian.PutUint32(b, 0xFFFFFFFF)
 			return b
 		}()}
 		fieldVal := bson.RawValue{Type: bson.TypeObjectID, Value: oid[:]}
@@ -401,7 +412,7 @@ func BenchmarkInsertWithIndex(b *testing.B) {
 	}
 
 	// Create a secondary index on "name"
-	if err := coll.CreateIndex(IndexSpec{
+	if _, err := e.CreateIndex("bench", "indexed", IndexSpec{
 		Name: "name_1",
 		Keys: mustMarshal(bson.D{{Key: "name", Value: int32(1)}}),
 	}); err != nil {


### PR DESCRIPTION
Closes #412

## What
Fixes 3 build errors in `internal/storage/perf_test.go` that are breaking CI on master:
1. `bson.AppendString` doesn't exist in mongo-driver v2 — replaced with manual BSON string encoder
2. `uint32(int32(-1))` constant overflow — replaced with `0xFFFFFFFF`
3. `coll.CreateIndex()` doesn't exist on Collection — changed to `e.CreateIndex("bench", "indexed", ...)`

## Why
CI is red on master. Unit tests and lint both fail because `perf_test.go` doesn't compile. This was introduced in the recent perf PRs (#405, #411) where test code referenced APIs that don't exist.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#412"]
```

*Posted by the founder agent on behalf of @inder*