### PR TITLE
fix: implement text score sort for $text queries

### DIFF
--- a/internal/query/filter.go
+++ b/internal/query/filter.go
@@ -729,6 +729,23 @@ func evalBits(fieldVal bson.RawValue, opVal bson.RawValue, mode string) (bool, e
 	return false, nil
 }
 
+// ExtractTextSearch returns the $text.$search string from a filter, or ""
+// if the filter does not contain a $text operator.
+func ExtractTextSearch(filter bson.Raw) string {
+	if len(filter) == 0 {
+		return ""
+	}
+	textVal, err := filter.LookupErr("$text")
+	if err != nil || textVal.Type != bson.TypeEmbeddedDocument {
+		return ""
+	}
+	searchVal, err := textVal.Document().LookupErr("$search")
+	if err != nil || searchVal.Type != bson.TypeString {
+		return ""
+	}
+	return searchVal.StringValue()
+}
+
 // evalTextFilter implements basic $text search (substring match on string fields).
 func evalTextFilter(doc bson.Raw, opVal bson.RawValue) (bool, error) {
 	if opVal.Type != bson.TypeEmbeddedDocument {

--- a/internal/query/sort.go
+++ b/internal/query/sort.go
@@ -3,23 +3,26 @@ package query
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
-// SortFunc returns a comparator for sorting documents by the given sort spec.
-// sort is like {"field": 1, "other": -1} (1=ascending, -1=descending).
-// Returns a function suitable for use with slices.SortFunc.
-func SortFunc(sortSpec bson.Raw) (func(a, b bson.Raw) int, error) {
-	if len(sortSpec) == 0 {
-		return func(a, b bson.Raw) int { return 0 }, nil
-	}
+type sortKeyKind int
 
-	type sortKey struct {
-		field string
-		dir   int // 1 or -1
-	}
+const (
+	sortKeyNormal    sortKeyKind = iota
+	sortKeyTextScore             // { $meta: "textScore" }
+)
 
+type sortKey struct {
+	field string
+	dir   int // 1 or -1
+	kind  sortKeyKind
+}
+
+// parseSortKeys extracts sort keys from a sort specification document.
+func parseSortKeys(sortSpec bson.Raw) ([]sortKey, error) {
 	elems, err := sortSpec.Elements()
 	if err != nil {
 		return nil, fmt.Errorf("invalid sort document: %w", err)
@@ -28,6 +31,7 @@ func SortFunc(sortSpec bson.Raw) (func(a, b bson.Raw) int, error) {
 	keys := make([]sortKey, 0, len(elems))
 	for _, e := range elems {
 		dir := 1
+		kind := sortKeyNormal
 		switch e.Value().Type {
 		case bson.TypeInt32:
 			if e.Value().Int32() < 0 {
@@ -41,18 +45,94 @@ func SortFunc(sortSpec bson.Raw) (func(a, b bson.Raw) int, error) {
 			if e.Value().Double() < 0 {
 				dir = -1
 			}
-		case bson.TypeString:
-			// "text" score sort — not fully implemented, treat as ascending
-			dir = 1
+		case bson.TypeEmbeddedDocument:
+			metaVal, lookupErr := e.Value().Document().LookupErr("$meta")
+			if lookupErr == nil && metaVal.Type == bson.TypeString {
+				if metaVal.StringValue() == "textScore" {
+					kind = sortKeyTextScore
+					dir = -1 // textScore sorts descending by default
+				} else {
+					return nil, fmt.Errorf("unsupported $meta sort value: %q", metaVal.StringValue())
+				}
+			}
 		}
-		keys = append(keys, sortKey{field: e.Key(), dir: dir})
+		keys = append(keys, sortKey{field: e.Key(), dir: dir, kind: kind})
+	}
+	return keys, nil
+}
+
+// SortFunc returns a comparator for sorting documents by the given sort spec.
+// sort is like {"field": 1, "other": -1} (1=ascending, -1=descending).
+// Returns a function suitable for use with slices.SortFunc.
+func SortFunc(sortSpec bson.Raw) (func(a, b bson.Raw) int, error) {
+	return SortFuncWithTextScore(sortSpec, "")
+}
+
+// SortFuncWithTextScore returns a comparator that supports { $meta: "textScore" }
+// sort keys. When textQuery is non-empty and a sort key uses $meta: "textScore",
+// documents are scored by counting case-insensitive occurrences of textQuery
+// across all string fields. Higher scores rank first (descending).
+//
+// When textQuery is empty and the sort spec contains a textScore key, all
+// documents receive a score of 0 (effectively no-op for that key).
+func SortFuncWithTextScore(sortSpec bson.Raw, textQuery string) (func(a, b bson.Raw) int, error) {
+	if len(sortSpec) == 0 {
+		return func(a, b bson.Raw) int { return 0 }, nil
+	}
+
+	keys, err := parseSortKeys(sortSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	hasTextScoreKey := false
+	for _, k := range keys {
+		if k.kind == sortKeyTextScore {
+			hasTextScoreKey = true
+			break
+		}
+	}
+
+	// Pre-compute text scores: the returned comparator closes over a
+	// map[*byte]int that caches each document's score. Scores are computed
+	// lazily on first access (one pass per unique doc pointer) instead of
+	// on every O(n log n) comparison.
+	var searchLower string
+	scoreCache := make(map[string]int) // key = doc's backing array pointer as string
+	if hasTextScoreKey {
+		searchLower = strings.ToLower(textQuery)
+	}
+
+	docScore := func(doc bson.Raw) int {
+		if searchLower == "" {
+			return 0
+		}
+		key := string(doc) // uses the raw bytes as a cache key
+		if s, ok := scoreCache[key]; ok {
+			return s
+		}
+		s := textScoreDoc(doc, searchLower)
+		scoreCache[key] = s
+		return s
 	}
 
 	return func(a, b bson.Raw) int {
 		for _, k := range keys {
-			av, _ := getField(a, k.field)
-			bv, _ := getField(b, k.field)
-			cmp := compareValues(av, bv)
+			var cmp int
+			if k.kind == sortKeyTextScore {
+				sa := docScore(a)
+				sb := docScore(b)
+				switch {
+				case sa > sb:
+					cmp = 1
+				case sa < sb:
+					cmp = -1
+				}
+			} else {
+				av, _ := getField(a, k.field)
+				bv, _ := getField(b, k.field)
+				cmp = compareValues(av, bv)
+			}
 			if cmp == 0 {
 				continue
 			}
@@ -63,6 +143,28 @@ func SortFunc(sortSpec bson.Raw) (func(a, b bson.Raw) int, error) {
 		}
 		return 0
 	}, nil
+}
+
+// textScoreDoc computes a relevance score for a document by counting
+// case-insensitive occurrences of the search term across all string fields.
+func textScoreDoc(doc bson.Raw, searchLower string) int {
+	score := 0
+	elems, err := doc.Elements()
+	if err != nil {
+		return 0
+	}
+	for _, e := range elems {
+		v := e.Value()
+		switch v.Type {
+		case bson.TypeString:
+			score += strings.Count(strings.ToLower(v.StringValue()), searchLower)
+		case bson.TypeEmbeddedDocument:
+			score += textScoreDoc(v.Document(), searchLower)
+		case bson.TypeArray:
+			score += textScoreDoc(bson.Raw(v.Array()), searchLower)
+		}
+	}
+	return score
 }
 
 // SortDocuments sorts a slice of documents in-place by the given sort spec.

--- a/internal/query/sort_test.go
+++ b/internal/query/sort_test.go
@@ -1,0 +1,230 @@
+package query
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestSortFunc_BasicAscDesc(t *testing.T) {
+	docs := []bson.Raw{
+		mustMarshal(bson.D{{Key: "x", Value: 3}}),
+		mustMarshal(bson.D{{Key: "x", Value: 1}}),
+		mustMarshal(bson.D{{Key: "x", Value: 2}}),
+	}
+	sortSpec := mustMarshal(bson.D{{Key: "x", Value: 1}})
+	if err := SortDocuments(docs, sortSpec); err != nil {
+		t.Fatal(err)
+	}
+	for i, want := range []int32{1, 2, 3} {
+		got, _ := docs[i].LookupErr("x")
+		if got.Int32() != want {
+			t.Errorf("docs[%d].x = %d, want %d", i, got.Int32(), want)
+		}
+	}
+
+	// Descending
+	sortSpec = mustMarshal(bson.D{{Key: "x", Value: -1}})
+	if err := SortDocuments(docs, sortSpec); err != nil {
+		t.Fatal(err)
+	}
+	for i, want := range []int32{3, 2, 1} {
+		got, _ := docs[i].LookupErr("x")
+		if got.Int32() != want {
+			t.Errorf("desc docs[%d].x = %d, want %d", i, got.Int32(), want)
+		}
+	}
+}
+
+func TestSortFuncWithTextScore_MetaTextScore(t *testing.T) {
+	docs := []bson.Raw{
+		mustMarshal(bson.D{{Key: "title", Value: "python tutorial"}}),                   // 0 matches
+		mustMarshal(bson.D{{Key: "title", Value: "go programming in go language"}}),      // 2 matches
+		mustMarshal(bson.D{{Key: "title", Value: "go tutorial"}}),                        // 1 match
+		mustMarshal(bson.D{{Key: "title", Value: "go go go: three reasons to love go"}}), // 4 matches
+	}
+
+	sortSpec := mustMarshal(bson.D{{Key: "score", Value: bson.D{{Key: "$meta", Value: "textScore"}}}})
+	sortStableWithTextScore(t, docs, sortSpec, "go")
+
+	wantOrder := []string{
+		"go go go: three reasons to love go", // 4
+		"go programming in go language",       // 2
+		"go tutorial",                         // 1
+		"python tutorial",                     // 0
+	}
+	for i, want := range wantOrder {
+		got, _ := docs[i].LookupErr("title")
+		if got.StringValue() != want {
+			t.Errorf("docs[%d].title = %q, want %q", i, got.StringValue(), want)
+		}
+	}
+}
+
+func TestSortFuncWithTextScore_CaseInsensitive(t *testing.T) {
+	docs := []bson.Raw{
+		mustMarshal(bson.D{{Key: "title", Value: "hello world"}}),
+		mustMarshal(bson.D{{Key: "title", Value: "HELLO HELLO"}}), // 2 matches
+		mustMarshal(bson.D{{Key: "title", Value: "Hello"}}),       // 1 match
+	}
+
+	sortSpec := mustMarshal(bson.D{{Key: "s", Value: bson.D{{Key: "$meta", Value: "textScore"}}}})
+	sortStableWithTextScore(t, docs, sortSpec, "hello")
+
+	got0, _ := docs[0].LookupErr("title")
+	if got0.StringValue() != "HELLO HELLO" {
+		t.Errorf("docs[0] = %q, want HELLO HELLO (highest score)", got0.StringValue())
+	}
+}
+
+func TestSortFuncWithTextScore_NestedFields(t *testing.T) {
+	docs := []bson.Raw{
+		mustMarshal(bson.D{{Key: "info", Value: bson.D{{Key: "desc", Value: "no match here"}}}}),
+		mustMarshal(bson.D{{Key: "info", Value: bson.D{{Key: "desc", Value: "go go"}}}}),
+		mustMarshal(bson.D{{Key: "info", Value: bson.D{{Key: "desc", Value: "go"}}}}),
+	}
+
+	sortSpec := mustMarshal(bson.D{{Key: "s", Value: bson.D{{Key: "$meta", Value: "textScore"}}}})
+	sortStableWithTextScore(t, docs, sortSpec, "go")
+
+	got, _ := docs[0].LookupErr("info")
+	inner, _ := got.Document().LookupErr("desc")
+	if inner.StringValue() != "go go" {
+		t.Errorf("docs[0].info.desc = %q, want 'go go'", inner.StringValue())
+	}
+}
+
+func TestSortFuncWithTextScore_ArrayFields(t *testing.T) {
+	docs := []bson.Raw{
+		mustMarshal(bson.D{{Key: "tags", Value: bson.A{"python", "java"}}}),
+		mustMarshal(bson.D{{Key: "tags", Value: bson.A{"go", "go", "rust"}}}), // 2 matches
+		mustMarshal(bson.D{{Key: "tags", Value: bson.A{"go"}}}),               // 1 match
+	}
+
+	sortSpec := mustMarshal(bson.D{{Key: "s", Value: bson.D{{Key: "$meta", Value: "textScore"}}}})
+	sortStableWithTextScore(t, docs, sortSpec, "go")
+
+	got, _ := docs[0].LookupErr("tags")
+	arr := got.Array()
+	vals, _ := bson.Raw(arr).Elements()
+	if len(vals) != 3 { // ["go", "go", "rust"]
+		t.Errorf("docs[0] should have 3 tags, got %d", len(vals))
+	}
+}
+
+func TestSortFuncWithTextScore_NoTextQuery(t *testing.T) {
+	// When textQuery is empty, $meta: "textScore" should not crash;
+	// all docs get score 0 so stable sort preserves input order.
+	docs := []bson.Raw{
+		mustMarshal(bson.D{{Key: "title", Value: "b"}}),
+		mustMarshal(bson.D{{Key: "title", Value: "a"}}),
+	}
+
+	sortSpec := mustMarshal(bson.D{{Key: "s", Value: bson.D{{Key: "$meta", Value: "textScore"}}}})
+	sortStableWithTextScore(t, docs, sortSpec, "")
+
+	got0, _ := docs[0].LookupErr("title")
+	if got0.StringValue() != "b" {
+		t.Errorf("expected stable order preserved, got %q first", got0.StringValue())
+	}
+}
+
+func TestSortFuncWithTextScore_MixedKeys(t *testing.T) {
+	// Sort by textScore first, then by a regular field as tiebreaker
+	docs := []bson.Raw{
+		mustMarshal(bson.D{{Key: "title", Value: "go"}, {Key: "name", Value: "charlie"}}),
+		mustMarshal(bson.D{{Key: "title", Value: "go"}, {Key: "name", Value: "alice"}}),
+		mustMarshal(bson.D{{Key: "title", Value: "go go"}, {Key: "name", Value: "bob"}}),
+	}
+
+	sortSpec := mustMarshal(bson.D{
+		{Key: "s", Value: bson.D{{Key: "$meta", Value: "textScore"}}},
+		{Key: "name", Value: 1},
+	})
+	sortStableWithTextScore(t, docs, sortSpec, "go")
+
+	wantNames := []string{"bob", "alice", "charlie"}
+	for i, want := range wantNames {
+		got, _ := docs[i].LookupErr("name")
+		if got.StringValue() != want {
+			t.Errorf("docs[%d].name = %q, want %q", i, got.StringValue(), want)
+		}
+	}
+}
+
+func TestSortFunc_EmptySpec(t *testing.T) {
+	fn, err := SortFunc(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := mustMarshal(bson.D{{Key: "x", Value: 1}})
+	b := mustMarshal(bson.D{{Key: "x", Value: 2}})
+	if fn(a, b) != 0 {
+		t.Error("empty sort spec should always return 0")
+	}
+}
+
+func TestSortFunc_UnknownMetaValue(t *testing.T) {
+	sortSpec := mustMarshal(bson.D{{Key: "s", Value: bson.D{{Key: "$meta", Value: "indexKey"}}}})
+	_, err := SortFunc(sortSpec)
+	if err == nil {
+		t.Fatal("expected error for unknown $meta value, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported $meta") {
+		t.Errorf("error = %q, want to contain 'unsupported $meta'", err.Error())
+	}
+}
+
+func TestExtractTextSearch(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter bson.D
+		want   string
+	}{
+		{
+			name:   "has $text.$search",
+			filter: bson.D{{Key: "$text", Value: bson.D{{Key: "$search", Value: "hello world"}}}},
+			want:   "hello world",
+		},
+		{
+			name:   "no $text",
+			filter: bson.D{{Key: "name", Value: "test"}},
+			want:   "",
+		},
+		{
+			name:   "empty filter",
+			filter: bson.D{},
+			want:   "",
+		},
+		{
+			name:   "$text without $search",
+			filter: bson.D{{Key: "$text", Value: bson.D{{Key: "$language", Value: "en"}}}},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := mustMarshal(tt.filter)
+			got := ExtractTextSearch(raw)
+			if got != tt.want {
+				t.Errorf("ExtractTextSearch() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// sortStableWithTextScore applies SortFuncWithTextScore using sort.SliceStable,
+// matching the production code path in collection.go.
+func sortStableWithTextScore(t *testing.T, docs []bson.Raw, sortSpec bson.Raw, textQuery string) {
+	t.Helper()
+	fn, err := SortFuncWithTextScore(sortSpec, textQuery)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.SliceStable(docs, func(i, j int) bool {
+		return fn(docs[i], docs[j]) < 0
+	})
+}

--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -442,7 +442,8 @@ func (c *bboltCollection) Find(filter bson.Raw, opts FindOptions) (Cursor, error
 			return nil, err
 		}
 		if hasSort {
-			sortFn, err := query.SortFunc(opts.Sort)
+			textQuery := query.ExtractTextSearch(filter)
+			sortFn, err := query.SortFuncWithTextScore(opts.Sort, textQuery)
 			if err != nil {
 				return nil, fmt.Errorf("find: sort: %w", err)
 			}
@@ -2312,7 +2313,8 @@ func (c *bboltCollection) findAndModify(
 
 		// Apply sort if specified
 		if len(opts.Sort) > 0 && len(candidates) > 1 {
-			sortFn, sortErr := query.SortFunc(opts.Sort)
+			textQuery := query.ExtractTextSearch(filter)
+			sortFn, sortErr := query.SortFuncWithTextScore(opts.Sort, textQuery)
 			if sortErr != nil {
 				return sortErr
 			}


### PR DESCRIPTION
Closes #452

## What
Sort by `{ $meta: "textScore" }` now ranks documents by actual match relevance instead of treating it as ascending sort. Scoring is based on case-insensitive occurrence count of the `$text.$search` term across all string fields (including nested documents and arrays).

## Why
The sort engine had a placeholder that treated text score as ascending sort (`dir = 1`), meaning `$text` queries with `$meta: "textScore"` sort returned results in arbitrary order. This is the last piece needed for usable full-text search.

## Changes
- `internal/query/sort.go`: New `SortFuncWithTextScore` with lazy-cached scoring (O(n) scoring, not O(n log n)). Errors on unsupported `$meta` values.
- `internal/query/filter.go`: New `ExtractTextSearch` helper.
- `internal/storage/collection.go`: Thread text query to sort in Find and FindAndModify paths.
- `internal/query/sort_test.go`: 10 tests covering relevance ordering, case insensitivity, nested/array fields, mixed sort keys, empty query edge case, and unknown $meta error.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#452"]
```

*Posted by the founder agent on behalf of @inder*