### PR TITLE
feat: implement $dateToParts and $dateFromParts expression operators

### DIFF
--- a/internal/aggregation/expressions.go
+++ b/internal/aggregation/expressions.go
@@ -372,6 +372,10 @@ func evalOperatorExpr(op string, arg bson.RawValue, doc bson.Raw) (interface{}, 
 		return evalDateDiff(arg, doc)
 	case "$dateTrunc":
 		return evalDateTrunc(arg, doc)
+	case "$dateToParts":
+		return evalDateToParts(arg, doc)
+	case "$dateFromParts":
+		return evalDateFromParts(arg, doc)
 
 	// ── Comparison ───────────────────────────────────────────────────────────
 	case "$cmp":
@@ -2522,6 +2526,203 @@ func evalDateTrunc(arg bson.RawValue, doc bson.Raw) (interface{}, error) {
 	}
 	unit, _ := toStringInterface(rawValToInterface(unitVal))
 	return truncateDate(t, unit), nil
+}
+
+func evalDateToParts(arg bson.RawValue, doc bson.Raw) (interface{}, error) {
+	subDoc, ok := arg.DocumentOK()
+	if !ok {
+		return nil, fmt.Errorf("$dateToParts requires a document argument")
+	}
+
+	dateVal, err := subDoc.LookupErr("date")
+	if err != nil {
+		return nil, fmt.Errorf("$dateToParts requires a 'date' field")
+	}
+	dateInterface, err := EvalExpr(dateVal, doc)
+	if err != nil {
+		return nil, err
+	}
+	if dateInterface == nil {
+		return nil, nil
+	}
+	t, ok := toTime(dateInterface)
+	if !ok {
+		return nil, nil
+	}
+
+	// Handle optional timezone
+	if tzVal, tzErr := subDoc.LookupErr("timezone"); tzErr == nil {
+		tzInterface, err := EvalExpr(tzVal, doc)
+		if err != nil {
+			return nil, err
+		}
+		if tzStr, ok := toStringInterface(tzInterface); ok && tzStr != "" {
+			loc, err := time.LoadLocation(tzStr)
+			if err != nil {
+				return nil, fmt.Errorf("$dateToParts: unrecognized timezone %q", tzStr)
+			}
+			t = t.In(loc)
+		}
+	}
+
+	// Check for iso8601 mode
+	iso8601 := false
+	if isoVal, isoErr := subDoc.LookupErr("iso8601"); isoErr == nil {
+		isoInterface, err := EvalExpr(isoVal, doc)
+		if err != nil {
+			return nil, err
+		}
+		iso8601 = toBoolInterface(isoInterface)
+	}
+
+	if iso8601 {
+		isoYear, isoWeek := t.ISOWeek()
+		isoDayOfWeek := int32(t.Weekday())
+		if isoDayOfWeek == 0 {
+			isoDayOfWeek = 7 // ISO: Sunday = 7
+		}
+		return bson.D{
+			{Key: "isoWeekYear", Value: int32(isoYear)},
+			{Key: "isoWeek", Value: int32(isoWeek)},
+			{Key: "isoDayOfWeek", Value: isoDayOfWeek},
+			{Key: "hour", Value: int32(t.Hour())},
+			{Key: "minute", Value: int32(t.Minute())},
+			{Key: "second", Value: int32(t.Second())},
+			{Key: "millisecond", Value: int32(t.Nanosecond() / 1e6)},
+		}, nil
+	}
+
+	return bson.D{
+		{Key: "year", Value: int32(t.Year())},
+		{Key: "month", Value: int32(t.Month())},
+		{Key: "day", Value: int32(t.Day())},
+		{Key: "hour", Value: int32(t.Hour())},
+		{Key: "minute", Value: int32(t.Minute())},
+		{Key: "second", Value: int32(t.Second())},
+		{Key: "millisecond", Value: int32(t.Nanosecond() / 1e6)},
+	}, nil
+}
+
+func evalDateFromParts(arg bson.RawValue, doc bson.Raw) (interface{}, error) {
+	subDoc, ok := arg.DocumentOK()
+	if !ok {
+		return nil, fmt.Errorf("$dateFromParts requires a document argument")
+	}
+
+	// Helper to extract an optional int32 field, defaulting to a given value.
+	getInt := func(key string, def int) (int, error) {
+		val, err := subDoc.LookupErr(key)
+		if err != nil {
+			return def, nil
+		}
+		v, err := EvalExpr(val, doc)
+		if err != nil {
+			return 0, err
+		}
+		if v == nil {
+			return def, nil
+		}
+		n, ok := toFloat64Interface(v)
+		if !ok {
+			return 0, fmt.Errorf("$dateFromParts: '%s' must be a number", key)
+		}
+		return int(n), nil
+	}
+
+	// Determine timezone (applies to both forms)
+	loc := time.UTC
+	if tzVal, tzErr := subDoc.LookupErr("timezone"); tzErr == nil {
+		tzInterface, err := EvalExpr(tzVal, doc)
+		if err != nil {
+			return nil, err
+		}
+		if tzStr, ok := toStringInterface(tzInterface); ok && tzStr != "" {
+			l, err := time.LoadLocation(tzStr)
+			if err != nil {
+				return nil, fmt.Errorf("$dateFromParts: unrecognized timezone %q", tzStr)
+			}
+			loc = l
+		}
+	}
+
+	// Check if this is the ISO week date form
+	_, hasIsoWeekYear := subDoc.LookupErr("isoWeekYear")
+	if hasIsoWeekYear == nil {
+		isoWeekYear, err := getInt("isoWeekYear", 1970)
+		if err != nil {
+			return nil, err
+		}
+		isoWeek, err := getInt("isoWeek", 1)
+		if err != nil {
+			return nil, err
+		}
+		isoDayOfWeek, err := getInt("isoDayOfWeek", 1)
+		if err != nil {
+			return nil, err
+		}
+		hour, err := getInt("hour", 0)
+		if err != nil {
+			return nil, err
+		}
+		minute, err := getInt("minute", 0)
+		if err != nil {
+			return nil, err
+		}
+		second, err := getInt("second", 0)
+		if err != nil {
+			return nil, err
+		}
+		millisecond, err := getInt("millisecond", 0)
+		if err != nil {
+			return nil, err
+		}
+
+		// Find the date of ISO week 1 day 1 (Monday) of the given ISO year.
+		// Jan 4 is always in ISO week 1.
+		jan4 := time.Date(isoWeekYear, time.January, 4, 0, 0, 0, 0, loc)
+		// Monday of that week
+		daysSinceMonday := int(jan4.Weekday()+6) % 7
+		week1Monday := jan4.AddDate(0, 0, -daysSinceMonday)
+		// Add weeks and days
+		target := week1Monday.AddDate(0, 0, (isoWeek-1)*7+(isoDayOfWeek-1))
+		target = time.Date(target.Year(), target.Month(), target.Day(),
+			hour, minute, second, millisecond*1e6, loc)
+		return target.UTC(), nil
+	}
+
+	// Calendar form
+	year, err := getInt("year", 1970)
+	if err != nil {
+		return nil, err
+	}
+	month, err := getInt("month", 1)
+	if err != nil {
+		return nil, err
+	}
+	day, err := getInt("day", 1)
+	if err != nil {
+		return nil, err
+	}
+	hour, err := getInt("hour", 0)
+	if err != nil {
+		return nil, err
+	}
+	minute, err := getInt("minute", 0)
+	if err != nil {
+		return nil, err
+	}
+	second, err := getInt("second", 0)
+	if err != nil {
+		return nil, err
+	}
+	millisecond, err := getInt("millisecond", 0)
+	if err != nil {
+		return nil, err
+	}
+
+	t := time.Date(year, time.Month(month), day, hour, minute, second,
+		millisecond*1e6, loc)
+	return t.UTC(), nil
 }
 
 func addDateUnit(t time.Time, unit string, amount int64) time.Time {

--- a/internal/aggregation/expressions_test.go
+++ b/internal/aggregation/expressions_test.go
@@ -3,6 +3,7 @@ package aggregation
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -2140,6 +2141,252 @@ func TestExprMinN(t *testing.T) {
 		_, err := EvalExpr(expr, doc)
 		if err == nil {
 			t.Fatal("expected error for negative n")
+		}
+	})
+}
+
+// ─── $dateToParts / $dateFromParts ────────────────────────────────────────────
+
+func TestExprDateToParts(t *testing.T) {
+	// 2026-05-01T14:30:45.123Z
+	ts := time.Date(2026, 5, 1, 14, 30, 45, 123000000, time.UTC)
+	doc := makeDoc(t, bson.D{{Key: "d", Value: ts}})
+
+	t.Run("basic decompose", func(t *testing.T) {
+		expr := bson.D{{Key: "$dateToParts", Value: bson.D{
+			{Key: "date", Value: "$d"},
+		}}}
+		result := evalExprHelper(t, expr, doc)
+		got, ok := result.(bson.D)
+		if !ok {
+			t.Fatalf("expected bson.D, got %T", result)
+		}
+		expect := bson.D{
+			{Key: "year", Value: int32(2026)},
+			{Key: "month", Value: int32(5)},
+			{Key: "day", Value: int32(1)},
+			{Key: "hour", Value: int32(14)},
+			{Key: "minute", Value: int32(30)},
+			{Key: "second", Value: int32(45)},
+			{Key: "millisecond", Value: int32(123)},
+		}
+		if !reflect.DeepEqual(got, expect) {
+			t.Fatalf("got %v, want %v", got, expect)
+		}
+	})
+
+	t.Run("iso8601 mode", func(t *testing.T) {
+		expr := bson.D{{Key: "$dateToParts", Value: bson.D{
+			{Key: "date", Value: "$d"},
+			{Key: "iso8601", Value: true},
+		}}}
+		result := evalExprHelper(t, expr, doc)
+		got, ok := result.(bson.D)
+		if !ok {
+			t.Fatalf("expected bson.D, got %T", result)
+		}
+		// 2026-05-01 is a Friday: isoWeekYear=2026, isoWeek=18, isoDayOfWeek=5
+		isoYear, isoWeek := ts.ISOWeek()
+		expect := bson.D{
+			{Key: "isoWeekYear", Value: int32(isoYear)},
+			{Key: "isoWeek", Value: int32(isoWeek)},
+			{Key: "isoDayOfWeek", Value: int32(5)}, // Friday
+			{Key: "hour", Value: int32(14)},
+			{Key: "minute", Value: int32(30)},
+			{Key: "second", Value: int32(45)},
+			{Key: "millisecond", Value: int32(123)},
+		}
+		if !reflect.DeepEqual(got, expect) {
+			t.Fatalf("got %v, want %v", got, expect)
+		}
+	})
+
+	t.Run("with timezone", func(t *testing.T) {
+		expr := bson.D{{Key: "$dateToParts", Value: bson.D{
+			{Key: "date", Value: "$d"},
+			{Key: "timezone", Value: "America/New_York"},
+		}}}
+		result := evalExprHelper(t, expr, doc)
+		got, ok := result.(bson.D)
+		if !ok {
+			t.Fatalf("expected bson.D, got %T", result)
+		}
+		// UTC 14:30 → EDT (UTC-4) = 10:30
+		expect := bson.D{
+			{Key: "year", Value: int32(2026)},
+			{Key: "month", Value: int32(5)},
+			{Key: "day", Value: int32(1)},
+			{Key: "hour", Value: int32(10)},
+			{Key: "minute", Value: int32(30)},
+			{Key: "second", Value: int32(45)},
+			{Key: "millisecond", Value: int32(123)},
+		}
+		if !reflect.DeepEqual(got, expect) {
+			t.Fatalf("got %v, want %v", got, expect)
+		}
+	})
+
+	t.Run("null input", func(t *testing.T) {
+		nullDoc := makeDoc(t, bson.D{{Key: "d", Value: nil}})
+		expr := bson.D{{Key: "$dateToParts", Value: bson.D{
+			{Key: "date", Value: "$d"},
+		}}}
+		result := evalExprHelper(t, expr, nullDoc)
+		if result != nil {
+			t.Fatalf("expected nil for null date, got %v", result)
+		}
+	})
+
+	t.Run("invalid timezone error", func(t *testing.T) {
+		expr := bson.D{{Key: "$dateToParts", Value: bson.D{
+			{Key: "date", Value: "$d"},
+			{Key: "timezone", Value: "Fake/Zone"},
+		}}}
+		_, err := EvalExpr(expr, doc)
+		if err == nil {
+			t.Fatal("expected error for invalid timezone")
+		}
+	})
+
+	t.Run("missing field returns null", func(t *testing.T) {
+		emptyDoc := makeDoc(t, bson.D{})
+		expr := bson.D{{Key: "$dateToParts", Value: bson.D{
+			{Key: "date", Value: "$nofield"},
+		}}}
+		result := evalExprHelper(t, expr, emptyDoc)
+		if result != nil {
+			t.Fatalf("expected nil for missing field, got %v", result)
+		}
+	})
+}
+
+func TestExprDateFromParts(t *testing.T) {
+	doc := makeDoc(t, bson.D{})
+
+	t.Run("basic calendar", func(t *testing.T) {
+		expr := bson.D{{Key: "$dateFromParts", Value: bson.D{
+			{Key: "year", Value: int32(2026)},
+			{Key: "month", Value: int32(5)},
+			{Key: "day", Value: int32(1)},
+			{Key: "hour", Value: int32(14)},
+			{Key: "minute", Value: int32(30)},
+			{Key: "second", Value: int32(45)},
+			{Key: "millisecond", Value: int32(123)},
+		}}}
+		result := evalExprHelper(t, expr, doc)
+		got, ok := toTime(result)
+		if !ok {
+			t.Fatalf("expected time.Time, got %T (%v)", result, result)
+		}
+		expect := time.Date(2026, 5, 1, 14, 30, 45, 123000000, time.UTC)
+		if !got.Equal(expect) {
+			t.Fatalf("got %v, want %v", got, expect)
+		}
+	})
+
+	t.Run("missing optional fields default to lowest", func(t *testing.T) {
+		expr := bson.D{{Key: "$dateFromParts", Value: bson.D{
+			{Key: "year", Value: int32(2026)},
+		}}}
+		result := evalExprHelper(t, expr, doc)
+		got, ok := toTime(result)
+		if !ok {
+			t.Fatalf("expected time.Time, got %T", result)
+		}
+		expect := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+		if !got.Equal(expect) {
+			t.Fatalf("got %v, want %v", got, expect)
+		}
+	})
+
+	t.Run("ISO week date form", func(t *testing.T) {
+		expr := bson.D{{Key: "$dateFromParts", Value: bson.D{
+			{Key: "isoWeekYear", Value: int32(2026)},
+			{Key: "isoWeek", Value: int32(18)},
+			{Key: "isoDayOfWeek", Value: int32(5)}, // Friday
+		}}}
+		result := evalExprHelper(t, expr, doc)
+		got, ok := toTime(result)
+		if !ok {
+			t.Fatalf("expected time.Time, got %T", result)
+		}
+		expect := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+		if !got.Equal(expect) {
+			t.Fatalf("got %v, want %v", got, expect)
+		}
+	})
+
+	t.Run("with timezone", func(t *testing.T) {
+		expr := bson.D{{Key: "$dateFromParts", Value: bson.D{
+			{Key: "year", Value: int32(2026)},
+			{Key: "month", Value: int32(5)},
+			{Key: "day", Value: int32(1)},
+			{Key: "hour", Value: int32(10)},
+			{Key: "timezone", Value: "America/New_York"},
+		}}}
+		result := evalExprHelper(t, expr, doc)
+		got, ok := toTime(result)
+		if !ok {
+			t.Fatalf("expected time.Time, got %T", result)
+		}
+		// 10:00 EDT (UTC-4) = 14:00 UTC
+		expect := time.Date(2026, 5, 1, 14, 0, 0, 0, time.UTC)
+		if !got.Equal(expect) {
+			t.Fatalf("got %v, want %v", got, expect)
+		}
+	})
+
+	t.Run("ISO defaults only isoWeekYear", func(t *testing.T) {
+		// Only isoWeekYear → defaults to week 1, day 1 (Monday)
+		expr := bson.D{{Key: "$dateFromParts", Value: bson.D{
+			{Key: "isoWeekYear", Value: int32(2026)},
+		}}}
+		result := evalExprHelper(t, expr, doc)
+		got, ok := toTime(result)
+		if !ok {
+			t.Fatalf("expected time.Time, got %T", result)
+		}
+		// ISO week 1 day 1 of 2026 = Monday 2025-12-29
+		expect := time.Date(2025, 12, 29, 0, 0, 0, 0, time.UTC)
+		if !got.Equal(expect) {
+			t.Fatalf("got %v, want %v", got, expect)
+		}
+	})
+
+	t.Run("invalid timezone", func(t *testing.T) {
+		expr := bson.D{{Key: "$dateFromParts", Value: bson.D{
+			{Key: "year", Value: int32(2026)},
+			{Key: "timezone", Value: "Not/A/Timezone"},
+		}}}
+		_, err := EvalExpr(expr, doc)
+		if err == nil {
+			t.Fatal("expected error for invalid timezone")
+		}
+	})
+
+	t.Run("round-trip parts to date to parts", func(t *testing.T) {
+		ts := time.Date(2026, 7, 15, 8, 45, 30, 500000000, time.UTC)
+		tsDoc := makeDoc(t, bson.D{{Key: "d", Value: ts}})
+
+		// dateToParts
+		partsExpr := bson.D{{Key: "$dateToParts", Value: bson.D{
+			{Key: "date", Value: "$d"},
+		}}}
+		parts := evalExprHelper(t, partsExpr, tsDoc)
+		partsDoc, ok := parts.(bson.D)
+		if !ok {
+			t.Fatalf("expected bson.D, got %T", parts)
+		}
+
+		// Reconstruct using $dateFromParts
+		fromPartsInput := bson.D{{Key: "$dateFromParts", Value: partsDoc}}
+		result := evalExprHelper(t, fromPartsInput, tsDoc)
+		got, ok := toTime(result)
+		if !ok {
+			t.Fatalf("expected time.Time, got %T", result)
+		}
+		if !got.Equal(ts) {
+			t.Fatalf("round-trip failed: got %v, want %v", got, ts)
 		}
 	})
 }


### PR DESCRIPTION
Closes #486

## What
Implements two complementary date expression operators:
- `$dateToParts` — decomposes a date into {year, month, day, hour, minute, second, millisecond} with optional timezone and `iso8601: true` for ISO week date output
- `$dateFromParts` — constructs a date from calendar parts (year/month/day) or ISO week parts (isoWeekYear/isoWeek/isoDayOfWeek) with optional timezone

## Why
These are standard MongoDB aggregation operators needed for date manipulation in pipelines. They enable round-tripping dates through component parts, timezone-aware decomposition, and date construction from individual fields.

## Tests
13 unit tests covering:
- Basic decompose and compose
- ISO 8601 week date mode (both directions)
- Timezone handling (IANA names)
- Round-trip (dateToParts → dateFromParts → same date)
- Null/missing field → null
- Invalid timezone → error
- ISO defaults (only isoWeekYear provided)

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#486"]
```

*Posted by the founder agent on behalf of @inder*