### PR TITLE
feat: implement SIGHUP config reload

### DIFF
--- a/cmd/mongod/main.go
+++ b/cmd/mongod/main.go
@@ -76,6 +76,9 @@ Improvements over MongoDB Community:
 	cmd.Flags().IntVar(&cfg.MaxDocSize, "maxDocSize", 16*1024*1024, "Maximum BSON document size in bytes")
 	cmd.Flags().IntVar(&cfg.RequestsPerSec, "rateLimit", 0, "Per-database rate limit (req/s, 0 = unlimited)")
 
+	// Config file (for SIGHUP reload)
+	cmd.Flags().StringVar(&cfg.ConfigFile, "config", "", "Path to YAML config file (enables SIGHUP reload)")
+
 	// Sub-commands
 	cmd.AddCommand(versionCmd(), adminCmd(&cfg))
 
@@ -116,7 +119,12 @@ func run(cfg server.Config) error {
 		for sig := range sigCh {
 			switch sig {
 			case syscall.SIGHUP:
-				log.Info("received SIGHUP — reloading config (not yet implemented)")
+				log.Info("received SIGHUP — reloading config")
+				if err := server.ReloadConfig(cfg.ConfigFile, srv.RuntimeConfig(), log); err != nil {
+					log.Error("config reload failed", zap.Error(err))
+				} else {
+					log.Info("config reload complete")
+				}
 			default:
 				log.Info("received signal, shutting down", zap.String("signal", sig.String()))
 				if err := srv.Shutdown(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,5 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/server/reload.go
+++ b/internal/server/reload.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+
+	"github.com/inder/salvobase/internal/commands"
+)
+
+// configFile mirrors the YAML structure in configs/mongod.yaml, but only the
+// sections that contain reload-safe parameters. Pointer fields distinguish
+// "absent from file" from "explicitly set to zero".
+type configFile struct {
+	Logging struct {
+		Level string `yaml:"level"`
+	} `yaml:"logging"`
+	Limits struct {
+		RequestsPerSecond *int `yaml:"requestsPerSecond"`
+	} `yaml:"limits"`
+}
+
+// ReloadConfig re-reads the config file at path and applies the mutable
+// parameters (logLevel, requestsPerSec) to the RuntimeConfig. Settings that
+// require a restart (ports, data dir, compression, etc.) are silently ignored.
+//
+// If path is empty or the file cannot be read/parsed, ReloadConfig returns an
+// error without modifying any state.
+func ReloadConfig(path string, rc *commands.RuntimeConfig, logger *zap.Logger) error {
+	if path == "" {
+		return fmt.Errorf("no config file specified (use --config)")
+	}
+	if rc == nil {
+		return fmt.Errorf("reload: runtime config is nil")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reload: cannot read %s: %w", path, err)
+	}
+
+	var cf configFile
+	if err := yaml.Unmarshal(data, &cf); err != nil {
+		return fmt.Errorf("reload: cannot parse %s: %w", path, err)
+	}
+
+	// Apply log level if specified.
+	if lvl := cf.Logging.Level; lvl != "" {
+		switch lvl {
+		case "debug", "info", "warn", "error":
+			old := rc.GetLogLevel()
+			if old != lvl {
+				rc.SetLogLevel(lvl)
+				logger.Info("config reload: logLevel changed",
+					zap.String("old", old), zap.String("new", lvl))
+			}
+		default:
+			return fmt.Errorf("reload: invalid logLevel %q; must be one of: debug, info, warn, error", lvl)
+		}
+	}
+
+	// Apply rate limit only if explicitly specified in the file.
+	// Absent key (nil) means "don't change"; explicit 0 means "unlimited".
+	if cf.Limits.RequestsPerSecond != nil {
+		rps := *cf.Limits.RequestsPerSecond
+		if rps < 0 {
+			return fmt.Errorf("reload: requestsPerSecond must be >= 0, got %d", rps)
+		}
+		old := rc.GetRequestsPerSec()
+		if old != rps {
+			rc.SetRequestsPerSec(rps)
+			logger.Info("config reload: requestsPerSec changed",
+				zap.Int("old", old), zap.Int("new", rps))
+		}
+	}
+
+	return nil
+}
+
+// RuntimeConfig returns the server's live RuntimeConfig, allowing callers
+// (such as the SIGHUP handler) to update parameters at runtime.
+func (s *Server) RuntimeConfig() *commands.RuntimeConfig {
+	return s.dispatcher.RuntimeConfig()
+}

--- a/internal/server/reload_test.go
+++ b/internal/server/reload_test.go
@@ -1,0 +1,261 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/inder/salvobase/internal/commands"
+)
+
+func testLogger() *zap.Logger {
+	return zap.Must(zap.NewDevelopment())
+}
+
+func TestReloadConfig_LogLevel(t *testing.T) {
+	rc := commands.NewRuntimeConfig("info", "none", 100, 0, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(path, []byte(`
+logging:
+  level: "debug"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReloadConfig(path, rc, testLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := rc.GetLogLevel(); got != "debug" {
+		t.Errorf("logLevel = %q, want %q", got, "debug")
+	}
+}
+
+func TestReloadConfig_RequestsPerSec(t *testing.T) {
+	rc := commands.NewRuntimeConfig("info", "none", 100, 0, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(path, []byte(`
+limits:
+  requestsPerSecond: 500
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReloadConfig(path, rc, testLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := rc.GetRequestsPerSec(); got != 500 {
+		t.Errorf("requestsPerSec = %d, want 500", got)
+	}
+}
+
+func TestReloadConfig_BothParams(t *testing.T) {
+	rc := commands.NewRuntimeConfig("info", "none", 100, 0, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(path, []byte(`
+logging:
+  level: "warn"
+limits:
+  requestsPerSecond: 1000
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReloadConfig(path, rc, testLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := rc.GetLogLevel(); got != "warn" {
+		t.Errorf("logLevel = %q, want %q", got, "warn")
+	}
+	if got := rc.GetRequestsPerSec(); got != 1000 {
+		t.Errorf("requestsPerSec = %d, want 1000", got)
+	}
+}
+
+func TestReloadConfig_InvalidLogLevel(t *testing.T) {
+	rc := commands.NewRuntimeConfig("info", "none", 100, 0, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(path, []byte(`
+logging:
+  level: "banana"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ReloadConfig(path, rc, testLogger())
+	if err == nil {
+		t.Fatal("expected error for invalid logLevel, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid logLevel") {
+		t.Errorf("error = %q, want it to mention 'invalid logLevel'", err)
+	}
+
+	// Original value must be unchanged.
+	if got := rc.GetLogLevel(); got != "info" {
+		t.Errorf("logLevel = %q, want %q (unchanged)", got, "info")
+	}
+}
+
+func TestReloadConfig_MissingFile(t *testing.T) {
+	rc := commands.NewRuntimeConfig("info", "none", 100, 0, true)
+	err := ReloadConfig("/nonexistent/config.yaml", rc, testLogger())
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestReloadConfig_MalformedYAML(t *testing.T) {
+	rc := commands.NewRuntimeConfig("info", "none", 100, 0, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(path, []byte(`{{{not yaml`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ReloadConfig(path, rc, testLogger())
+	if err == nil {
+		t.Fatal("expected error for malformed YAML, got nil")
+	}
+
+	// Original values should be unchanged.
+	if got := rc.GetLogLevel(); got != "info" {
+		t.Errorf("logLevel = %q, want %q (unchanged after bad parse)", got, "info")
+	}
+}
+
+func TestReloadConfig_EmptyPath(t *testing.T) {
+	rc := commands.NewRuntimeConfig("info", "none", 100, 0, true)
+	err := ReloadConfig("", rc, testLogger())
+	if err == nil {
+		t.Fatal("expected error for empty path, got nil")
+	}
+}
+
+func TestReloadConfig_NilRuntimeConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(path, []byte(`
+logging:
+  level: "debug"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ReloadConfig(path, nil, testLogger())
+	if err == nil {
+		t.Fatal("expected error for nil RuntimeConfig, got nil")
+	}
+}
+
+func TestReloadConfig_NoChange(t *testing.T) {
+	rc := commands.NewRuntimeConfig("info", "none", 100, 0, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Same values as initial — should succeed with no changes.
+	if err := os.WriteFile(path, []byte(`
+logging:
+  level: "info"
+limits:
+  requestsPerSecond: 0
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReloadConfig(path, rc, testLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := rc.GetLogLevel(); got != "info" {
+		t.Errorf("logLevel = %q, want %q", got, "info")
+	}
+	if got := rc.GetRequestsPerSec(); got != 0 {
+		t.Errorf("requestsPerSec = %d, want 0", got)
+	}
+}
+
+func TestReloadConfig_PartialYAML_PreservesOmittedFields(t *testing.T) {
+	rc := commands.NewRuntimeConfig("info", "none", 100, 50, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Only logging section — requestsPerSec should remain at 50 (not reset).
+	if err := os.WriteFile(path, []byte(`
+logging:
+  level: "error"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReloadConfig(path, rc, testLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := rc.GetLogLevel(); got != "error" {
+		t.Errorf("logLevel = %q, want %q", got, "error")
+	}
+	// Key was absent from YAML — must not be touched.
+	if got := rc.GetRequestsPerSec(); got != 50 {
+		t.Errorf("requestsPerSec = %d, want 50 (preserved when absent from file)", got)
+	}
+}
+
+func TestReloadConfig_ExplicitZeroRateLimit(t *testing.T) {
+	rc := commands.NewRuntimeConfig("info", "none", 100, 500, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Explicitly set to 0 (unlimited) — should apply.
+	if err := os.WriteFile(path, []byte(`
+limits:
+  requestsPerSecond: 0
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReloadConfig(path, rc, testLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := rc.GetRequestsPerSec(); got != 0 {
+		t.Errorf("requestsPerSec = %d, want 0 (explicitly set to unlimited)", got)
+	}
+}
+
+func TestReloadConfig_NegativeRateLimit(t *testing.T) {
+	rc := commands.NewRuntimeConfig("info", "none", 100, 50, true)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	if err := os.WriteFile(path, []byte(`
+limits:
+  requestsPerSecond: -1
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ReloadConfig(path, rc, testLogger())
+	if err == nil {
+		t.Fatal("expected error for negative rate limit, got nil")
+	}
+
+	// Original value must be unchanged.
+	if got := rc.GetRequestsPerSec(); got != 50 {
+		t.Errorf("requestsPerSec = %d, want 50 (unchanged)", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,6 +38,7 @@ type Config struct {
 	TLSKey         string
 	Version        string
 	BuildTime      string
+	ConfigFile     string // Path to YAML config file (for SIGHUP reload)
 }
 
 // Server is the main Salvobase server.


### PR DESCRIPTION
Closes #451

## What
- Added `--config` flag for specifying a YAML config file path
- SIGHUP signal now re-reads the config file and applies mutable parameters
- Mutable: `logLevel`, `requestsPerSecond`
- Immutable (silently ignored on reload): ports, data dir, compression, TLS, etc.
- Absent keys in partial YAML files are preserved (not reset to zero)
- Invalid values return errors; malformed/missing files leave state untouched

## Why
Advertised feature that was stubbed. Enables runtime tuning without restart — critical for production ops.

## Tests
12 unit tests covering:
- Happy path (single param, both params, no-change)
- Partial YAML preserves omitted fields
- Explicit zero vs absent (pointer-based distinction)
- Invalid log level returns error
- Negative rate limit returns error
- Malformed YAML, missing file, empty path, nil RuntimeConfig

## Known limitation
`logLevel` reload updates RuntimeConfig (what `getParameter` reports) but does not change the live zap logger's AtomicLevel. This is a pre-existing gap shared with `setParameter` — tracked separately.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#451"]
```

*Posted by the founder agent on behalf of @inder*