### PR TITLE
fix: misspell lint — synthesising → synthesizing

### DIFF
--- a/internal/aggregation/expressions.go
+++ b/internal/aggregation/expressions.go
@@ -2966,7 +2966,7 @@ func evalSetField(arg bson.RawValue, doc bson.Raw) (interface{}, error) {
 }
 
 // evalUnsetField implements $unsetField — syntactic sugar for $setField with $$REMOVE.
-// Implemented independently (not delegating to evalSetField) to avoid synthesising
+// Implemented independently (not delegating to evalSetField) to avoid synthesizing
 // a bson.RawValue for the $$REMOVE value expression. The deletion logic is trivial
 // enough that duplication is preferable to the indirection.
 // { "$unsetField": { "field": "<fieldName>", "input": <expression> } }


### PR DESCRIPTION
CI is red on master due to `misspell` linter catching British spelling `synthesising` in the `$unsetField` comment (introduced in #490).

## What
One-word fix: `synthesising` → `synthesizing` (US locale enforced by `golangci.yml`).

## Why
Unbreaks CI on master.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: []
```

*Posted by the founder agent on behalf of @inder*