### PR TITLE
feat: implement $tsSecond and $tsIncrement expression operators

### DIFF
--- a/internal/aggregation/expressions.go
+++ b/internal/aggregation/expressions.go
@@ -377,6 +377,12 @@ func evalOperatorExpr(op string, arg bson.RawValue, doc bson.Raw) (interface{}, 
 	case "$dateFromParts":
 		return evalDateFromParts(arg, doc)
 
+	// ── Timestamp ────────────────────────────────────────────────────────────
+	case "$tsSecond":
+		return evalTsComponent(arg, doc, true)
+	case "$tsIncrement":
+		return evalTsComponent(arg, doc, false)
+
 	// ── Comparison ───────────────────────────────────────────────────────────
 	case "$cmp":
 		return evalCmpExpr(arg, doc)
@@ -2831,6 +2837,36 @@ func mongoDateFormat(t time.Time, format string) string {
 		result = strings.ReplaceAll(result, k, v)
 	}
 	return result
+}
+
+// ─── Timestamp expressions ────────────────────────────────────────────────────
+
+// evalTsComponent extracts the seconds (second=true) or increment (second=false)
+// component from a BSON Timestamp value.
+func evalTsComponent(arg bson.RawValue, doc bson.Raw, second bool) (interface{}, error) {
+	val, err := EvalExpr(arg, doc)
+	if err != nil {
+		return nil, err
+	}
+	if val == nil {
+		return nil, nil
+	}
+	rv := interfaceToRawValue(val)
+	if rv.Type == bson.TypeNull {
+		return nil, nil
+	}
+	if rv.Type != bson.TypeTimestamp {
+		name := "$tsSecond"
+		if !second {
+			name = "$tsIncrement"
+		}
+		return nil, fmt.Errorf("%s requires a timestamp input, got %s", name, query.BsonTypeName(rv.Type))
+	}
+	t, i := rv.Timestamp()
+	if second {
+		return int64(t), nil
+	}
+	return int64(i), nil
 }
 
 // ─── Comparison expressions ───────────────────────────────────────────────────

--- a/internal/aggregation/expressions_test.go
+++ b/internal/aggregation/expressions_test.go
@@ -2392,6 +2392,71 @@ func TestExprDateFromParts(t *testing.T) {
 	})
 }
 
+// ─── Timestamp expressions ────────────────────────────────────────────────────
+
+func TestExprTsSecond(t *testing.T) {
+	doc := makeDoc(t, bson.D{{Key: "ts", Value: bson.Timestamp{T: 1704067200, I: 42}}})
+
+	tests := []struct {
+		name    string
+		expr    interface{}
+		want    interface{}
+		wantErr bool
+	}{
+		{"basic", bson.D{{Key: "$tsSecond", Value: "$ts"}}, int64(1704067200), false},
+		{"zero", bson.D{{Key: "$tsSecond", Value: bson.Timestamp{T: 0, I: 0}}}, int64(0), false},
+		{"max uint32", bson.D{{Key: "$tsSecond", Value: bson.Timestamp{T: 4294967295, I: 1}}}, int64(4294967295), false},
+		{"null input", bson.D{{Key: "$tsSecond", Value: nil}}, nil, false},
+		{"missing field", bson.D{{Key: "$tsSecond", Value: "$nonexistent"}}, nil, false},
+		{"wrong type string", bson.D{{Key: "$tsSecond", Value: "hello"}}, nil, true},
+		{"wrong type int", bson.D{{Key: "$tsSecond", Value: int32(42)}}, nil, true},
+		{"wrong type date", bson.D{{Key: "$tsSecond", Value: bson.DateTime(1704067200000)}}, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EvalExpr(tt.expr, doc)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v (%T), want %v (%T)", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func TestExprTsIncrement(t *testing.T) {
+	doc := makeDoc(t, bson.D{{Key: "ts", Value: bson.Timestamp{T: 1704067200, I: 42}}})
+
+	tests := []struct {
+		name    string
+		expr    interface{}
+		want    interface{}
+		wantErr bool
+	}{
+		{"basic", bson.D{{Key: "$tsIncrement", Value: "$ts"}}, int64(42), false},
+		{"zero increment", bson.D{{Key: "$tsIncrement", Value: bson.Timestamp{T: 100, I: 0}}}, int64(0), false},
+		{"max uint32", bson.D{{Key: "$tsIncrement", Value: bson.Timestamp{T: 0, I: 4294967295}}}, int64(4294967295), false},
+		{"null input", bson.D{{Key: "$tsIncrement", Value: nil}}, nil, false},
+		{"missing field", bson.D{{Key: "$tsIncrement", Value: "$nonexistent"}}, nil, false},
+		{"wrong type string", bson.D{{Key: "$tsIncrement", Value: "hello"}}, nil, true},
+		{"wrong type int", bson.D{{Key: "$tsIncrement", Value: int64(42)}}, nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EvalExpr(tt.expr, doc)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v (%T), want %v (%T)", got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
 // ─── Bitwise expressions ─────────────────────────────────────────────────────
 
 func TestExprBitAnd(t *testing.T) {


### PR DESCRIPTION
Closes #502

## What
Implement `$tsSecond` and `$tsIncrement` expression operators (MongoDB 5.1+). These extract the seconds and increment components from a BSON Timestamp value, returning `int64`.

## Why
Fills a gap in timestamp introspection — these are needed for oplog-style queries and change stream analysis where callers need to decompose Timestamp values.

## Changes
- `internal/aggregation/expressions.go`: added `evalTsComponent` function and switch cases
- `internal/aggregation/expressions_test.go`: 15 test cases covering happy path, null/missing, wrong types, boundary values

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#502"]
```

*Posted by the founder agent on behalf of @inder*