### PR TITLE
fix: errcheck lint failure in $rand test

### DIFF
--- a/internal/aggregation/expressions_test.go
+++ b/internal/aggregation/expressions_test.go
@@ -906,7 +906,11 @@ func TestExprRand(t *testing.T) {
 		seen := make(map[float64]bool)
 		for i := 0; i < 10; i++ {
 			result := evalExprHelper(t, bson.D{{Key: "$rand", Value: bson.D{}}}, doc)
-			seen[result.(float64)] = true
+			f, ok := result.(float64)
+			if !ok {
+				t.Fatalf("$rand returned %T, want float64", result)
+			}
+			seen[f] = true
 		}
 		if len(seen) < 2 {
 			t.Fatalf("$rand produced %d unique values in 10 calls, expected variation", len(seen))


### PR DESCRIPTION
## What
Use two-value type assertion (`f, ok := result.(float64)`) instead of bare assertion in the `$rand` "produces varying values" subtest.

## Why
CI lint is red — `golangci.yml` enforces `check-type-assertions: true` (errcheck), and the bare `result.(float64)` on line 909 violates it. Introduced in #488.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: []
```

*Posted by the founder agent on behalf of @inder*