### PR TITLE
test: add unit tests for aggregation expression operators (closes #434)

### DIFF
--- a/internal/aggregation/expressions_test.go
+++ b/internal/aggregation/expressions_test.go
@@ -1,6 +1,7 @@
 package aggregation
 
 import (
+	"reflect"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -442,5 +443,443 @@ func TestExprNestedArithmetic(t *testing.T) {
 	got := evalExprHelper(t, expr, doc)
 	if got != int32(17) {
 		t.Errorf("(a*b)+c: got %v, want 17", got)
+	}
+}
+
+// ─── String expression operators ─────────────────────────────────────────────
+
+func TestExprStringOps(t *testing.T) {
+	doc := makeDoc(t, bson.D{
+		{Key: "s", Value: "hello world"},
+		{Key: "padded", Value: "  trimme  "},
+		{Key: "csv", Value: "a,b,c"},
+	})
+
+	tests := []struct {
+		name string
+		expr interface{}
+		want interface{}
+	}{
+		// $split
+		{
+			"split_basic",
+			bson.D{{Key: "$split", Value: bson.A{"$csv", ","}}},
+			[]interface{}{"a", "b", "c"},
+		},
+		{
+			"split_no_match",
+			bson.D{{Key: "$split", Value: bson.A{"$s", ";"}}},
+			[]interface{}{"hello world"},
+		},
+		{
+			"split_empty_sep",
+			bson.D{{Key: "$split", Value: bson.A{"abc", ""}}},
+			[]interface{}{"a", "b", "c"},
+		},
+		// $ltrim
+		{
+			"ltrim_default",
+			bson.D{{Key: "$ltrim", Value: bson.D{{Key: "input", Value: "$padded"}}}},
+			"trimme  ",
+		},
+		{
+			"ltrim_custom_chars",
+			bson.D{{Key: "$ltrim", Value: bson.D{
+				{Key: "input", Value: "xxyhello"},
+				{Key: "chars", Value: "xy"},
+			}}},
+			"hello",
+		},
+		// $rtrim
+		{
+			"rtrim_default",
+			bson.D{{Key: "$rtrim", Value: bson.D{{Key: "input", Value: "$padded"}}}},
+			"  trimme",
+		},
+		{
+			"rtrim_custom_chars",
+			bson.D{{Key: "$rtrim", Value: bson.D{
+				{Key: "input", Value: "helloxyyx"},
+				{Key: "chars", Value: "xy"},
+			}}},
+			"hello",
+		},
+		// $trim
+		{
+			"trim_default",
+			bson.D{{Key: "$trim", Value: bson.D{{Key: "input", Value: "$padded"}}}},
+			"trimme",
+		},
+		{
+			"trim_custom_chars",
+			bson.D{{Key: "$trim", Value: bson.D{
+				{Key: "input", Value: "xxhelloxx"},
+				{Key: "chars", Value: "x"},
+			}}},
+			"hello",
+		},
+		// $replaceOne
+		{
+			"replaceOne_basic",
+			bson.D{{Key: "$replaceOne", Value: bson.D{
+				{Key: "input", Value: "$s"},
+				{Key: "find", Value: "world"},
+				{Key: "replacement", Value: "there"},
+			}}},
+			"hello there",
+		},
+		{
+			"replaceOne_first_only",
+			bson.D{{Key: "$replaceOne", Value: bson.D{
+				{Key: "input", Value: "aaa"},
+				{Key: "find", Value: "a"},
+				{Key: "replacement", Value: "b"},
+			}}},
+			"baa",
+		},
+		// $replaceAll
+		{
+			"replaceAll_basic",
+			bson.D{{Key: "$replaceAll", Value: bson.D{
+				{Key: "input", Value: "aaa"},
+				{Key: "find", Value: "a"},
+				{Key: "replacement", Value: "b"},
+			}}},
+			"bbb",
+		},
+		{
+			"replaceAll_no_match",
+			bson.D{{Key: "$replaceAll", Value: bson.D{
+				{Key: "input", Value: "hello"},
+				{Key: "find", Value: "z"},
+				{Key: "replacement", Value: "!"},
+			}}},
+			"hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evalExprHelper(t, tt.expr, doc)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v (%T), want %v (%T)", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestExprStringOps_NilInput(t *testing.T) {
+	doc := makeDoc(t, bson.D{{Key: "x", Value: nil}})
+
+	// $split with nil input returns nil
+	got := evalExprHelper(t, bson.D{{Key: "$split", Value: bson.A{"$x", ","}}}, doc)
+	if got != nil {
+		t.Errorf("$split nil input: got %v, want nil", got)
+	}
+
+	// $trim with nil input returns nil
+	got = evalExprHelper(t, bson.D{{Key: "$trim", Value: bson.D{{Key: "input", Value: "$x"}}}}, doc)
+	if got != nil {
+		t.Errorf("$trim nil input: got %v, want nil", got)
+	}
+
+	// $replaceOne with nil input returns nil
+	got = evalExprHelper(t, bson.D{{Key: "$replaceOne", Value: bson.D{
+		{Key: "input", Value: "$x"},
+		{Key: "find", Value: "a"},
+		{Key: "replacement", Value: "b"},
+	}}}, doc)
+	if got != nil {
+		t.Errorf("$replaceOne nil input: got %v, want nil", got)
+	}
+}
+
+// ─── Regex expression operators ──────────────────────────────────────────────
+
+func TestExprRegexOps(t *testing.T) {
+	doc := makeDoc(t, bson.D{{Key: "s", Value: "Hello World 123"}})
+
+	t.Run("regexFind_match", func(t *testing.T) {
+		expr := bson.D{{Key: "$regexFind", Value: bson.D{
+			{Key: "input", Value: "$s"},
+			{Key: "regex", Value: `(\d+)`},
+		}}}
+		got := evalExprHelper(t, expr, doc)
+		want := bson.D{
+			{Key: "match", Value: "123"},
+			{Key: "idx", Value: int32(12)},
+			{Key: "captures", Value: []interface{}{"123"}},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("regexFind_no_match", func(t *testing.T) {
+		expr := bson.D{{Key: "$regexFind", Value: bson.D{
+			{Key: "input", Value: "$s"},
+			{Key: "regex", Value: `zzz`},
+		}}}
+		got := evalExprHelper(t, expr, doc)
+		if got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("regexFind_case_insensitive", func(t *testing.T) {
+		expr := bson.D{{Key: "$regexFind", Value: bson.D{
+			{Key: "input", Value: "$s"},
+			{Key: "regex", Value: `hello`},
+			{Key: "options", Value: "i"},
+		}}}
+		got := evalExprHelper(t, expr, doc)
+		gotD, ok := got.(bson.D)
+		if !ok {
+			t.Fatalf("expected bson.D, got %T", got)
+		}
+		for _, e := range gotD {
+			if e.Key == "match" {
+				if e.Value != "Hello" {
+					t.Errorf("match: got %v, want Hello", e.Value)
+				}
+			}
+		}
+	})
+
+	t.Run("regexMatch_true", func(t *testing.T) {
+		expr := bson.D{{Key: "$regexMatch", Value: bson.D{
+			{Key: "input", Value: "$s"},
+			{Key: "regex", Value: `\d+`},
+		}}}
+		got := evalExprHelper(t, expr, doc)
+		if got != true {
+			t.Errorf("got %v, want true", got)
+		}
+	})
+
+	t.Run("regexMatch_false", func(t *testing.T) {
+		expr := bson.D{{Key: "$regexMatch", Value: bson.D{
+			{Key: "input", Value: "$s"},
+			{Key: "regex", Value: `^xyz$`},
+		}}}
+		got := evalExprHelper(t, expr, doc)
+		if got != false {
+			t.Errorf("got %v, want false", got)
+		}
+	})
+
+	t.Run("regexMatch_nil_input", func(t *testing.T) {
+		nilDoc := makeDoc(t, bson.D{{Key: "s", Value: nil}})
+		expr := bson.D{{Key: "$regexMatch", Value: bson.D{
+			{Key: "input", Value: "$s"},
+			{Key: "regex", Value: `.*`},
+		}}}
+		got := evalExprHelper(t, expr, nilDoc)
+		if got != false {
+			t.Errorf("got %v, want false", got)
+		}
+	})
+
+	t.Run("regexFind_no_captures", func(t *testing.T) {
+		expr := bson.D{{Key: "$regexFind", Value: bson.D{
+			{Key: "input", Value: "$s"},
+			{Key: "regex", Value: `\d+`},
+		}}}
+		got := evalExprHelper(t, expr, doc)
+		want := bson.D{
+			{Key: "match", Value: "123"},
+			{Key: "idx", Value: int32(12)},
+			{Key: "captures", Value: ([]interface{})(nil)},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("regexFind_invalid_regex", func(t *testing.T) {
+		expr := bson.D{{Key: "$regexFind", Value: bson.D{
+			{Key: "input", Value: "$s"},
+			{Key: "regex", Value: `[invalid`},
+		}}}
+		_, err := EvalExpr(expr, makeDoc(t, bson.D{{Key: "s", Value: "test"}}))
+		if err == nil {
+			t.Error("expected error for invalid regex, got nil")
+		}
+	})
+}
+
+// ─── Type conversion operators ───────────────────────────────────────────────
+
+func TestExprTypeConversion(t *testing.T) {
+	doc := makeDoc(t, bson.D{
+		{Key: "n", Value: int32(42)},
+		{Key: "f", Value: 3.14},
+		{Key: "s", Value: "100"},
+		{Key: "b", Value: true},
+		{Key: "zero", Value: int32(0)},
+		{Key: "empty", Value: ""},
+	})
+
+	tests := []struct {
+		name string
+		expr interface{}
+		want interface{}
+	}{
+		// $toString
+		{"toString_int", bson.D{{Key: "$toString", Value: "$n"}}, "42"},
+		{"toString_double", bson.D{{Key: "$toString", Value: "$f"}}, "3.14"},
+		{"toString_bool_true", bson.D{{Key: "$toString", Value: "$b"}}, "true"},
+		{"toString_string", bson.D{{Key: "$toString", Value: "$s"}}, "100"},
+
+		// $toInt
+		{"toInt_string", bson.D{{Key: "$toInt", Value: "$s"}}, int32(100)},
+		{"toInt_double", bson.D{{Key: "$toInt", Value: "$f"}}, int32(3)},
+		{"toInt_int", bson.D{{Key: "$toInt", Value: "$n"}}, int32(42)},
+		{"toInt_truncates_not_rounds", bson.D{{Key: "$toInt", Value: 3.99}}, int32(3)},
+
+		// $toDouble
+		{"toDouble_int", bson.D{{Key: "$toDouble", Value: "$n"}}, float64(42)},
+		{"toDouble_string", bson.D{{Key: "$toDouble", Value: "$s"}}, float64(100)},
+		{"toDouble_double", bson.D{{Key: "$toDouble", Value: "$f"}}, 3.14},
+
+		// $toLong
+		{"toLong_int", bson.D{{Key: "$toLong", Value: "$n"}}, int64(42)},
+		{"toLong_string", bson.D{{Key: "$toLong", Value: "$s"}}, int64(100)},
+		{"toLong_double", bson.D{{Key: "$toLong", Value: "$f"}}, int64(3)},
+
+		// $toBool
+		{"toBool_true", bson.D{{Key: "$toBool", Value: "$b"}}, true},
+		{"toBool_int_nonzero", bson.D{{Key: "$toBool", Value: "$n"}}, true},
+		{"toBool_int_zero", bson.D{{Key: "$toBool", Value: "$zero"}}, false},
+		{"toBool_string_nonempty", bson.D{{Key: "$toBool", Value: "$s"}}, true},
+		{"toBool_string_empty", bson.D{{Key: "$toBool", Value: "$empty"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evalExprHelper(t, tt.expr, doc)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v (%T), want %v (%T)", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestExprTypeConversion_Null(t *testing.T) {
+	doc := makeDoc(t, bson.D{{Key: "x", Value: nil}})
+
+	// $toString on null should return nil (not error)
+	got := evalExprHelper(t, bson.D{{Key: "$toString", Value: "$x"}}, doc)
+	if got != nil {
+		t.Errorf("$toString nil: got %v, want nil", got)
+	}
+}
+
+func TestExprTypeConversion_InvalidString(t *testing.T) {
+	doc := makeDoc(t, bson.D{{Key: "s", Value: "not_a_number"}})
+
+	// $toInt on non-numeric string should error
+	_, err := EvalExpr(bson.D{{Key: "$toInt", Value: "$s"}}, doc)
+	if err == nil {
+		t.Error("$toInt non-numeric: expected error, got nil")
+	}
+
+	// $toDouble on non-numeric string should error
+	_, err = EvalExpr(bson.D{{Key: "$toDouble", Value: "$s"}}, doc)
+	if err == nil {
+		t.Error("$toDouble non-numeric: expected error, got nil")
+	}
+}
+
+func TestExprToObjectId(t *testing.T) {
+	oid := bson.NewObjectID()
+	doc := makeDoc(t, bson.D{{Key: "hex", Value: oid.Hex()}, {Key: "oid", Value: oid}})
+
+	// from hex string
+	got := evalExprHelper(t, bson.D{{Key: "$toObjectId", Value: "$hex"}}, doc)
+	if got != oid {
+		t.Errorf("from hex: got %v, want %v", got, oid)
+	}
+
+	// passthrough
+	got = evalExprHelper(t, bson.D{{Key: "$toObjectId", Value: "$oid"}}, doc)
+	if got != oid {
+		t.Errorf("passthrough: got %v, want %v", got, oid)
+	}
+
+	// invalid hex
+	badDoc := makeDoc(t, bson.D{{Key: "s", Value: "not_a_hex"}})
+	_, err := EvalExpr(bson.D{{Key: "$toObjectId", Value: "$s"}}, badDoc)
+	if err == nil {
+		t.Error("$toObjectId invalid hex: expected error, got nil")
+	}
+}
+
+// ─── Comparison expression operators ─────────────────────────────────────────
+
+func TestExprComparison(t *testing.T) {
+	doc := makeDoc(t, bson.D{
+		{Key: "a", Value: int32(10)},
+		{Key: "b", Value: int32(20)},
+		{Key: "c", Value: int32(10)},
+		{Key: "s1", Value: "abc"},
+		{Key: "s2", Value: "xyz"},
+	})
+
+	tests := []struct {
+		name string
+		expr interface{}
+		want interface{}
+	}{
+		// $cmp
+		{"cmp_less", bson.D{{Key: "$cmp", Value: bson.A{"$a", "$b"}}}, int32(-1)},
+		{"cmp_greater", bson.D{{Key: "$cmp", Value: bson.A{"$b", "$a"}}}, int32(1)},
+		{"cmp_equal", bson.D{{Key: "$cmp", Value: bson.A{"$a", "$c"}}}, int32(0)},
+		{"cmp_strings", bson.D{{Key: "$cmp", Value: bson.A{"$s1", "$s2"}}}, int32(-1)},
+
+		// $eq
+		{"eq_true", bson.D{{Key: "$eq", Value: bson.A{"$a", "$c"}}}, true},
+		{"eq_false", bson.D{{Key: "$eq", Value: bson.A{"$a", "$b"}}}, false},
+
+		// $ne
+		{"ne_true", bson.D{{Key: "$ne", Value: bson.A{"$a", "$b"}}}, true},
+		{"ne_false", bson.D{{Key: "$ne", Value: bson.A{"$a", "$c"}}}, false},
+
+		// $gt
+		{"gt_true", bson.D{{Key: "$gt", Value: bson.A{"$b", "$a"}}}, true},
+		{"gt_false_eq", bson.D{{Key: "$gt", Value: bson.A{"$a", "$c"}}}, false},
+		{"gt_false_less", bson.D{{Key: "$gt", Value: bson.A{"$a", "$b"}}}, false},
+
+		// $gte
+		{"gte_greater", bson.D{{Key: "$gte", Value: bson.A{"$b", "$a"}}}, true},
+		{"gte_equal", bson.D{{Key: "$gte", Value: bson.A{"$a", "$c"}}}, true},
+		{"gte_less", bson.D{{Key: "$gte", Value: bson.A{"$a", "$b"}}}, false},
+
+		// $lt
+		{"lt_true", bson.D{{Key: "$lt", Value: bson.A{"$a", "$b"}}}, true},
+		{"lt_false_eq", bson.D{{Key: "$lt", Value: bson.A{"$a", "$c"}}}, false},
+		{"lt_false_greater", bson.D{{Key: "$lt", Value: bson.A{"$b", "$a"}}}, false},
+
+		// $lte
+		{"lte_less", bson.D{{Key: "$lte", Value: bson.A{"$a", "$b"}}}, true},
+		{"lte_equal", bson.D{{Key: "$lte", Value: bson.A{"$a", "$c"}}}, true},
+		{"lte_greater", bson.D{{Key: "$lte", Value: bson.A{"$b", "$a"}}}, false},
+
+		// null comparisons
+		{"eq_null", bson.D{{Key: "$eq", Value: bson.A{nil, nil}}}, true},
+		{"ne_null_vs_int", bson.D{{Key: "$ne", Value: bson.A{nil, "$a"}}}, true},
+
+		// cross-type: string vs string
+		{"lt_strings", bson.D{{Key: "$lt", Value: bson.A{"$s1", "$s2"}}}, true},
+		{"gt_strings", bson.D{{Key: "$gt", Value: bson.A{"$s2", "$s1"}}}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evalExprHelper(t, tt.expr, doc)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v (%T), want %v (%T)", got, got, tt.want, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #434

## What
Adds 40+ table-driven unit tests for aggregation expression operators that previously had zero test coverage:

- **String ops**: `$split`, `$ltrim`, `$rtrim`, `$trim`, `$replaceOne`, `$replaceAll` — including nil inputs, custom trim chars, empty separator
- **Regex ops**: `$regexFind`, `$regexMatch` — including captures, no match, case-insensitive, zero capture groups, invalid regex
- **Type conversion**: `$toString`, `$toInt`, `$toDouble`, `$toLong`, `$toBool`, `$toObjectId` — including null inputs, invalid conversions, truncation-not-rounding semantics
- **Comparison ops**: `$cmp`, `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte` — including numeric, string, and null comparisons

## Why
These operators were entirely untested. Tests catch regressions as we continue building out the aggregation pipeline.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#434"]
```

*Posted by the founder agent on behalf of @inder*