### PR TITLE
fix: rawValToInterface uses pure BSON-to-Go conversion (closes #493)

### DIFF
--- a/internal/aggregation/expressions.go
+++ b/internal/aggregation/expressions.go
@@ -194,8 +194,10 @@ func evalFieldRef(path string, doc bson.Raw) interface{} {
 	if !found {
 		return nil
 	}
-	result, _ := evalRawValue(val, doc)
-	return result
+	// Field values are data, not expressions. Use rawValToInterface to avoid
+	// treating $-prefixed strings as field references or embedded documents
+	// as operator expressions.
+	return rawValToInterface(val)
 }
 
 // evalOperatorExpr dispatches to the appropriate expression handler.
@@ -553,9 +555,53 @@ func toStringInterface(v interface{}) (string, bool) {
 	return "", false
 }
 
+// rawValToInterface converts a bson.RawValue to a Go value without expression
+// evaluation. Strings starting with "$" are returned as-is (not treated as
+// field references), and embedded documents are decoded literally (not
+// evaluated as operator expressions).
 func rawValToInterface(v bson.RawValue) interface{} {
-	result, _ := evalRawValue(v, nil)
-	return result
+	switch v.Type {
+	case bson.TypeString:
+		return v.StringValue()
+	case bson.TypeEmbeddedDocument:
+		elems, err := v.Document().Elements()
+		if err != nil {
+			return nil
+		}
+		result := make(bson.D, 0, len(elems))
+		for _, e := range elems {
+			result = append(result, bson.E{Key: e.Key(), Value: rawValToInterface(e.Value())})
+		}
+		return result
+	case bson.TypeArray:
+		vals, err := bson.RawArray(v.Value).Values()
+		if err != nil {
+			return nil
+		}
+		result := make([]interface{}, len(vals))
+		for i, rv := range vals {
+			result[i] = rawValToInterface(rv)
+		}
+		return result
+	case bson.TypeNull, bson.TypeUndefined:
+		return nil
+	case bson.TypeBoolean:
+		return v.Boolean()
+	case bson.TypeInt32:
+		return v.Int32()
+	case bson.TypeInt64:
+		return v.Int64()
+	case bson.TypeDouble:
+		return v.Double()
+	case bson.TypeDateTime:
+		return time.Unix(0, v.DateTime()*int64(time.Millisecond)).UTC()
+	case bson.TypeObjectID:
+		return v.ObjectID()
+	case bson.TypeDecimal128:
+		return v.Decimal128()
+	default:
+		return v
+	}
 }
 
 func interfaceToRawValue(v interface{}) bson.RawValue {

--- a/internal/aggregation/expressions_test.go
+++ b/internal/aggregation/expressions_test.go
@@ -1391,11 +1391,34 @@ func TestExprSortArray(t *testing.T) {
 	})
 
 	t.Run("document sort preserves dollar-prefixed string values", func(t *testing.T) {
-		// Known limitation: rawValToInterface delegates to evalRawValue which
-		// interprets $-prefixed strings as field references. This affects all
-		// array expressions ($filter, $reverseArray, etc.), not just $sortArray.
-		// TODO: fix rawValToInterface to use a non-evaluating deserializer.
-		t.Skip("pre-existing bug: rawValToInterface treats $-prefixed strings as field refs")
+		// Regression test for #493: $-prefixed string values in array elements
+		// must be preserved as literal strings, not interpreted as field refs.
+		doc := makeDoc(t, bson.D{
+			{Key: "items", Value: bson.A{
+				bson.D{{Key: "name", Value: "Widget"}, {Key: "tag", Value: "$sale"}},
+				bson.D{{Key: "name", Value: "Gadget"}, {Key: "tag", Value: "$new"}},
+			}},
+		})
+		expr := bson.D{{Key: "$sortArray", Value: bson.D{
+			{Key: "input", Value: "$items"},
+			{Key: "sortBy", Value: bson.D{{Key: "name", Value: int32(1)}}},
+		}}}
+		result, err := EvalExpr(expr, doc)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		arr, ok := result.([]interface{})
+		if !ok {
+			t.Fatalf("expected []interface{}, got %T", result)
+		}
+		tags := extractField(t, arr, "tag")
+		// Gadget sorts before Widget
+		if tags[0] != "$new" {
+			t.Errorf("tags[0] = %v, want \"$new\"", tags[0])
+		}
+		if tags[1] != "$sale" {
+			t.Errorf("tags[1] = %v, want \"$sale\"", tags[1])
+		}
 	})
 
 	t.Run("rejects sortBy value other than 1 or -1", func(t *testing.T) {
@@ -1450,4 +1473,80 @@ func toInt32(v interface{}) int32 {
 	default:
 		return 0
 	}
+}
+
+func TestRawValToInterface(t *testing.T) {
+	t.Run("preserves dollar-prefixed strings", func(t *testing.T) {
+		raw, err := bson.Marshal(bson.D{{Key: "x", Value: "$sale"}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		doc := bson.Raw(raw)
+		elems, _ := doc.Elements()
+		got := rawValToInterface(elems[0].Value())
+		if got != "$sale" {
+			t.Errorf("rawValToInterface($sale) = %v (%T), want \"$sale\"", got, got)
+		}
+	})
+
+	t.Run("preserves dollar-prefixed strings in nested docs", func(t *testing.T) {
+		raw, err := bson.Marshal(bson.D{{Key: "x", Value: bson.D{
+			{Key: "tag", Value: "$promo"},
+			{Key: "name", Value: "Widget"},
+		}}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		doc := bson.Raw(raw)
+		elems, _ := doc.Elements()
+		got := rawValToInterface(elems[0].Value())
+		d, ok := got.(bson.D)
+		if !ok {
+			t.Fatalf("expected bson.D, got %T", got)
+		}
+		if d[0].Value != "$promo" {
+			t.Errorf("nested doc tag = %v, want \"$promo\"", d[0].Value)
+		}
+	})
+
+	t.Run("preserves dollar-prefixed strings in arrays", func(t *testing.T) {
+		raw, err := bson.Marshal(bson.D{{Key: "x", Value: bson.A{"$a", "$b", "c"}}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		doc := bson.Raw(raw)
+		elems, _ := doc.Elements()
+		got := rawValToInterface(elems[0].Value())
+		arr, ok := got.([]interface{})
+		if !ok {
+			t.Fatalf("expected []interface{}, got %T", got)
+		}
+		if arr[0] != "$a" || arr[1] != "$b" || arr[2] != "c" {
+			t.Errorf("got %v, want [\"$a\", \"$b\", \"c\"]", arr)
+		}
+	})
+}
+
+func TestExprLiteral(t *testing.T) {
+	doc := makeDoc(t, bson.D{{Key: "x", Value: 1}})
+
+	t.Run("dollar-prefixed string preserved", func(t *testing.T) {
+		expr := bson.D{{Key: "$literal", Value: "$notAField"}}
+		result := evalExprHelper(t, expr, doc)
+		if result != "$notAField" {
+			t.Errorf("$literal(\"$notAField\") = %v (%T), want \"$notAField\"", result, result)
+		}
+	})
+
+	t.Run("dollar-prefixed doc preserved", func(t *testing.T) {
+		expr := bson.D{{Key: "$literal", Value: bson.D{{Key: "$add", Value: bson.A{1, 2}}}}}
+		result := evalExprHelper(t, expr, doc)
+		d, ok := result.(bson.D)
+		if !ok {
+			t.Fatalf("expected bson.D, got %T (%v)", result, result)
+		}
+		if len(d) != 1 || d[0].Key != "$add" {
+			t.Errorf("expected {$add: [1,2]} as literal, got %v", d)
+		}
+	})
 }


### PR DESCRIPTION
Closes #493

## What

Rewrites `rawValToInterface` to do pure BSON→Go type mapping without expression evaluation.
Also fixes `evalFieldRef` to use the non-evaluating deserializer since field values are data,
not expressions.

## Why

`rawValToInterface` delegated to `evalRawValue` which treated `$`-prefixed strings as field
references and embedded documents as operator expressions. This caused `$`-prefixed string
values in array elements (e.g. `{tag: "$sale"}`) to silently become `nil` after the `toSlice`
round-trip, affecting ALL array expression operators (`$filter`, `$map`, `$reduce`, `$sortArray`,
`$reverseArray`, `$slice`, `$zip`, `$concatArrays`, etc.) and `$literal`.

## Tests

- Un-skipped `TestExprSortArray/document_sort_preserves_dollar-prefixed_string_values`
- Added `TestRawValToInterface` (strings, nested docs, arrays with `$`-prefixed values)
- Added `TestExprLiteral` (`$literal` with `$`-prefixed strings and operator-shaped docs)
- Full test suite passes

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#493"]
```

*Posted by the founder agent on behalf of @inder*