### PR TITLE
fix: gofmt lint failures from SCRAM-SHA-1 merge

### DIFF
--- a/internal/auth/scram_test.go
+++ b/internal/auth/scram_test.go
@@ -106,10 +106,10 @@ type mockUserStore struct {
 	users map[string]storage.User
 }
 
-func (m *mockUserStore) CreateUser(u storage.User) error          { return nil }
+func (m *mockUserStore) CreateUser(u storage.User) error                     { return nil }
 func (m *mockUserStore) UpdateUser(string, string, storage.UserUpdate) error { return nil }
-func (m *mockUserStore) DeleteUser(string, string) error          { return nil }
-func (m *mockUserStore) ListUsers(string) ([]storage.User, error) { return nil, nil }
+func (m *mockUserStore) DeleteUser(string, string) error                     { return nil }
+func (m *mockUserStore) ListUsers(string) ([]storage.User, error)            { return nil, nil }
 func (m *mockUserStore) HasUser(db, username string) (bool, error) {
 	_, ok := m.users[db+"."+username]
 	return ok, nil
@@ -331,9 +331,9 @@ func TestMechanismNegotiation(t *testing.T) {
 // TestParseUsernameFromClientFirst covers the username parser.
 func TestParseUsernameFromClientFirst(t *testing.T) {
 	tests := []struct {
-		input    string
-		want     string
-		wantErr  bool
+		input   string
+		want    string
+		wantErr bool
 	}{
 		{"n,,n=alice,r=rOprNGfwEbeRWgbNEkqO", "alice", false},
 		{"n,,n=bob=3Dspecial,r=nonce", "bob=special", false},

--- a/internal/storage/types.go
+++ b/internal/storage/types.go
@@ -318,13 +318,13 @@ type MemStats struct {
 
 // User is a database user.
 type User struct {
-	ID         string   `json:"id"`
-	DB         string   `json:"db"`
-	Username   string   `json:"user"`
-	StoredKey  []byte   `json:"storedKey"` // SCRAM-SHA-256 StoredKey
-	ServerKey  []byte   `json:"serverKey"` // SCRAM-SHA-256 ServerKey
-	Salt       []byte   `json:"salt"`      // SCRAM-SHA-256 salt
-	IterCount  int      `json:"iterCount"` // SCRAM-SHA-256 iteration count
+	ID        string `json:"id"`
+	DB        string `json:"db"`
+	Username  string `json:"user"`
+	StoredKey []byte `json:"storedKey"` // SCRAM-SHA-256 StoredKey
+	ServerKey []byte `json:"serverKey"` // SCRAM-SHA-256 ServerKey
+	Salt      []byte `json:"salt"`      // SCRAM-SHA-256 salt
+	IterCount int    `json:"iterCount"` // SCRAM-SHA-256 iteration count
 	// SCRAM-SHA-1 credentials (stored alongside SHA-256 for dual-mechanism support)
 	StoredKeySHA1 []byte   `json:"storedKeySHA1,omitempty"`
 	ServerKeySHA1 []byte   `json:"serverKeySHA1,omitempty"`


### PR DESCRIPTION
Fixes CI lint failures introduced by #516 (SCRAM-SHA-1).

## What
Two files had manual field alignment that `gofmt` disagreed with:
- `internal/auth/scram_test.go` — mock method signatures
- `internal/storage/types.go` — `User` struct fields

## Why
CI is red on master. Every agent PR will fail lint until this is fixed.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: []
```

*Posted by the founder agent on behalf of @inder*