### PR TITLE
feat: implement $graphLookup aggregation stage

### DIFF
--- a/internal/aggregation/stages.go
+++ b/internal/aggregation/stages.go
@@ -159,7 +159,11 @@ func buildStage(spec bson.Raw, engine storage.Engine, db string) (Stage, error) 
 		return nil, fmt.Errorf("$geoNear is not implemented")
 
 	case "$graphLookup":
-		return nil, fmt.Errorf("$graphLookup is not implemented")
+		glDoc, ok := stageVal.DocumentOK()
+		if !ok {
+			return nil, fmt.Errorf("$graphLookup requires a document")
+		}
+		return buildGraphLookupStage(glDoc, engine, db)
 
 	case "$search":
 		return nil, fmt.Errorf("$search is not implemented")
@@ -1708,6 +1712,271 @@ func (s *redactStage) redactDoc(doc bson.Raw) (bson.Raw, error) {
 	default:
 		return nil, fmt.Errorf("$redact: expression must evaluate to $$DESCEND, $$PRUNE, or $$KEEP")
 	}
+}
+
+// ─── $graphLookup ─────────────────────────────────────────────────────────────
+
+type graphLookupStage struct {
+	from                  string
+	startWith             bson.RawValue
+	connectFromField      string
+	connectToField        string
+	as                    string
+	maxDepth              int
+	hasMaxDepth           bool
+	depthField            string
+	restrictSearchWithMatch bson.Raw
+	engine                storage.Engine
+	db                    string
+}
+
+func buildGraphLookupStage(spec bson.Raw, engine storage.Engine, db string) (*graphLookupStage, error) {
+	s := &graphLookupStage{engine: engine, db: db, maxDepth: -1}
+
+	elems, err := spec.Elements()
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range elems {
+		switch e.Key() {
+		case "from":
+			if e.Value().Type == bson.TypeString {
+				s.from = e.Value().StringValue()
+			}
+		case "startWith":
+			s.startWith = e.Value()
+		case "connectFromField":
+			if e.Value().Type == bson.TypeString {
+				s.connectFromField = e.Value().StringValue()
+			}
+		case "connectToField":
+			if e.Value().Type == bson.TypeString {
+				s.connectToField = e.Value().StringValue()
+			}
+		case "as":
+			if e.Value().Type == bson.TypeString {
+				s.as = e.Value().StringValue()
+			}
+		case "maxDepth":
+			n, ok := toFloat64Interface(rawValToInterface(e.Value()))
+			if ok {
+				s.maxDepth = int(n)
+				s.hasMaxDepth = true
+			}
+		case "depthField":
+			if e.Value().Type == bson.TypeString {
+				s.depthField = e.Value().StringValue()
+			}
+		case "restrictSearchWithMatch":
+			if e.Value().Type == bson.TypeEmbeddedDocument {
+				s.restrictSearchWithMatch = e.Value().Document()
+			}
+		}
+	}
+
+	if s.from == "" {
+		return nil, fmt.Errorf("$graphLookup requires 'from'")
+	}
+	if s.connectFromField == "" {
+		return nil, fmt.Errorf("$graphLookup requires 'connectFromField'")
+	}
+	if s.connectToField == "" {
+		return nil, fmt.Errorf("$graphLookup requires 'connectToField'")
+	}
+	if s.as == "" {
+		return nil, fmt.Errorf("$graphLookup requires 'as'")
+	}
+	if s.startWith.Type == 0 {
+		return nil, fmt.Errorf("$graphLookup requires 'startWith'")
+	}
+
+	return s, nil
+}
+
+func (s *graphLookupStage) Process(docs []bson.Raw) ([]bson.Raw, error) {
+	if s.engine == nil {
+		return nil, fmt.Errorf("$graphLookup requires a storage engine")
+	}
+
+	coll, err := s.engine.Collection(s.db, s.from)
+	if err != nil {
+		return nil, fmt.Errorf("$graphLookup: cannot open collection %s: %w", s.from, err)
+	}
+
+	// Load all documents from the target collection once.
+	cursor, err := coll.Find(nil, storage.FindOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("$graphLookup: find: %w", err)
+	}
+	var allTargetDocs []bson.Raw
+	for {
+		batch, exhausted, err := cursor.NextBatch(1000)
+		if err != nil {
+			cursor.Close()
+			return nil, fmt.Errorf("$graphLookup: read: %w", err)
+		}
+		allTargetDocs = append(allTargetDocs, batch...)
+		if exhausted {
+			break
+		}
+	}
+	cursor.Close()
+
+	result := make([]bson.Raw, 0, len(docs))
+	for _, doc := range docs {
+		matched, err := s.traverse(doc, allTargetDocs)
+		if err != nil {
+			return nil, err
+		}
+
+		d, err := rawToD(doc)
+		if err != nil {
+			return nil, err
+		}
+		arr := make(bson.A, len(matched))
+		for i, m := range matched {
+			arr[i] = m
+		}
+		d = setFieldD(d, s.as, arr)
+		raw, err := dToRaw(d)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, raw)
+	}
+	return result, nil
+}
+
+// traverse performs BFS from the startWith expression value through the target docs.
+func (s *graphLookupStage) traverse(inputDoc bson.Raw, targetDocs []bson.Raw) ([]bson.Raw, error) {
+	// Evaluate startWith to get initial search value(s)
+	startVal, err := EvalExpr(s.startWith, inputDoc)
+	if err != nil {
+		return nil, fmt.Errorf("$graphLookup startWith: %w", err)
+	}
+
+	// Normalize start values into a slice for uniform handling
+	frontier := normalizeToSlice(startVal)
+	if len(frontier) == 0 {
+		return nil, nil
+	}
+
+	// Track visited documents by serialized _id to prevent cycles
+	visited := make(map[string]bool)
+
+	var results []bson.Raw
+	depth := 0
+
+	for len(frontier) > 0 {
+		if s.hasMaxDepth && depth > s.maxDepth {
+			break
+		}
+
+		var nextFrontier []interface{}
+		for _, searchVal := range frontier {
+			searchRV := interfaceToRawValue(searchVal)
+
+			for _, targetDoc := range targetDocs {
+				connectToVal, found := query.GetField(targetDoc, s.connectToField)
+				if !found {
+					continue
+				}
+
+				if !valuesMatch(searchRV, connectToVal) {
+					continue
+				}
+
+				// Apply restrictSearchWithMatch if present
+				if len(s.restrictSearchWithMatch) > 0 {
+					match, err := query.Filter(targetDoc, s.restrictSearchWithMatch)
+					if err != nil {
+						return nil, err
+					}
+					if !match {
+						continue
+					}
+				}
+
+				// Cycle detection: track by _id for efficiency and correctness
+				idVal, _ := query.GetField(targetDoc, "_id")
+				docKey := string(idVal.Value)
+				if visited[docKey] {
+					continue
+				}
+				visited[docKey] = true
+
+				// Add depth field if requested
+				var resultDoc bson.Raw
+				if s.depthField != "" {
+					d, err := rawToD(targetDoc)
+					if err != nil {
+						return nil, err
+					}
+					d = setFieldD(d, s.depthField, int64(depth))
+					resultDoc, err = dToRaw(d)
+					if err != nil {
+						return nil, err
+					}
+				} else {
+					resultDoc = targetDoc
+				}
+				results = append(results, resultDoc)
+
+				// Extract connectFrom value for next level
+				connectFromVal, found := query.GetField(targetDoc, s.connectFromField)
+				if found {
+					nextFrontier = append(nextFrontier, normalizeToSlice(rawValToInterface(connectFromVal))...)
+				}
+			}
+		}
+		frontier = nextFrontier
+		depth++
+	}
+	return results, nil
+}
+
+// normalizeToSlice converts a value (possibly an array) into a flat slice of values.
+func normalizeToSlice(val interface{}) []interface{} {
+	if val == nil {
+		return nil
+	}
+	switch v := val.(type) {
+	case []interface{}:
+		return v
+	case bson.RawValue:
+		if v.Type == bson.TypeArray {
+			arr, ok := v.ArrayOK()
+			if ok {
+				vals, _ := arr.Values()
+				result := make([]interface{}, len(vals))
+				for i, rv := range vals {
+					result[i] = rawValToInterface(rv)
+				}
+				return result
+			}
+		}
+		return []interface{}{rawValToInterface(v)}
+	default:
+		return []interface{}{val}
+	}
+}
+
+// valuesMatch checks if a search value matches a target connectTo value.
+// The connectTo value may be an array, in which case any element match counts.
+func valuesMatch(search bson.RawValue, target bson.RawValue) bool {
+	if target.Type == bson.TypeArray {
+		arr, ok := target.ArrayOK()
+		if ok {
+			vals, _ := arr.Values()
+			for _, v := range vals {
+				if query.CompareValues(search, v) == 0 {
+					return true
+				}
+			}
+			return false
+		}
+	}
+	return query.CompareValues(search, target) == 0
 }
 
 // ─── $unionWith ───────────────────────────────────────────────────────────────

--- a/internal/aggregation/stages_test.go
+++ b/internal/aggregation/stages_test.go
@@ -1095,3 +1095,385 @@ func TestStageFacetWithGroup(t *testing.T) {
 		}
 	})
 }
+
+// ─── $graphLookup tests ───────────────────────────────────────────────────────
+
+func TestStageGraphLookup(t *testing.T) {
+	// Employee hierarchy: CEO -> VP -> Manager -> Dev
+	employeeDocs := []bson.Raw{
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(1)}, {Key: "name", Value: "CEO"}, {Key: "reportsTo", Value: nil}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(2)}, {Key: "name", Value: "VP"}, {Key: "reportsTo", Value: "CEO"}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(3)}, {Key: "name", Value: "Manager"}, {Key: "reportsTo", Value: "VP"}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(4)}, {Key: "name", Value: "Dev"}, {Key: "reportsTo", Value: "Manager"}}),
+	}
+	engine := &lookupTestEngine{
+		collections: map[string]*lookupTestCollection{
+			"employees": {docs: employeeDocs, name: "employees"},
+		},
+	}
+
+	t.Run("linear chain traversal", func(t *testing.T) {
+		// Starting from Dev, walk up the reporting chain
+		inputDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(10)}, {Key: "startName", Value: "Dev"}}),
+		}
+		stage := &graphLookupStage{
+			from:             "employees",
+			startWith:        mustRawValue(t, "$startName"),
+			connectFromField: "reportsTo",
+			connectToField:   "name",
+			as:               "chain",
+			maxDepth:         -1,
+			engine:           engine,
+			db:               "testdb",
+		}
+		result, err := stage.Process(inputDocs)
+		if err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		if len(result) != 1 {
+			t.Fatalf("expected 1 doc, got %d", len(result))
+		}
+		d := decodeResult(t, result[0])
+		chain := getFieldD(d, "chain")
+		arr, ok := chain.(bson.A)
+		if !ok {
+			t.Fatalf("expected bson.A, got %T", chain)
+		}
+		// Dev -> Manager -> VP -> CEO = 3 nodes traversed (not including the start "Dev" lookup itself,
+		// but the first match IS Dev, then Manager, VP, CEO... let me think)
+		// startWith = "Dev", connectTo = "name", connectFrom = "reportsTo"
+		// Depth 0: search name == "Dev" -> finds doc #4 (Dev), connectFrom = "Manager"
+		// Depth 1: search name == "Manager" -> finds doc #3 (Manager), connectFrom = "VP"
+		// Depth 2: search name == "VP" -> finds doc #2 (VP), connectFrom = "CEO"
+		// Depth 3: search name == "CEO" -> finds doc #1 (CEO), connectFrom = nil
+		// Total: 4 documents
+		if len(arr) != 4 {
+			t.Errorf("expected 4 chain docs (Dev->Manager->VP->CEO), got %d", len(arr))
+		}
+	})
+
+	t.Run("maxDepth limits traversal", func(t *testing.T) {
+		inputDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(10)}, {Key: "startName", Value: "Dev"}}),
+		}
+		stage := &graphLookupStage{
+			from:             "employees",
+			startWith:        mustRawValue(t, "$startName"),
+			connectFromField: "reportsTo",
+			connectToField:   "name",
+			as:               "chain",
+			maxDepth:         1,
+			hasMaxDepth:      true,
+			engine:           engine,
+			db:               "testdb",
+		}
+		result, err := stage.Process(inputDocs)
+		if err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		d := decodeResult(t, result[0])
+		arr, ok := getFieldD(d, "chain").(bson.A)
+		if !ok {
+			t.Fatalf("expected bson.A")
+		}
+		// maxDepth=1: depth 0 finds Dev, depth 1 finds Manager. Stop.
+		if len(arr) != 2 {
+			t.Errorf("expected 2 docs with maxDepth=1, got %d", len(arr))
+		}
+	})
+
+	t.Run("depthField adds depth annotation", func(t *testing.T) {
+		inputDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(10)}, {Key: "startName", Value: "Dev"}}),
+		}
+		stage := &graphLookupStage{
+			from:             "employees",
+			startWith:        mustRawValue(t, "$startName"),
+			connectFromField: "reportsTo",
+			connectToField:   "name",
+			as:               "chain",
+			maxDepth:         1,
+			hasMaxDepth:      true,
+			depthField:       "depth",
+			engine:           engine,
+			db:               "testdb",
+		}
+		result, err := stage.Process(inputDocs)
+		if err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		d := decodeResult(t, result[0])
+		arr := getFieldD(d, "chain").(bson.A)
+
+		// Check that each matched doc has a "depth" field
+		for i, elem := range arr {
+			var depthVal interface{}
+			switch v := elem.(type) {
+			case bson.Raw:
+				ed := decodeResult(t, v)
+				depthVal = getFieldD(ed, "depth")
+			case bson.D:
+				depthVal = getFieldD(v, "depth")
+			default:
+				t.Fatalf("element %d: unexpected type %T", i, elem)
+			}
+			if depthVal == nil {
+				t.Errorf("element %d: missing depth field", i)
+			}
+		}
+	})
+
+	t.Run("cycle detection", func(t *testing.T) {
+		// Create a cycle: A -> B -> C -> A
+		cycleDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(1)}, {Key: "name", Value: "A"}, {Key: "next", Value: "B"}}),
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(2)}, {Key: "name", Value: "B"}, {Key: "next", Value: "C"}}),
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(3)}, {Key: "name", Value: "C"}, {Key: "next", Value: "A"}}),
+		}
+		cycleEngine := &lookupTestEngine{
+			collections: map[string]*lookupTestCollection{
+				"nodes": {docs: cycleDocs, name: "nodes"},
+			},
+		}
+
+		inputDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(10)}, {Key: "start", Value: "A"}}),
+		}
+		stage := &graphLookupStage{
+			from:             "nodes",
+			startWith:        mustRawValue(t, "$start"),
+			connectFromField: "next",
+			connectToField:   "name",
+			as:               "traversed",
+			maxDepth:         -1,
+			engine:           cycleEngine,
+			db:               "testdb",
+		}
+		result, err := stage.Process(inputDocs)
+		if err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		d := decodeResult(t, result[0])
+		arr := getFieldD(d, "traversed").(bson.A)
+		// Should find all 3 nodes and stop (cycle detection prevents infinite loop)
+		if len(arr) != 3 {
+			t.Errorf("expected 3 nodes with cycle detection, got %d", len(arr))
+		}
+	})
+
+	t.Run("empty results (no matches)", func(t *testing.T) {
+		inputDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(10)}, {Key: "startName", Value: "NonExistent"}}),
+		}
+		stage := &graphLookupStage{
+			from:             "employees",
+			startWith:        mustRawValue(t, "$startName"),
+			connectFromField: "reportsTo",
+			connectToField:   "name",
+			as:               "chain",
+			maxDepth:         -1,
+			engine:           engine,
+			db:               "testdb",
+		}
+		result, err := stage.Process(inputDocs)
+		if err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		d := decodeResult(t, result[0])
+		arr := getFieldD(d, "chain").(bson.A)
+		if len(arr) != 0 {
+			t.Errorf("expected 0 matches for nonexistent start, got %d", len(arr))
+		}
+	})
+
+	t.Run("tree traversal (multiple children)", func(t *testing.T) {
+		// Tree: root -> [child1, child2], child1 -> [grandchild1]
+		treeDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(1)}, {Key: "name", Value: "root"}, {Key: "parent", Value: nil}}),
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(2)}, {Key: "name", Value: "child1"}, {Key: "parent", Value: "root"}}),
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(3)}, {Key: "name", Value: "child2"}, {Key: "parent", Value: "root"}}),
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(4)}, {Key: "name", Value: "grandchild1"}, {Key: "parent", Value: "child1"}}),
+		}
+		treeEngine := &lookupTestEngine{
+			collections: map[string]*lookupTestCollection{
+				"tree": {docs: treeDocs, name: "tree"},
+			},
+		}
+
+		// Find all descendants of root by traversing parent -> name
+		// Actually we need to go top-down: start with "root", find children by parent=root
+		inputDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(10)}, {Key: "start", Value: "root"}}),
+		}
+		stage := &graphLookupStage{
+			from:             "tree",
+			startWith:        mustRawValue(t, "$start"),
+			connectFromField: "name",     // from the matched doc, take "name"
+			connectToField:   "parent",   // and find docs where parent == name
+			as:               "descendants",
+			maxDepth:         -1,
+			engine:           treeEngine,
+			db:               "testdb",
+		}
+		result, err := stage.Process(inputDocs)
+		if err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		d := decodeResult(t, result[0])
+		arr := getFieldD(d, "descendants").(bson.A)
+		// root matches parent=root: child1, child2
+		// child1 matches parent=child1: grandchild1
+		// child2 matches parent=child2: none
+		// grandchild1 matches parent=grandchild1: none
+		// Wait: startWith="root", connectTo="parent"
+		// Depth 0: find docs where parent == "root" -> child1, child2
+		//   connectFrom=name -> "child1", "child2"
+		// Depth 1: find docs where parent == "child1" -> grandchild1
+		//          find docs where parent == "child2" -> none
+		//   connectFrom=name -> "grandchild1"
+		// Depth 2: find docs where parent == "grandchild1" -> none
+		// Total: 3 docs (child1, child2, grandchild1)
+		if len(arr) != 3 {
+			t.Errorf("expected 3 descendants, got %d", len(arr))
+		}
+	})
+
+	t.Run("restrictSearchWithMatch filters results", func(t *testing.T) {
+		// Employees with department field
+		deptDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(1)}, {Key: "name", Value: "CEO"}, {Key: "reportsTo", Value: nil}, {Key: "dept", Value: "exec"}}),
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(2)}, {Key: "name", Value: "VP-Eng"}, {Key: "reportsTo", Value: "CEO"}, {Key: "dept", Value: "eng"}}),
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(3)}, {Key: "name", Value: "VP-Sales"}, {Key: "reportsTo", Value: "CEO"}, {Key: "dept", Value: "sales"}}),
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(4)}, {Key: "name", Value: "Dev"}, {Key: "reportsTo", Value: "VP-Eng"}, {Key: "dept", Value: "eng"}}),
+		}
+		deptEngine := &lookupTestEngine{
+			collections: map[string]*lookupTestCollection{
+				"staff": {docs: deptDocs, name: "staff"},
+			},
+		}
+
+		inputDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(10)}, {Key: "startName", Value: "Dev"}}),
+		}
+		restrictFilter := makeRaw(t, bson.D{{Key: "dept", Value: "eng"}})
+		stage := &graphLookupStage{
+			from:                    "staff",
+			startWith:               mustRawValue(t, "$startName"),
+			connectFromField:        "reportsTo",
+			connectToField:          "name",
+			as:                      "engChain",
+			maxDepth:                -1,
+			restrictSearchWithMatch: restrictFilter,
+			engine:                  deptEngine,
+			db:                      "testdb",
+		}
+		result, err := stage.Process(inputDocs)
+		if err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		d := decodeResult(t, result[0])
+		arr := getFieldD(d, "engChain").(bson.A)
+		// Dev (dept=eng) -> reportsTo=VP-Eng (dept=eng) -> reportsTo=CEO (dept=exec, FILTERED OUT)
+		// So only Dev and VP-Eng match
+		if len(arr) != 2 {
+			t.Errorf("expected 2 eng dept results, got %d", len(arr))
+		}
+	})
+
+	t.Run("maxDepth 0 returns only seed matches", func(t *testing.T) {
+		inputDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(10)}, {Key: "startName", Value: "Dev"}}),
+		}
+		stage := &graphLookupStage{
+			from:             "employees",
+			startWith:        mustRawValue(t, "$startName"),
+			connectFromField: "reportsTo",
+			connectToField:   "name",
+			as:               "chain",
+			maxDepth:         0,
+			hasMaxDepth:      true,
+			engine:           engine,
+			db:               "testdb",
+		}
+		result, err := stage.Process(inputDocs)
+		if err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		d := decodeResult(t, result[0])
+		arr := getFieldD(d, "chain").(bson.A)
+		// maxDepth=0: only depth 0 matches, finds Dev only
+		if len(arr) != 1 {
+			t.Errorf("expected 1 doc with maxDepth=0, got %d", len(arr))
+		}
+	})
+
+	t.Run("startWith array value", func(t *testing.T) {
+		inputDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(10)}, {Key: "names", Value: bson.A{"Dev", "VP"}}}),
+		}
+		stage := &graphLookupStage{
+			from:             "employees",
+			startWith:        mustRawValue(t, "$names"),
+			connectFromField: "reportsTo",
+			connectToField:   "name",
+			as:               "chain",
+			maxDepth:         0,
+			hasMaxDepth:      true,
+			engine:           engine,
+			db:               "testdb",
+		}
+		result, err := stage.Process(inputDocs)
+		if err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		d := decodeResult(t, result[0])
+		arr := getFieldD(d, "chain").(bson.A)
+		// startWith=["Dev","VP"], maxDepth=0: finds Dev and VP
+		if len(arr) != 2 {
+			t.Errorf("expected 2 docs from array startWith, got %d", len(arr))
+		}
+	})
+
+	t.Run("cross-collection lookup", func(t *testing.T) {
+		// Same as linear chain but proves cross-collection works (the collection is always "from")
+		inputDocs := []bson.Raw{
+			makeRaw(t, bson.D{{Key: "_id", Value: int32(10)}, {Key: "startName", Value: "Manager"}}),
+		}
+		stage := &graphLookupStage{
+			from:             "employees",
+			startWith:        mustRawValue(t, "$startName"),
+			connectFromField: "reportsTo",
+			connectToField:   "name",
+			as:               "ancestors",
+			maxDepth:         -1,
+			engine:           engine,
+			db:               "testdb",
+		}
+		result, err := stage.Process(inputDocs)
+		if err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		d := decodeResult(t, result[0])
+		arr := getFieldD(d, "ancestors").(bson.A)
+		// Manager -> VP -> CEO = find Manager, then VP, then CEO
+		if len(arr) != 3 {
+			t.Errorf("expected 3 ancestors, got %d", len(arr))
+		}
+	})
+}
+
+// mustRawValue builds a bson.RawValue from a field path string like "$field".
+func mustRawValue(t *testing.T, s string) bson.RawValue {
+	t.Helper()
+	b, err := bson.Marshal(bson.D{{Key: "v", Value: s}})
+	if err != nil {
+		t.Fatalf("mustRawValue: %v", err)
+	}
+	raw := bson.Raw(b)
+	val, err := raw.LookupErr("v")
+	if err != nil {
+		t.Fatalf("mustRawValue lookup: %v", err)
+	}
+	return val
+}


### PR DESCRIPTION
Closes #468

## What
Implements the `$graphLookup` aggregation stage — recursive graph traversal using BFS with:
- Same-collection and cross-collection support
- Cycle detection (by `_id`)
- `maxDepth` limit (optional)
- `depthField` annotation on matched documents
- `restrictSearchWithMatch` filter at each recursion level
- Array `startWith` values (multiple seed nodes)
- Proper cursor draining for large collections (avoids the `NextBatch(0)` = 101 doc truncation)

## Why
`$graphLookup` is a key aggregation stage for graph-structured data (org charts, dependency trees, social graphs). This was the highest-priority unclaimed feature issue.

## Tests
10 unit tests:
- Linear chain traversal (4-node reporting chain)
- `maxDepth` limits traversal depth
- `maxDepth=0` returns only seed matches
- `depthField` adds depth annotation
- Cycle detection (A→B→C→A)
- Empty results (no matches)
- Tree traversal (multiple children per node)
- `restrictSearchWithMatch` filters results
- Array `startWith` (multiple seed values)
- Cross-collection lookup

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#468"]
```

*Posted by the founder agent on behalf of @inder*