### PR TITLE
feat: implement $bitAnd, $bitOr, $bitNot, $bitXor expression operators

### DIFF
--- a/internal/aggregation/expressions.go
+++ b/internal/aggregation/expressions.go
@@ -437,6 +437,16 @@ func evalOperatorExpr(op string, arg bson.RawValue, doc bson.Raw) (interface{}, 
 	case "$allElementsTrue":
 		return evalAnyAllElementsTrue(arg, doc, true)
 
+	// ── Bitwise ─────────────────────────────────────────────────────────────
+	case "$bitAnd":
+		return evalBitwise(arg, doc, "$bitAnd")
+	case "$bitOr":
+		return evalBitwise(arg, doc, "$bitOr")
+	case "$bitXor":
+		return evalBitwise(arg, doc, "$bitXor")
+	case "$bitNot":
+		return evalBitNot(arg, doc)
+
 	// ── Miscellaneous ────────────────────────────────────────────────────────
 	case "$rand":
 		if arg.Type != bson.TypeEmbeddedDocument {
@@ -3621,6 +3631,111 @@ func appendField(doc bson.Raw, key string, val bson.RawValue) bson.Raw {
 		return doc
 	}
 	return bson.Raw(raw)
+}
+
+// ─── Bitwise expressions ─────────────────────────────────────────────────────
+
+// toInt64ForBitwise converts a value to int64 for bitwise operations.
+// Returns (value, isNull, error). Only int32 and int64 are accepted.
+func toInt64ForBitwise(v interface{}, op string) (int64, bool, error) {
+	if v == nil {
+		return 0, true, nil
+	}
+	switch n := v.(type) {
+	case int32:
+		return int64(n), false, nil
+	case int64:
+		return n, false, nil
+	default:
+		return 0, false, fmt.Errorf("%s only supports int types, got %T", op, v)
+	}
+}
+
+// evalBitwise implements $bitAnd, $bitOr, $bitXor (variadic, 2+ args).
+// Type-checks all arguments before null-propagating (matches MongoDB behavior).
+func evalBitwise(arg bson.RawValue, doc bson.Raw, op string) (interface{}, error) {
+	args, err := evalArgs(arg, doc)
+	if err != nil {
+		return nil, err
+	}
+	if len(args) < 2 {
+		return nil, fmt.Errorf("%s requires at least 2 arguments, got %d", op, len(args))
+	}
+
+	// First pass: type-check all args and detect nulls.
+	vals := make([]int64, len(args))
+	hasNull := false
+	allInt32 := true
+	for i, a := range args {
+		v, isNull, err := toInt64ForBitwise(a, op)
+		if err != nil {
+			return nil, err
+		}
+		if isNull {
+			hasNull = true
+			continue
+		}
+		vals[i] = v
+		if _, ok := a.(int32); !ok {
+			allInt32 = false
+		}
+	}
+	if hasNull {
+		return nil, nil
+	}
+
+	// Second pass: compute the result.
+	result := vals[0]
+	for i := 1; i < len(vals); i++ {
+		switch op {
+		case "$bitAnd":
+			result &= vals[i]
+		case "$bitOr":
+			result |= vals[i]
+		case "$bitXor":
+			result ^= vals[i]
+		}
+	}
+
+	if allInt32 {
+		return int32(result), nil
+	}
+	return result, nil
+}
+
+// evalBitNot implements $bitNot (unary, exactly 1 argument).
+func evalBitNot(arg bson.RawValue, doc bson.Raw) (interface{}, error) {
+	// $bitNot accepts a single expression, not necessarily in an array
+	var val interface{}
+	var err error
+	if arg.Type == bson.TypeArray {
+		args, err := evalArgs(arg, doc)
+		if err != nil {
+			return nil, err
+		}
+		if len(args) != 1 {
+			return nil, fmt.Errorf("$bitNot requires exactly 1 argument, got %d", len(args))
+		}
+		val = args[0]
+	} else {
+		val, err = EvalExpr(arg, doc)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	n, isNull, err := toInt64ForBitwise(val, "$bitNot")
+	if err != nil {
+		return nil, err
+	}
+	if isNull {
+		return nil, nil
+	}
+
+	if _, ok := val.(int32); ok {
+		return ^int32(n), nil
+	}
+	return ^n, nil
 }
 
 // big.Int wrapper for Decimal128 (simplified)

--- a/internal/aggregation/expressions_test.go
+++ b/internal/aggregation/expressions_test.go
@@ -1,6 +1,7 @@
 package aggregation
 
 import (
+	"math"
 	"reflect"
 	"testing"
 	"time"
@@ -2389,4 +2390,148 @@ func TestExprDateFromParts(t *testing.T) {
 			t.Fatalf("round-trip failed: got %v, want %v", got, ts)
 		}
 	})
+}
+
+// ─── Bitwise expressions ─────────────────────────────────────────────────────
+
+func TestExprBitAnd(t *testing.T) {
+	doc := makeDoc(t, bson.D{{Key: "a", Value: int32(0b1100)}, {Key: "b", Value: int32(0b1010)}})
+
+	tests := []struct {
+		name    string
+		expr    interface{}
+		want    interface{}
+		wantErr bool
+	}{
+		{"int32 basic", bson.D{{Key: "$bitAnd", Value: bson.A{"$a", "$b"}}}, int32(0b1000), false},
+		{"int32 literals", bson.D{{Key: "$bitAnd", Value: bson.A{int32(0xFF), int32(0x0F)}}}, int32(0x0F), false},
+		{"int64", bson.D{{Key: "$bitAnd", Value: bson.A{int64(0xFF00), int64(0x0FF0)}}}, int64(0x0F00), false},
+		{"mixed int32+int64", bson.D{{Key: "$bitAnd", Value: bson.A{int32(0xFF), int64(0x0F)}}}, int64(0x0F), false},
+		{"variadic 3 args", bson.D{{Key: "$bitAnd", Value: bson.A{int32(0xFF), int32(0x0F), int32(0x03)}}}, int32(0x03), false},
+		{"null propagation", bson.D{{Key: "$bitAnd", Value: bson.A{int32(5), nil}}}, nil, false},
+		{"all zeros", bson.D{{Key: "$bitAnd", Value: bson.A{int32(0), int32(0)}}}, int32(0), false},
+		{"all ones", bson.D{{Key: "$bitAnd", Value: bson.A{int32(-1), int32(-1)}}}, int32(-1), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := EvalExpr(tt.expr, doc)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result != tt.want {
+				t.Errorf("got %v (%T), want %v (%T)", result, result, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestExprBitOr(t *testing.T) {
+	doc := makeDoc(t, bson.D{})
+
+	tests := []struct {
+		name string
+		expr interface{}
+		want interface{}
+	}{
+		{"basic", bson.D{{Key: "$bitOr", Value: bson.A{int32(0b1100), int32(0b0011)}}}, int32(0b1111)},
+		{"int64", bson.D{{Key: "$bitOr", Value: bson.A{int64(0), int64(0xFF)}}}, int64(0xFF)},
+		{"variadic", bson.D{{Key: "$bitOr", Value: bson.A{int32(1), int32(2), int32(4)}}}, int32(7)},
+		{"null", bson.D{{Key: "$bitOr", Value: bson.A{nil, int32(5)}}}, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evalExprHelper(t, tt.expr, doc)
+			if got != tt.want {
+				t.Errorf("got %v (%T), want %v (%T)", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestExprBitXor(t *testing.T) {
+	doc := makeDoc(t, bson.D{})
+
+	tests := []struct {
+		name string
+		expr interface{}
+		want interface{}
+	}{
+		{"basic", bson.D{{Key: "$bitXor", Value: bson.A{int32(0b1100), int32(0b1010)}}}, int32(0b0110)},
+		{"same value", bson.D{{Key: "$bitXor", Value: bson.A{int32(42), int32(42)}}}, int32(0)},
+		{"int64", bson.D{{Key: "$bitXor", Value: bson.A{int64(0xFF), int64(0x0F)}}}, int64(0xF0)},
+		{"variadic", bson.D{{Key: "$bitXor", Value: bson.A{int32(1), int32(3), int32(2)}}}, int32(0)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evalExprHelper(t, tt.expr, doc)
+			if got != tt.want {
+				t.Errorf("got %v (%T), want %v (%T)", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestExprBitNot(t *testing.T) {
+	doc := makeDoc(t, bson.D{})
+
+	tests := []struct {
+		name string
+		expr interface{}
+		want interface{}
+	}{
+		{"int32", bson.D{{Key: "$bitNot", Value: int32(0)}}, int32(-1)},
+		{"int32 -1", bson.D{{Key: "$bitNot", Value: int32(-1)}}, int32(0)},
+		{"int32 max", bson.D{{Key: "$bitNot", Value: int32(0x7FFFFFFF)}}, int32(-0x80000000)},
+		{"int64", bson.D{{Key: "$bitNot", Value: int64(0)}}, int64(-1)},
+		{"int64 specific", bson.D{{Key: "$bitNot", Value: int64(0xFF)}}, int64(-256)},
+		{"int64 max", bson.D{{Key: "$bitNot", Value: int64(math.MaxInt64)}}, int64(math.MinInt64)},
+		{"int64 min", bson.D{{Key: "$bitNot", Value: int64(math.MinInt64)}}, int64(math.MaxInt64)},
+		{"null", bson.D{{Key: "$bitNot", Value: nil}}, nil},
+		{"array form", bson.D{{Key: "$bitNot", Value: bson.A{int32(0)}}}, int32(-1)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evalExprHelper(t, tt.expr, doc)
+			if got != tt.want {
+				t.Errorf("got %v (%T), want %v (%T)", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestExprBitwiseErrors(t *testing.T) {
+	doc := makeDoc(t, bson.D{})
+
+	tests := []struct {
+		name string
+		expr interface{}
+	}{
+		{"bitAnd with double", bson.D{{Key: "$bitAnd", Value: bson.A{float64(1.5), int32(1)}}}},
+		{"bitOr with string", bson.D{{Key: "$bitOr", Value: bson.A{int32(1), "hello"}}}},
+		{"bitXor with bool", bson.D{{Key: "$bitXor", Value: bson.A{int32(1), true}}}},
+		{"bitNot with double", bson.D{{Key: "$bitNot", Value: float64(1.0)}}},
+		{"bitAnd too few args", bson.D{{Key: "$bitAnd", Value: bson.A{int32(1)}}}},
+		{"bitNot too many args", bson.D{{Key: "$bitNot", Value: bson.A{int32(1), int32(2)}}}},
+		{"bitAnd null before bad type", bson.D{{Key: "$bitAnd", Value: bson.A{nil, float64(1.5)}}}},
+		{"bitOr bad type after null", bson.D{{Key: "$bitOr", Value: bson.A{nil, "bad"}}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := EvalExpr(tt.expr, doc)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
 }


### PR DESCRIPTION
Closes #503

## What
Implements the four bitwise expression operators (MongoDB 6.3+):
- `$bitAnd` — variadic (2+ args), returns bitwise AND
- `$bitOr` — variadic (2+ args), returns bitwise OR
- `$bitXor` — variadic (2+ args), returns bitwise XOR
- `$bitNot` — unary (1 arg), returns bitwise complement

## Why
Continues the expression operator coverage sprint. These are commonly used in IoT/embedded data pipelines where documents store flags and bitmasks.

## Behavior
- Accepts int32 and int64 inputs only; errors on float/string/bool
- Returns int32 when all inputs are int32, int64 otherwise
- Null propagation: any null input → null result
- Type checking happens before null propagation (matches MongoDB behavior)
- `$bitNot` accepts both direct value and array-wrapped forms

## Tests
29 test cases covering:
- Basic operations for all four operators
- int32/int64/mixed type handling
- Variadic (3+ args)
- Null propagation
- Edge values (0, -1, MAX_INT32, MAX_INT64, MIN_INT64)
- Error cases: wrong types, too few/many args, null-before-bad-type

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#503"]
```

*Posted by the founder agent on behalf of @inder*