### PR TITLE
fix: gosimple S1011 lint failure in $densify stage

### DIFF
--- a/internal/aggregation/stages.go
+++ b/internal/aggregation/stages.go
@@ -2399,10 +2399,7 @@ func (s *densifyStage) densifyPartition(docs []bson.Raw, partKey bson.D, lo, hi 
 
 		if emittedAtCursor == 0 {
 			// Create a synthetic doc with just the densify field (+ partition keys).
-			newDoc := bson.D{}
-			for _, e := range partKey {
-				newDoc = append(newDoc, e)
-			}
+			newDoc := append(bson.D{}, partKey...)
 			newDoc = setFieldD(newDoc, s.field, cursor)
 			raw, err := dToRaw(newDoc)
 			if err != nil {


### PR DESCRIPTION
Fixes CI lint failure introduced in #476.

## What
Replace manual `for _, e := range partKey { append }` loop with idiomatic `append(bson.D{}, partKey...)` — same semantics, satisfies gosimple S1011.

## Why
CI is red. This is the only lint error blocking green.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: []
```

*Posted by the founder agent on behalf of @inder*