### PR TITLE
feat: implement $rand expression operator

### DIFF
--- a/internal/aggregation/expressions.go
+++ b/internal/aggregation/expressions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"math/rand/v2"
 	"regexp"
 	"strconv"
 	"strings"
@@ -420,6 +421,11 @@ func evalOperatorExpr(op string, arg bson.RawValue, doc bson.Raw) (interface{}, 
 		return evalAnyAllElementsTrue(arg, doc, true)
 
 	// ── Miscellaneous ────────────────────────────────────────────────────────
+	case "$rand":
+		if arg.Type != bson.TypeEmbeddedDocument {
+			return nil, fmt.Errorf("$rand takes no arguments, got %s", arg.Type)
+		}
+		return rand.Float64(), nil
 	case "$literal":
 		return rawValToInterface(arg), nil
 	case "$mergeObjects":

--- a/internal/aggregation/expressions_test.go
+++ b/internal/aggregation/expressions_test.go
@@ -883,3 +883,40 @@ func TestExprComparison(t *testing.T) {
 		})
 	}
 }
+
+// ─── $rand ──────────────────────────────────────────────────────────────────────
+
+func TestExprRand(t *testing.T) {
+	doc := makeDoc(t, bson.D{})
+
+	t.Run("returns float64 in [0,1)", func(t *testing.T) {
+		for i := 0; i < 100; i++ {
+			result := evalExprHelper(t, bson.D{{Key: "$rand", Value: bson.D{}}}, doc)
+			f, ok := result.(float64)
+			if !ok {
+				t.Fatalf("expected float64, got %T", result)
+			}
+			if f < 0 || f >= 1 {
+				t.Fatalf("$rand returned %v, want [0, 1)", f)
+			}
+		}
+	})
+
+	t.Run("produces varying values", func(t *testing.T) {
+		seen := make(map[float64]bool)
+		for i := 0; i < 10; i++ {
+			result := evalExprHelper(t, bson.D{{Key: "$rand", Value: bson.D{}}}, doc)
+			seen[result.(float64)] = true
+		}
+		if len(seen) < 2 {
+			t.Fatalf("$rand produced %d unique values in 10 calls, expected variation", len(seen))
+		}
+	})
+
+	t.Run("rejects non-document argument", func(t *testing.T) {
+		_, err := EvalExpr(bson.D{{Key: "$rand", Value: int32(1)}}, doc)
+		if err == nil {
+			t.Fatal("expected error for non-document $rand argument")
+		}
+	})
+}


### PR DESCRIPTION
Closes #485

## What
Implements the `$rand` aggregation expression operator. Returns a random float64 in [0, 1) on each evaluation. Rejects non-document arguments per MongoDB spec.

## Why
Fills a gap in expression operator coverage. `$rand` is used for sampling, randomized sorting, and probabilistic pipelines.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#485"]
```

*Posted by the founder agent on behalf of @inder*