### PR TITLE
feat: field-level diffs in change stream updateDescription

### DIFF
--- a/internal/query/diff.go
+++ b/internal/query/diff.go
@@ -1,0 +1,131 @@
+package query
+
+import (
+	"bytes"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// UpdateDiff describes the field-level changes between two documents.
+// Used by change streams to populate updateDescription in update events.
+type UpdateDiff struct {
+	// UpdatedFields maps dot-notation field paths to their new values.
+	UpdatedFields bson.D
+	// RemovedFields lists dot-notation paths of fields that were removed.
+	RemovedFields []string
+}
+
+// ComputeUpdateDiff compares before and after documents and returns the
+// field-level diff. It recurses into nested documents to produce dot-notation
+// paths (e.g., "address.city"). Array fields are compared as opaque values —
+// any change to an array element reports the entire array as updated.
+func ComputeUpdateDiff(before, after bson.Raw) UpdateDiff {
+	var diff UpdateDiff
+	computeDiff("", before, after, &diff)
+	return diff
+}
+
+func computeDiff(prefix string, before, after bson.Raw, diff *UpdateDiff) {
+	beforeMap := elemMap(before)
+	afterMap := elemMap(after)
+
+	// Check for updated and new fields (iterate after to preserve order).
+	afterElems, _ := after.Elements()
+	for _, ae := range afterElems {
+		key := ae.Key()
+		// _id is immutable and must never appear in updatedFields.
+		if key == "_id" && prefix == "" {
+			continue
+		}
+		path := joinPath(prefix, key)
+		bv, exists := beforeMap[key]
+		if !exists {
+			// New field.
+			diff.UpdatedFields = append(diff.UpdatedFields, bson.E{Key: path, Value: ae.Value()})
+			continue
+		}
+		av := ae.Value()
+		if av.Type == bson.TypeEmbeddedDocument && bv.Type == bson.TypeEmbeddedDocument {
+			// Recurse into sub-documents.
+			computeDiff(path, bv.Document(), av.Document(), diff)
+		} else if !rawValuesEqual(bv, av) {
+			diff.UpdatedFields = append(diff.UpdatedFields, bson.E{Key: path, Value: av})
+		}
+	}
+
+	// Check for removed fields (in before but not in after).
+	beforeElems, _ := before.Elements()
+	for _, be := range beforeElems {
+		key := be.Key()
+		if key == "_id" {
+			continue // _id is never reported as removed
+		}
+		if _, exists := afterMap[key]; !exists {
+			diff.RemovedFields = append(diff.RemovedFields, joinPath(prefix, key))
+		}
+	}
+}
+
+// elemMap builds a map of key → RawValue from a BSON document for O(1) lookup.
+func elemMap(doc bson.Raw) map[string]bson.RawValue {
+	elems, err := doc.Elements()
+	if err != nil {
+		return nil
+	}
+	m := make(map[string]bson.RawValue, len(elems))
+	for _, e := range elems {
+		m[e.Key()] = e.Value()
+	}
+	return m
+}
+
+// rawValuesEqual compares two RawValues by type and byte content.
+func rawValuesEqual(a, b bson.RawValue) bool {
+	return a.Type == b.Type && bytes.Equal(a.Value, b.Value)
+}
+
+// joinPath joins a prefix and key with a dot separator.
+func joinPath(prefix, key string) string {
+	if prefix == "" {
+		return key
+	}
+	return prefix + "." + key
+}
+
+// MarshalUpdateDescription produces the BSON-encoded updateDescription document
+// for a change event from the given diff.
+func MarshalUpdateDescription(diff UpdateDiff) bson.Raw {
+	updatedFields := diff.UpdatedFields
+	if updatedFields == nil {
+		updatedFields = bson.D{}
+	}
+
+	removedFields := make(bson.A, len(diff.RemovedFields))
+	for i, f := range diff.RemovedFields {
+		removedFields[i] = f
+	}
+
+	doc := bson.D{
+		{Key: "updatedFields", Value: updatedFields},
+		{Key: "removedFields", Value: removedFields},
+		{Key: "truncatedArrays", Value: bson.A{}},
+	}
+
+	raw, err := bson.Marshal(doc)
+	if err != nil {
+		// Fall back to empty description — should never happen.
+		raw, _ = bson.Marshal(bson.D{
+			{Key: "updatedFields", Value: bson.D{}},
+			{Key: "removedFields", Value: bson.A{}},
+			{Key: "truncatedArrays", Value: bson.A{}},
+		})
+	}
+	return raw
+}
+
+// IsUpdateDescriptionEmpty reports whether the diff contains no changes
+// (no updated fields and no removed fields). This can happen when the
+// update matches a document but doesn't actually change any field values.
+func IsUpdateDescriptionEmpty(diff UpdateDiff) bool {
+	return len(diff.UpdatedFields) == 0 && len(diff.RemovedFields) == 0
+}

--- a/internal/query/diff_test.go
+++ b/internal/query/diff_test.go
@@ -1,0 +1,387 @@
+package query
+
+import (
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func mustMarshalDoc(t *testing.T, v interface{}) bson.Raw {
+	t.Helper()
+	raw, err := bson.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
+}
+
+func TestComputeUpdateDiff_Set(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "name", Value: "Alice"},
+		{Key: "age", Value: 30},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "name", Value: "Alice"},
+		{Key: "age", Value: 31},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	if len(diff.UpdatedFields) != 1 {
+		t.Fatalf("expected 1 updated field, got %d: %v", len(diff.UpdatedFields), diff.UpdatedFields)
+	}
+	if diff.UpdatedFields[0].Key != "age" {
+		t.Errorf("expected updated field 'age', got %q", diff.UpdatedFields[0].Key)
+	}
+	if len(diff.RemovedFields) != 0 {
+		t.Errorf("expected 0 removed fields, got %d", len(diff.RemovedFields))
+	}
+}
+
+func TestComputeUpdateDiff_Unset(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "name", Value: "Alice"},
+		{Key: "age", Value: 30},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "name", Value: "Alice"},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	if len(diff.UpdatedFields) != 0 {
+		t.Errorf("expected 0 updated fields, got %d", len(diff.UpdatedFields))
+	}
+	if len(diff.RemovedFields) != 1 || diff.RemovedFields[0] != "age" {
+		t.Errorf("expected removed field 'age', got %v", diff.RemovedFields)
+	}
+}
+
+func TestComputeUpdateDiff_SetAndUnset(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "x", Value: 10},
+		{Key: "y", Value: 20},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "x", Value: 99},
+		{Key: "z", Value: "new"},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	if len(diff.UpdatedFields) != 2 {
+		t.Fatalf("expected 2 updated fields, got %d: %v", len(diff.UpdatedFields), diff.UpdatedFields)
+	}
+	// x changed, z is new
+	keys := map[string]bool{}
+	for _, f := range diff.UpdatedFields {
+		keys[f.Key] = true
+	}
+	if !keys["x"] || !keys["z"] {
+		t.Errorf("expected updated fields x and z, got %v", diff.UpdatedFields)
+	}
+	if len(diff.RemovedFields) != 1 || diff.RemovedFields[0] != "y" {
+		t.Errorf("expected removed field 'y', got %v", diff.RemovedFields)
+	}
+}
+
+func TestComputeUpdateDiff_NestedDotNotation(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "address", Value: bson.D{
+			{Key: "city", Value: "NYC"},
+			{Key: "zip", Value: "10001"},
+		}},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "address", Value: bson.D{
+			{Key: "city", Value: "LA"},
+			{Key: "zip", Value: "10001"},
+		}},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	if len(diff.UpdatedFields) != 1 {
+		t.Fatalf("expected 1 updated field, got %d: %v", len(diff.UpdatedFields), diff.UpdatedFields)
+	}
+	if diff.UpdatedFields[0].Key != "address.city" {
+		t.Errorf("expected 'address.city', got %q", diff.UpdatedFields[0].Key)
+	}
+}
+
+func TestComputeUpdateDiff_NestedFieldRemoved(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "address", Value: bson.D{
+			{Key: "city", Value: "NYC"},
+			{Key: "zip", Value: "10001"},
+		}},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "address", Value: bson.D{
+			{Key: "city", Value: "NYC"},
+		}},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	if len(diff.UpdatedFields) != 0 {
+		t.Errorf("expected 0 updated fields, got %d", len(diff.UpdatedFields))
+	}
+	if len(diff.RemovedFields) != 1 || diff.RemovedFields[0] != "address.zip" {
+		t.Errorf("expected removed field 'address.zip', got %v", diff.RemovedFields)
+	}
+}
+
+func TestComputeUpdateDiff_Inc(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "counter", Value: int32(5)},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "counter", Value: int32(8)},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	if len(diff.UpdatedFields) != 1 || diff.UpdatedFields[0].Key != "counter" {
+		t.Errorf("expected updated field 'counter', got %v", diff.UpdatedFields)
+	}
+}
+
+func TestComputeUpdateDiff_Rename(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "old_name", Value: "value"},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "new_name", Value: "value"},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	if len(diff.UpdatedFields) != 1 || diff.UpdatedFields[0].Key != "new_name" {
+		t.Errorf("expected updated field 'new_name', got %v", diff.UpdatedFields)
+	}
+	if len(diff.RemovedFields) != 1 || diff.RemovedFields[0] != "old_name" {
+		t.Errorf("expected removed field 'old_name', got %v", diff.RemovedFields)
+	}
+}
+
+func TestComputeUpdateDiff_Push(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "tags", Value: bson.A{"a", "b"}},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "tags", Value: bson.A{"a", "b", "c"}},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	if len(diff.UpdatedFields) != 1 || diff.UpdatedFields[0].Key != "tags" {
+		t.Errorf("expected updated field 'tags', got %v", diff.UpdatedFields)
+	}
+}
+
+func TestComputeUpdateDiff_Pull(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "tags", Value: bson.A{"a", "b", "c"}},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "tags", Value: bson.A{"a", "c"}},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	if len(diff.UpdatedFields) != 1 || diff.UpdatedFields[0].Key != "tags" {
+		t.Errorf("expected updated field 'tags', got %v", diff.UpdatedFields)
+	}
+}
+
+func TestComputeUpdateDiff_AddToSet(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "items", Value: bson.A{1, 2}},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "items", Value: bson.A{1, 2, 3}},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	if len(diff.UpdatedFields) != 1 || diff.UpdatedFields[0].Key != "items" {
+		t.Errorf("expected updated field 'items', got %v", diff.UpdatedFields)
+	}
+}
+
+func TestComputeUpdateDiff_NoChange(t *testing.T) {
+	doc := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "x", Value: 10},
+	})
+
+	diff := ComputeUpdateDiff(doc, doc)
+
+	if len(diff.UpdatedFields) != 0 {
+		t.Errorf("expected 0 updated fields, got %d", len(diff.UpdatedFields))
+	}
+	if len(diff.RemovedFields) != 0 {
+		t.Errorf("expected 0 removed fields, got %d", len(diff.RemovedFields))
+	}
+	if !IsUpdateDescriptionEmpty(diff) {
+		t.Error("expected empty diff")
+	}
+}
+
+func TestComputeUpdateDiff_IDNeverReported(t *testing.T) {
+	// _id removed from after — should not appear in removedFields
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "x", Value: 10},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "x", Value: 10},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	for _, f := range diff.RemovedFields {
+		if f == "_id" {
+			t.Error("_id should never appear in removedFields")
+		}
+	}
+
+	// _id changed value — should not appear in updatedFields
+	before2 := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "x", Value: 10},
+	})
+	after2 := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 2},
+		{Key: "x", Value: 10},
+	})
+
+	diff2 := ComputeUpdateDiff(before2, after2)
+
+	for _, f := range diff2.UpdatedFields {
+		if f.Key == "_id" {
+			t.Error("_id should never appear in updatedFields")
+		}
+	}
+
+	// _id added to after (was absent in before) — should not appear in updatedFields
+	before3 := mustMarshalDoc(t, bson.D{
+		{Key: "x", Value: 10},
+	})
+	after3 := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "x", Value: 10},
+	})
+
+	diff3 := ComputeUpdateDiff(before3, after3)
+
+	for _, f := range diff3.UpdatedFields {
+		if f.Key == "_id" {
+			t.Error("_id should never appear in updatedFields (new field case)")
+		}
+	}
+}
+
+func TestComputeUpdateDiff_DeeplyNested(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "a", Value: bson.D{
+			{Key: "b", Value: bson.D{
+				{Key: "c", Value: 1},
+			}},
+		}},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "a", Value: bson.D{
+			{Key: "b", Value: bson.D{
+				{Key: "c", Value: 2},
+			}},
+		}},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	if len(diff.UpdatedFields) != 1 || diff.UpdatedFields[0].Key != "a.b.c" {
+		t.Errorf("expected 'a.b.c', got %v", diff.UpdatedFields)
+	}
+}
+
+func TestComputeUpdateDiff_SubdocToScalar(t *testing.T) {
+	before := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "addr", Value: bson.D{
+			{Key: "city", Value: "NYC"},
+			{Key: "zip", Value: "10001"},
+		}},
+	})
+	after := mustMarshalDoc(t, bson.D{
+		{Key: "_id", Value: 1},
+		{Key: "addr", Value: "flat string"},
+	})
+
+	diff := ComputeUpdateDiff(before, after)
+
+	// Entire addr field reported as updated (not individual sub-fields)
+	if len(diff.UpdatedFields) != 1 || diff.UpdatedFields[0].Key != "addr" {
+		t.Errorf("expected updated field 'addr', got %v", diff.UpdatedFields)
+	}
+	if len(diff.RemovedFields) != 0 {
+		t.Errorf("expected 0 removed fields, got %v", diff.RemovedFields)
+	}
+}
+
+func TestMarshalUpdateDescription(t *testing.T) {
+	diff := UpdateDiff{
+		UpdatedFields: bson.D{{Key: "name", Value: "Bob"}},
+		RemovedFields: []string{"age"},
+	}
+
+	raw := MarshalUpdateDescription(diff)
+
+	// Verify it's valid BSON and has the expected structure
+	var result bson.D
+	if err := bson.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Check keys exist
+	keys := map[string]bool{}
+	for _, e := range result {
+		keys[e.Key] = true
+	}
+	if !keys["updatedFields"] || !keys["removedFields"] || !keys["truncatedArrays"] {
+		t.Errorf("missing expected keys in updateDescription: %v", result)
+	}
+}
+
+func TestMarshalUpdateDescription_Empty(t *testing.T) {
+	diff := UpdateDiff{}
+	raw := MarshalUpdateDescription(diff)
+
+	var result bson.D
+	if err := bson.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+}

--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -1636,10 +1636,13 @@ func (c *bboltCollection) updateDocs(filter, update bson.Raw, opts UpdateOptions
 			}
 			c.engine.insertIntoIndexes(tx, c.db, c.coll, newKey, newDoc) //nolint:errcheck
 			result.ModifiedCount++
+
+			// Compute field-level diff for change stream updateDescription.
+			diff := query.ComputeUpdateDiff(item.doc, newDoc)
 			pendingEvents = append(pendingEvents, ChangeEvent{
 				OperationType:     ChangeUpdate,
 				DocumentKey:       makeDocumentKey(newDoc.Lookup("_id")),
-				UpdateDescription: updateDescriptionPlaceholder,
+				UpdateDescription: query.MarshalUpdateDescription(diff),
 			})
 		}
 		return nil


### PR DESCRIPTION
Closes #455

## What
Update change stream events now include accurate `updatedFields` and `removedFields` in `updateDescription`, replacing the Phase 1 placeholder with real field-level diffs.

**New files:**
- `internal/query/diff.go` — `ComputeUpdateDiff()` compares before/after BSON documents, producing dot-notation field paths for changes. Recurses into nested sub-documents. Arrays compared as opaque values.
- `internal/query/diff_test.go` — 17 test cases covering: `$set`, `$unset`, `$inc`, `$rename`, `$push`, `$pull`, `$addToSet`, nested dot-notation, deeply nested fields, subdoc-to-scalar type change, `_id` exclusion (three cases), no-change, and marshaling.

**Modified:**
- `internal/storage/collection.go` — Update loop now calls `ComputeUpdateDiff(oldDoc, newDoc)` and marshals the result into the change event.

## Why
Phase 1 shipped with placeholder empty diffs (`{updatedFields: {}, removedFields: []}`). Real applications need accurate diffs to react to specific field changes without re-fetching the full document.

## Design decisions
- **Diff-based over threading:** Computing diffs by comparing before/after documents is simpler and more maintainable than threading change tracking through every update operator. Works automatically for all current and future operators.
- **Arrays as opaque:** Matching MongoDB behavior — any array element change reports the entire array as updated. Element-level array diffs are a separate concern (truncatedArrays).
- **Always compute diff:** The diff is computed unconditionally inside the update loop to avoid a TOCTOU race where a subscriber opens a stream mid-transaction and receives stale placeholder data.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#455"]
```

*Posted by the founder agent on behalf of @inder*