### PR TITLE
perf: pool wire protocol response header buffers (closes #403)

### DIFF
--- a/internal/wire/op_reply.go
+++ b/internal/wire/op_reply.go
@@ -4,9 +4,24 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"sync"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
+
+// opReplyHdrSize is the fixed byte count for the non-document portion of an
+// OP_REPLY message: header(16) + responseFlags(4) + cursorID(8) +
+// startingFrom(4) + numberReturned(4) = 36.
+const opReplyHdrSize = HeaderSize + 4 + 8 + 4 + 4
+
+// opReplyHdrPool pools the fixed-size header buffer used by WriteOpReply so
+// that high-throughput query paths avoid a 36-byte allocation per response.
+var opReplyHdrPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, opReplyHdrSize)
+		return &b
+	},
+}
 
 // OpReplyMessage represents an OP_REPLY wire protocol message (opcode 1).
 // OP_REPLY is the server-to-client response format used with legacy OP_QUERY.
@@ -45,12 +60,17 @@ func WriteOpReply(
 
 	// messageLength = header(16) + responseFlags(4) + cursorID(8) +
 	//                 startingFrom(4) + numberReturned(4) + docs
-	msgLen := int32(HeaderSize + 4 + 8 + 4 + 4 + docBytes)
+	msgLen := int32(opReplyHdrSize + docBytes)
 
-	// Allocate a buffer for everything except the document bodies (which we
-	// write separately to avoid a large intermediate allocation for big result
-	// sets — though we still write them in one Write call per document).
-	hdrBuf := make([]byte, HeaderSize+4+8+4+4)
+	// Borrow a pooled buffer for the fixed-size header portion.
+	bp, ok := opReplyHdrPool.Get().(*[]byte)
+	if !ok {
+		b := make([]byte, opReplyHdrSize)
+		bp = &b
+	}
+	hdrBuf := *bp // aliases the pooled array; do not retain beyond this function
+	defer opReplyHdrPool.Put(bp)
+
 	offset := 0
 
 	// Header
@@ -71,7 +91,6 @@ func WriteOpReply(
 	binary.LittleEndian.PutUint32(hdrBuf[offset:], uint32(startingFrom))
 	offset += 4
 	binary.LittleEndian.PutUint32(hdrBuf[offset:], uint32(len(docs)))
-	// offset += 4  (last field, not needed)
 
 	if _, err := w.Write(hdrBuf); err != nil {
 		return fmt.Errorf("WriteOpReply header: %w", err)

--- a/internal/wire/op_reply_test.go
+++ b/internal/wire/op_reply_test.go
@@ -1,0 +1,92 @@
+package wire
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestWriteOpReply_RoundTrip(t *testing.T) {
+	doc := marshalDoc(t, bson.D{{Key: "ok", Value: 1}})
+
+	var buf bytes.Buffer
+	err := WriteOpReply(&buf, 42, 7, 0, 123, 0, []bson.Raw{doc})
+	if err != nil {
+		t.Fatalf("WriteOpReply: %v", err)
+	}
+
+	raw := buf.Bytes()
+
+	// Header checks
+	msgLen := int32(binary.LittleEndian.Uint32(raw[0:4]))
+	if int(msgLen) != len(raw) {
+		t.Fatalf("messageLength = %d, want %d", msgLen, len(raw))
+	}
+
+	reqID := int32(binary.LittleEndian.Uint32(raw[4:8]))
+	if reqID != 42 {
+		t.Fatalf("requestID = %d, want 42", reqID)
+	}
+
+	respTo := int32(binary.LittleEndian.Uint32(raw[8:12]))
+	if respTo != 7 {
+		t.Fatalf("responseTo = %d, want 7", respTo)
+	}
+
+	opCode := int32(binary.LittleEndian.Uint32(raw[12:16]))
+	if opCode != int32(OpReply) {
+		t.Fatalf("opCode = %d, want %d", opCode, OpReply)
+	}
+
+	// Response fields
+	cursorID := int64(binary.LittleEndian.Uint64(raw[20:28]))
+	if cursorID != 123 {
+		t.Fatalf("cursorID = %d, want 123", cursorID)
+	}
+
+	numReturned := int32(binary.LittleEndian.Uint32(raw[32:36]))
+	if numReturned != 1 {
+		t.Fatalf("numberReturned = %d, want 1", numReturned)
+	}
+
+	// Document body should match the original
+	docBytes := raw[36:]
+	if !bytes.Equal(docBytes, []byte(doc)) {
+		t.Fatalf("document mismatch:\n  got  %x\n  want %x", docBytes, doc)
+	}
+}
+
+func TestWriteOpReply_EmptyDocs(t *testing.T) {
+	var buf bytes.Buffer
+	err := WriteOpReply(&buf, 1, 1, 0, 0, 0, nil)
+	if err != nil {
+		t.Fatalf("WriteOpReply: %v", err)
+	}
+
+	raw := buf.Bytes()
+	if len(raw) != opReplyHdrSize {
+		t.Fatalf("len = %d, want %d (header only)", len(raw), opReplyHdrSize)
+	}
+
+	numReturned := int32(binary.LittleEndian.Uint32(raw[32:36]))
+	if numReturned != 0 {
+		t.Fatalf("numberReturned = %d, want 0", numReturned)
+	}
+}
+
+func TestWriteOpReply_PoolReuse(t *testing.T) {
+	// Call twice to exercise pool get/put cycle
+	doc := marshalDoc(t, bson.D{{Key: "x", Value: 1}})
+	for i := 0; i < 10; i++ {
+		var buf bytes.Buffer
+		if err := WriteOpReply(&buf, int32(i), 0, 0, 0, 0, []bson.Raw{doc}); err != nil {
+			t.Fatalf("iteration %d: %v", i, err)
+		}
+		reqID := int32(binary.LittleEndian.Uint32(buf.Bytes()[4:8]))
+		if reqID != int32(i) {
+			t.Fatalf("iteration %d: requestID = %d", i, reqID)
+		}
+	}
+}


### PR DESCRIPTION
Closes #403

## What
Replace per-call `make([]byte, 36)` in `WriteOpReply` with a `sync.Pool`, eliminating a heap allocation on every OP_REPLY response. Adds round-trip tests for `WriteOpReply` (previously untested).

## Why
Every query response hits this allocation path. Under YCSB-style throughput (thousands of responses/sec), the per-call allocation generates unnecessary GC pressure. The pool follows the same `*[]byte` pattern used by `snappyDstPool` in `engine.go`.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#403"]
```

*Posted by the founder agent on behalf of @inder*