### PR TITLE
feat: implement SCRAM-SHA-1 authentication mechanism

### DIFF
--- a/internal/auth/scram.go
+++ b/internal/auth/scram.go
@@ -1,4 +1,4 @@
-// Package auth implements SCRAM-SHA-256 authentication per RFC 5802.
+// Package auth implements SCRAM-SHA-256 and SCRAM-SHA-1 authentication per RFC 5802.
 package auth
 
 import (
@@ -13,7 +13,7 @@ import (
 	"github.com/inder/salvobase/internal/storage"
 )
 
-// Manager handles SCRAM-SHA-256 authentication conversations.
+// Manager handles SCRAM-SHA-256 and SCRAM-SHA-1 authentication conversations.
 // It is safe for concurrent use.
 type Manager struct {
 	users  storage.UserStore
@@ -63,8 +63,7 @@ func (m *Manager) cleanupLoop() {
 }
 
 // SASLStart handles the initial saslStart command.
-// mechanism must be "SCRAM-SHA-256" (SCRAM-SHA-1 is accepted for compat but
-// the server always uses SHA-256 credentials).
+// mechanism must be "SCRAM-SHA-256" or "SCRAM-SHA-1".
 // payload is the SCRAM client-first-message: n,,n=<username>,r=<nonce>
 // Returns (serverFirstMessage, conversationID, error).
 func (m *Manager) SASLStart(db, mechanism string, payload []byte) ([]byte, int32, error) {
@@ -73,15 +72,15 @@ func (m *Manager) SASLStart(db, mechanism string, payload []byte) ([]byte, int32
 		return nil, 0, fmt.Errorf("unsupported SASL mechanism: %s", mechanism)
 	}
 
+	useSHA1 := mech == "SCRAM-SHA-1"
+
 	// Parse the username from the client-first-message.
-	// Format: n,,n=<username>,r=<nonce>
-	// or: n,a=<authzid>,n=<username>,r=<nonce>
 	username, err := parseUsernameFromClientFirst(string(payload))
 	if err != nil {
 		return nil, 0, fmt.Errorf("SASL: failed to parse client-first-message: %w", err)
 	}
 
-	// Build credential lookup function that fetches SCRAM credentials for this db.
+	// Build credential lookup function that fetches the right SCRAM credentials.
 	credLookup := func(name string) (scram.StoredCredentials, error) {
 		user, ok, lookupErr := m.users.GetUser(db, name)
 		if lookupErr != nil {
@@ -89,6 +88,19 @@ func (m *Manager) SASLStart(db, mechanism string, payload []byte) ([]byte, int32
 		}
 		if !ok {
 			return scram.StoredCredentials{}, fmt.Errorf("authentication failed")
+		}
+		if useSHA1 {
+			if user.StoredKeySHA1 == nil {
+				return scram.StoredCredentials{}, fmt.Errorf("authentication failed")
+			}
+			return scram.StoredCredentials{
+				KeyFactors: scram.KeyFactors{
+					Salt:  string(user.SaltSHA1),
+					Iters: user.IterCountSHA1,
+				},
+				StoredKey: user.StoredKeySHA1,
+				ServerKey: user.ServerKeySHA1,
+			}, nil
 		}
 		return scram.StoredCredentials{
 			KeyFactors: scram.KeyFactors{
@@ -100,7 +112,11 @@ func (m *Manager) SASLStart(db, mechanism string, payload []byte) ([]byte, int32
 		}, nil
 	}
 
-	serverSCRAM, err := scram.SHA256.NewServer(credLookup)
+	hashGen := scram.SHA256
+	if useSHA1 {
+		hashGen = scram.SHA1
+	}
+	serverSCRAM, err := hashGen.NewServer(credLookup)
 	if err != nil {
 		return nil, 0, fmt.Errorf("SASL: failed to create SCRAM server: %w", err)
 	}

--- a/internal/auth/scram_test.go
+++ b/internal/auth/scram_test.go
@@ -1,0 +1,363 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha1" //nolint:gosec
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/xdg-go/scram"
+	"golang.org/x/crypto/pbkdf2"
+
+	"github.com/inder/salvobase/internal/storage"
+)
+
+// TestHashPassword verifies SCRAM-SHA-256 key derivation produces valid credentials.
+func TestHashPassword(t *testing.T) {
+	storedKey, serverKey, salt, iterCount, err := HashPassword("testpassword")
+	if err != nil {
+		t.Fatalf("HashPassword: %v", err)
+	}
+	if iterCount != 15000 {
+		t.Errorf("expected iterCount=15000, got %d", iterCount)
+	}
+	if len(salt) != 16 {
+		t.Errorf("expected 16-byte salt, got %d", len(salt))
+	}
+	if len(storedKey) != 32 {
+		t.Errorf("expected 32-byte storedKey (SHA-256), got %d", len(storedKey))
+	}
+	if len(serverKey) != 32 {
+		t.Errorf("expected 32-byte serverKey (SHA-256), got %d", len(serverKey))
+	}
+
+	// Verify the derived keys match manual computation.
+	saltedPassword := pbkdf2.Key([]byte("testpassword"), salt, iterCount, 32, sha256.New)
+	ckMAC := hmac.New(sha256.New, saltedPassword)
+	ckMAC.Write([]byte("Client Key"))
+	clientKey := ckMAC.Sum(nil)
+	expectedStored := sha256.Sum256(clientKey)
+	if !hmac.Equal(storedKey, expectedStored[:]) {
+		t.Error("storedKey does not match manual derivation")
+	}
+	skMAC := hmac.New(sha256.New, saltedPassword)
+	skMAC.Write([]byte("Server Key"))
+	expectedServer := skMAC.Sum(nil)
+	if !hmac.Equal(serverKey, expectedServer) {
+		t.Error("serverKey does not match manual derivation")
+	}
+}
+
+// TestHashPasswordSHA1 verifies SCRAM-SHA-1 key derivation produces valid credentials.
+func TestHashPasswordSHA1(t *testing.T) {
+	storedKey, serverKey, salt, iterCount, err := HashPasswordSHA1("testpassword")
+	if err != nil {
+		t.Fatalf("HashPasswordSHA1: %v", err)
+	}
+	if iterCount != 10000 {
+		t.Errorf("expected iterCount=10000, got %d", iterCount)
+	}
+	if len(salt) != 16 {
+		t.Errorf("expected 16-byte salt, got %d", len(salt))
+	}
+	if len(storedKey) != 20 {
+		t.Errorf("expected 20-byte storedKey (SHA-1), got %d", len(storedKey))
+	}
+	if len(serverKey) != 20 {
+		t.Errorf("expected 20-byte serverKey (SHA-1), got %d", len(serverKey))
+	}
+
+	// Verify the derived keys match manual computation.
+	saltedPassword := pbkdf2.Key([]byte("testpassword"), salt, iterCount, 20, sha1.New) //nolint:gosec
+	ckMAC := hmac.New(sha1.New, saltedPassword)                                         //nolint:gosec
+	ckMAC.Write([]byte("Client Key"))
+	clientKey := ckMAC.Sum(nil)
+	expectedStored := sha1.Sum(clientKey) //nolint:gosec
+	if !hmac.Equal(storedKey, expectedStored[:]) {
+		t.Error("storedKey does not match manual derivation")
+	}
+	skMAC := hmac.New(sha1.New, saltedPassword) //nolint:gosec
+	skMAC.Write([]byte("Server Key"))
+	expectedServer := skMAC.Sum(nil)
+	if !hmac.Equal(serverKey, expectedServer) {
+		t.Error("serverKey does not match manual derivation")
+	}
+}
+
+// TestHashPasswordDifferentSalts ensures two calls produce different salts.
+func TestHashPasswordDifferentSalts(t *testing.T) {
+	_, _, salt1, _, _ := HashPassword("same")
+	_, _, salt2, _, _ := HashPassword("same")
+	if hmac.Equal(salt1, salt2) {
+		t.Error("two HashPassword calls should produce different salts")
+	}
+
+	_, _, salt3, _, _ := HashPasswordSHA1("same")
+	_, _, salt4, _, _ := HashPasswordSHA1("same")
+	if hmac.Equal(salt3, salt4) {
+		t.Error("two HashPasswordSHA1 calls should produce different salts")
+	}
+}
+
+// mockUserStore is a minimal UserStore for testing SCRAM conversations.
+type mockUserStore struct {
+	users map[string]storage.User
+}
+
+func (m *mockUserStore) CreateUser(u storage.User) error          { return nil }
+func (m *mockUserStore) UpdateUser(string, string, storage.UserUpdate) error { return nil }
+func (m *mockUserStore) DeleteUser(string, string) error          { return nil }
+func (m *mockUserStore) ListUsers(string) ([]storage.User, error) { return nil, nil }
+func (m *mockUserStore) HasUser(db, username string) (bool, error) {
+	_, ok := m.users[db+"."+username]
+	return ok, nil
+}
+func (m *mockUserStore) GetUser(db, username string) (storage.User, bool, error) {
+	u, ok := m.users[db+"."+username]
+	return u, ok, nil
+}
+
+// TestSASLStartSHA256 verifies a full SCRAM-SHA-256 conversation via SASLStart/Continue.
+func TestSASLStartSHA256(t *testing.T) {
+	testSASLConversation(t, "SCRAM-SHA-256")
+}
+
+// TestSASLStartSHA1 verifies a full SCRAM-SHA-1 conversation via SASLStart/Continue.
+func TestSASLStartSHA1(t *testing.T) {
+	testSASLConversation(t, "SCRAM-SHA-1")
+}
+
+func testSASLConversation(t *testing.T, mechanism string) {
+	t.Helper()
+	password := "s3cret"
+
+	// Generate credentials for both mechanisms.
+	storedKey256, serverKey256, salt256, iter256, err := HashPassword(password)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storedKey1, serverKey1, salt1, iter1, err := HashPasswordSHA1(password)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := &mockUserStore{users: map[string]storage.User{
+		"testdb.alice": {
+			Username:      "alice",
+			DB:            "testdb",
+			StoredKey:     storedKey256,
+			ServerKey:     serverKey256,
+			Salt:          salt256,
+			IterCount:     iter256,
+			StoredKeySHA1: storedKey1,
+			ServerKeySHA1: serverKey1,
+			SaltSHA1:      salt1,
+			IterCountSHA1: iter1,
+		},
+	}}
+
+	mgr := NewManager(store, false)
+
+	// Build a SCRAM client to drive the conversation.
+	var hashGen scram.HashGeneratorFcn
+	if mechanism == "SCRAM-SHA-1" {
+		hashGen = scram.SHA1
+	} else {
+		hashGen = scram.SHA256
+	}
+
+	client, err := hashGen.NewClient("alice", password, "")
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	conv := client.NewConversation()
+
+	// Step 1: client-first-message
+	clientFirst, err := conv.Step("")
+	if err != nil {
+		t.Fatalf("client step 1: %v", err)
+	}
+
+	serverFirst, convID, err := mgr.SASLStart("testdb", mechanism, []byte(clientFirst))
+	if err != nil {
+		t.Fatalf("SASLStart: %v", err)
+	}
+
+	// Step 2: client-final-message
+	clientFinal, err := conv.Step(string(serverFirst))
+	if err != nil {
+		t.Fatalf("client step 2: %v", err)
+	}
+
+	serverFinal, done, err := mgr.SASLContinue(convID, []byte(clientFinal))
+	if err != nil {
+		t.Fatalf("SASLContinue step 2: %v", err)
+	}
+
+	// Step 3: verify server signature
+	_, err = conv.Step(string(serverFinal))
+	if err != nil {
+		t.Fatalf("client step 3 (verify server sig): %v", err)
+	}
+
+	if !done {
+		// The xdg-go/scram library marks done after the server-final step.
+		// Some implementations need one more empty Continue to finalize.
+		_, done, err = mgr.SASLContinue(convID, []byte(""))
+		if err != nil {
+			t.Fatalf("SASLContinue final: %v", err)
+		}
+		if !done {
+			t.Fatal("expected conversation to be done after final step")
+		}
+	}
+
+	username, db, ok := mgr.GetAuthenticatedUser(convID)
+	if !ok {
+		t.Fatal("expected authenticated user")
+	}
+	if username != "alice" || db != "testdb" {
+		t.Errorf("got user=%q db=%q, want alice/testdb", username, db)
+	}
+}
+
+// TestSASLStartWrongPassword verifies that a wrong password is rejected.
+func TestSASLStartWrongPassword(t *testing.T) {
+	for _, mech := range []string{"SCRAM-SHA-256", "SCRAM-SHA-1"} {
+		t.Run(mech, func(t *testing.T) {
+			storedKey256, serverKey256, salt256, iter256, _ := HashPassword("correct")
+			storedKey1, serverKey1, salt1, iter1, _ := HashPasswordSHA1("correct")
+
+			store := &mockUserStore{users: map[string]storage.User{
+				"testdb.bob": {
+					Username:      "bob",
+					DB:            "testdb",
+					StoredKey:     storedKey256,
+					ServerKey:     serverKey256,
+					Salt:          salt256,
+					IterCount:     iter256,
+					StoredKeySHA1: storedKey1,
+					ServerKeySHA1: serverKey1,
+					SaltSHA1:      salt1,
+					IterCountSHA1: iter1,
+				},
+			}}
+
+			mgr := NewManager(store, false)
+
+			var hashGen scram.HashGeneratorFcn
+			if mech == "SCRAM-SHA-1" {
+				hashGen = scram.SHA1
+			} else {
+				hashGen = scram.SHA256
+			}
+
+			client, _ := hashGen.NewClient("bob", "wrong-password", "")
+			conv := client.NewConversation()
+			clientFirst, _ := conv.Step("")
+
+			serverFirst, convID, err := mgr.SASLStart("testdb", mech, []byte(clientFirst))
+			if err != nil {
+				t.Fatalf("SASLStart: %v", err)
+			}
+
+			clientFinal, _ := conv.Step(string(serverFirst))
+			_, _, err = mgr.SASLContinue(convID, []byte(clientFinal))
+			if err == nil {
+				t.Error("expected authentication to fail with wrong password")
+			}
+		})
+	}
+}
+
+// TestSASLStartUnsupportedMechanism verifies that unsupported mechanisms are rejected.
+func TestSASLStartUnsupportedMechanism(t *testing.T) {
+	mgr := NewManager(&mockUserStore{}, false)
+	_, _, err := mgr.SASLStart("db", "PLAIN", []byte("n,,n=user,r=nonce"))
+	if err == nil || !strings.Contains(err.Error(), "unsupported") {
+		t.Errorf("expected unsupported mechanism error, got: %v", err)
+	}
+}
+
+// TestSASLStartUserNotFound verifies that a non-existent user is rejected.
+func TestSASLStartUserNotFound(t *testing.T) {
+	store := &mockUserStore{users: map[string]storage.User{}}
+	mgr := NewManager(store, false)
+
+	for _, mech := range []string{"SCRAM-SHA-256", "SCRAM-SHA-1"} {
+		t.Run(mech, func(t *testing.T) {
+			_, _, err := mgr.SASLStart("testdb", mech, []byte("n,,n=nobody,r=randomnonce123"))
+			if err == nil || !strings.Contains(err.Error(), "failed") {
+				t.Errorf("expected auth failure for non-existent user, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestSASLStartSHA1NoCredentials verifies that SHA-1 auth fails when user has no SHA-1 credentials.
+func TestSASLStartSHA1NoCredentials(t *testing.T) {
+	storedKey256, serverKey256, salt256, iter256, _ := HashPassword("pass")
+
+	store := &mockUserStore{users: map[string]storage.User{
+		"testdb.sha256only": {
+			Username:  "sha256only",
+			DB:        "testdb",
+			StoredKey: storedKey256,
+			ServerKey: serverKey256,
+			Salt:      salt256,
+			IterCount: iter256,
+			// No SHA-1 credentials
+		},
+	}}
+
+	mgr := NewManager(store, false)
+	_, _, err := mgr.SASLStart("testdb", "SCRAM-SHA-1", []byte("n,,n=sha256only,r=randomnonce123"))
+	if err == nil {
+		t.Error("expected auth failure when user has no SHA-1 credentials")
+	}
+}
+
+// TestMechanismNegotiation verifies the same user can auth with both mechanisms.
+func TestMechanismNegotiation(t *testing.T) {
+	for _, mech := range []string{"SCRAM-SHA-256", "SCRAM-SHA-1"} {
+		t.Run(mech, func(t *testing.T) {
+			testSASLConversation(t, mech)
+		})
+	}
+}
+
+// TestParseUsernameFromClientFirst covers the username parser.
+func TestParseUsernameFromClientFirst(t *testing.T) {
+	tests := []struct {
+		input    string
+		want     string
+		wantErr  bool
+	}{
+		{"n,,n=alice,r=rOprNGfwEbeRWgbNEkqO", "alice", false},
+		{"n,,n=bob=3Dspecial,r=nonce", "bob=special", false},
+		{"n,,n=user=2Cwith=2Ccommas,r=nonce", "user,with,commas", false},
+		{"n,a=authzid,n=carol,r=nonce", "carol", false},
+		{"bad", "", true},
+		{"n,", "", true},
+		{"n,,r=nonceonly", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("input=%q", tt.input), func(t *testing.T) {
+			got, err := parseUsernameFromClientFirst(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha1" //nolint:gosec // SCRAM-SHA-1 requires SHA-1 per RFC 5802
 	"crypto/sha256"
 
 	"golang.org/x/crypto/pbkdf2"
@@ -32,6 +33,32 @@ func HashPassword(password string) (storedKey, serverKey, salt []byte, iterCount
 
 	// ServerKey := HMAC(SaltedPassword, "Server Key")
 	serverKeyHMAC := hmac.New(sha256.New, saltedPassword)
+	serverKeyHMAC.Write([]byte("Server Key"))
+	serverKey = serverKeyHMAC.Sum(nil)
+
+	return storedKey, serverKey, salt, iterCount, nil
+}
+
+// HashPasswordSHA1 derives SCRAM-SHA-1 stored credentials from a plaintext password.
+// Uses SHA-1 per RFC 5802 — required for older MongoDB drivers.
+// Note: SHA-1 collision weaknesses do not apply to SCRAM's HMAC-SHA-1 usage (PRF context).
+func HashPasswordSHA1(password string) (storedKey, serverKey, salt []byte, iterCount int, err error) {
+	iterCount = 10000
+	salt = make([]byte, 16)
+	if _, err = rand.Read(salt); err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	saltedPassword := pbkdf2.Key([]byte(password), salt, iterCount, 20, sha1.New) //nolint:gosec
+
+	clientKeyHMAC := hmac.New(sha1.New, saltedPassword) //nolint:gosec
+	clientKeyHMAC.Write([]byte("Client Key"))
+	clientKeyBytes := clientKeyHMAC.Sum(nil)
+
+	storedKeyArr := sha1.Sum(clientKeyBytes) //nolint:gosec
+	storedKey = storedKeyArr[:]
+
+	serverKeyHMAC := hmac.New(sha1.New, saltedPassword) //nolint:gosec
 	serverKeyHMAC.Write([]byte("Server Key"))
 	serverKey = serverKeyHMAC.Sum(nil)
 

--- a/internal/commands/auth_cmds.go
+++ b/internal/commands/auth_cmds.go
@@ -151,15 +151,24 @@ func handleCreateUser(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		return nil, fmt.Errorf("createUser: failed to hash password: %w", err)
 	}
 
+	storedKeySHA1, serverKeySHA1, saltSHA1, iterCountSHA1, err := auth.HashPasswordSHA1(password)
+	if err != nil {
+		return nil, fmt.Errorf("createUser: failed to hash password (SHA-1): %w", err)
+	}
+
 	user := storage.User{
-		ID:        uuid.New().String(),
-		DB:        ctx.DB,
-		Username:  username,
-		StoredKey: storedKey,
-		ServerKey: serverKey,
-		Salt:      salt,
-		IterCount: iterCount,
-		Roles:     roles,
+		ID:            uuid.New().String(),
+		DB:            ctx.DB,
+		Username:      username,
+		StoredKey:     storedKey,
+		ServerKey:     serverKey,
+		Salt:          salt,
+		IterCount:     iterCount,
+		StoredKeySHA1: storedKeySHA1,
+		ServerKeySHA1: serverKeySHA1,
+		SaltSHA1:      saltSHA1,
+		IterCountSHA1: iterCountSHA1,
+		Roles:         roles,
 	}
 
 	if err := ctx.Engine.Users().CreateUser(user); err != nil {
@@ -209,7 +218,7 @@ func handleUpdateUser(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 
 	update := storage.UserUpdate{}
 
-	// Update password if provided.
+	// Update password if provided — regenerate both SHA-256 and SHA-1 credentials.
 	if password := lookupStringField(cmd, "pwd"); password != "" {
 		storedKey, serverKey, salt, iterCount, err := auth.HashPassword(password)
 		if err != nil {
@@ -219,6 +228,15 @@ func handleUpdateUser(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		update.ServerKey = serverKey
 		update.Salt = salt
 		update.IterCount = iterCount
+
+		storedKeySHA1, serverKeySHA1, saltSHA1, iterCountSHA1, err := auth.HashPasswordSHA1(password)
+		if err != nil {
+			return nil, fmt.Errorf("updateUser: failed to hash password (SHA-1): %w", err)
+		}
+		update.StoredKeySHA1 = storedKeySHA1
+		update.ServerKeySHA1 = serverKeySHA1
+		update.SaltSHA1 = saltSHA1
+		update.IterCountSHA1 = iterCountSHA1
 	}
 
 	// Update roles if provided.

--- a/internal/commands/diagnostic.go
+++ b/internal/commands/diagnostic.go
@@ -53,6 +53,25 @@ func handleHello(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		d = append(d, bson.E{Key: "ismaster", Value: true})
 	}
 
+	// Advertise supported SASL mechanisms when the client sends saslSupportedMechs.
+	// Format: "db.username" — drivers use this to pick the auth mechanism.
+	// Per MongoDB spec, look up the user and return only mechanisms they have credentials for.
+	if saslField := lookupStringField(cmd, "saslSupportedMechs"); saslField != "" {
+		mechs := bson.A{}
+		if parts := strings.SplitN(saslField, ".", 2); len(parts) == 2 {
+			user, ok, err := ctx.Engine.Users().GetUser(parts[0], parts[1])
+			if err == nil && ok {
+				if user.StoredKey != nil {
+					mechs = append(mechs, "SCRAM-SHA-256")
+				}
+				if user.StoredKeySHA1 != nil {
+					mechs = append(mechs, "SCRAM-SHA-1")
+				}
+			}
+		}
+		d = append(d, bson.E{Key: "saslSupportedMechs", Value: mechs})
+	}
+
 	d = append(d, bson.E{Key: "ok", Value: float64(1)})
 	return marshalResponse(d), nil
 }

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -325,18 +325,27 @@ type User struct {
 	ServerKey  []byte   `json:"serverKey"` // SCRAM-SHA-256 ServerKey
 	Salt       []byte   `json:"salt"`      // SCRAM-SHA-256 salt
 	IterCount  int      `json:"iterCount"` // SCRAM-SHA-256 iteration count
-	Roles      []Role   `json:"roles"`
-	CustomData bson.Raw `json:"customData,omitempty"`
+	// SCRAM-SHA-1 credentials (stored alongside SHA-256 for dual-mechanism support)
+	StoredKeySHA1 []byte   `json:"storedKeySHA1,omitempty"`
+	ServerKeySHA1 []byte   `json:"serverKeySHA1,omitempty"`
+	SaltSHA1      []byte   `json:"saltSHA1,omitempty"`
+	IterCountSHA1 int      `json:"iterCountSHA1"`
+	Roles         []Role   `json:"roles"`
+	CustomData    bson.Raw `json:"customData,omitempty"`
 }
 
 // UserUpdate is used to update mutable user fields.
 type UserUpdate struct {
-	StoredKey  []byte
-	ServerKey  []byte
-	Salt       []byte
-	IterCount  int
-	Roles      []Role
-	CustomData bson.Raw
+	StoredKey     []byte
+	ServerKey     []byte
+	Salt          []byte
+	IterCount     int
+	StoredKeySHA1 []byte
+	ServerKeySHA1 []byte
+	SaltSHA1      []byte
+	IterCountSHA1 int
+	Roles         []Role
+	CustomData    bson.Raw
 }
 
 // Role is a database role assignment.

--- a/internal/storage/userstore.go
+++ b/internal/storage/userstore.go
@@ -70,6 +70,18 @@ func (s *userStore) UpdateUser(db, username string, update UserUpdate) error {
 		if update.IterCount != 0 {
 			u.IterCount = update.IterCount
 		}
+		if update.StoredKeySHA1 != nil {
+			u.StoredKeySHA1 = update.StoredKeySHA1
+		}
+		if update.ServerKeySHA1 != nil {
+			u.ServerKeySHA1 = update.ServerKeySHA1
+		}
+		if update.SaltSHA1 != nil {
+			u.SaltSHA1 = update.SaltSHA1
+		}
+		if update.IterCountSHA1 != 0 {
+			u.IterCountSHA1 = update.IterCountSHA1
+		}
 		if update.Roles != nil {
 			u.Roles = update.Roles
 		}


### PR DESCRIPTION
Closes #505

## What
- SCRAM-SHA-1 authentication works end-to-end alongside existing SHA-256
- User creation stores both SHA-1 and SHA-256 credentials
- `hello`/`isMaster` response advertises only mechanisms a user actually has credentials for via `saslSupportedMechs`
- Existing SCRAM-SHA-256 tests still pass (zero regressions)
- New tests: SHA-1 happy path, SHA-1 wrong password, mechanism negotiation, mixed mechanism users, user without SHA-1 creds, username parser

## Why
Older MongoDB drivers (especially certain language drivers) default to or require SCRAM-SHA-1. Without this, those drivers can't connect at all.

## Files changed
- `internal/storage/types.go` — added SHA-1 credential fields to User/UserUpdate
- `internal/storage/userstore.go` — SHA-1 field handling in UpdateUser
- `internal/auth/users.go` — added `HashPasswordSHA1` (PBKDF2-SHA-1 key derivation)
- `internal/auth/scram.go` — `SASLStart` now branches on mechanism to use correct hash
- `internal/commands/auth_cmds.go` — `createUser`/`updateUser` generate both credential sets
- `internal/commands/diagnostic.go` — `saslSupportedMechs` in hello response per MongoDB spec
- `internal/auth/scram_test.go` — 10 new tests covering both mechanisms

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#505"]
```

*Posted by the founder agent on behalf of @inder*