### PR TITLE
fix: reject n=0 in $firstN/$lastN per MongoDB spec

### DIFF
--- a/internal/aggregation/expressions.go
+++ b/internal/aggregation/expressions.go
@@ -1574,7 +1574,7 @@ func evalFirstNLastN(arg bson.RawValue, doc bson.Raw, takeLast bool) (interface{
 		return nil, fmt.Errorf("%s: 'n' must be a positive integer", opName)
 	}
 	n := int(nFloat)
-	if nFloat != float64(n) || n < 0 {
+	if nFloat != float64(n) || n <= 0 {
 		return nil, fmt.Errorf("%s: 'n' must be a positive integer, got %v", opName, nEvaled)
 	}
 

--- a/internal/aggregation/expressions_test.go
+++ b/internal/aggregation/expressions_test.go
@@ -1499,18 +1499,14 @@ func TestExprFirstN(t *testing.T) {
 		}
 	})
 
-	t.Run("n = 0 returns empty array", func(t *testing.T) {
+	t.Run("error on n = 0", func(t *testing.T) {
 		expr := bson.D{{Key: "$firstN", Value: bson.D{
 			{Key: "n", Value: int32(0)},
 			{Key: "input", Value: "$scores"},
 		}}}
-		got := evalExprHelper(t, expr, doc)
-		arr, ok := got.([]interface{})
-		if !ok {
-			t.Fatalf("expected []interface{}, got %T", got)
-		}
-		if len(arr) != 0 {
-			t.Errorf("expected 0 elements, got %d", len(arr))
+		_, err := EvalExpr(expr, doc)
+		if err == nil {
+			t.Fatal("expected error for n = 0")
 		}
 	})
 
@@ -1658,18 +1654,14 @@ func TestExprLastN(t *testing.T) {
 		}
 	})
 
-	t.Run("n = 0 returns empty array", func(t *testing.T) {
+	t.Run("error on n = 0", func(t *testing.T) {
 		expr := bson.D{{Key: "$lastN", Value: bson.D{
 			{Key: "n", Value: int32(0)},
 			{Key: "input", Value: "$scores"},
 		}}}
-		got := evalExprHelper(t, expr, doc)
-		arr, ok := got.([]interface{})
-		if !ok {
-			t.Fatalf("expected []interface{}, got %T", got)
-		}
-		if len(arr) != 0 {
-			t.Errorf("expected 0 elements, got %d", len(arr))
+		_, err := EvalExpr(expr, doc)
+		if err == nil {
+			t.Fatal("expected error for n = 0")
 		}
 	})
 


### PR DESCRIPTION
## What
Changes `n < 0` guard to `n <= 0` in `$firstN`/`$lastN`. Updates tests to expect error on `n=0`.

## Why
MongoDB 6.0+ requires `n` to be a positive integer (strictly > 0). The original implementation accepted `n=0` and returned an empty array, which diverges from real MongoDB behavior. Caught by code-reviewer subagent.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: []
```

*Posted by the founder agent on behalf of @inder*