### PR TITLE
feat: implement $fill aggregation stage

### DIFF
--- a/internal/aggregation/stages.go
+++ b/internal/aggregation/stages.go
@@ -157,7 +157,11 @@ func buildStage(spec bson.Raw, engine storage.Engine, db string) (Stage, error) 
 		return buildDensifyStage(densifyDoc)
 
 	case "$fill":
-		return nil, fmt.Errorf("$fill is not implemented")
+		fillDoc, ok := stageVal.DocumentOK()
+		if !ok {
+			return nil, fmt.Errorf("$fill requires a document")
+		}
+		return buildFillStage(fillDoc)
 
 	case "$geoNear":
 		return nil, fmt.Errorf("$geoNear is not implemented")
@@ -2429,6 +2433,378 @@ func (s *densifyStage) densifyPartition(docs []bson.Raw, partKey bson.D, lo, hi 
 	}
 
 	return result, nil
+}
+
+// ─── $fill ────────────────────────────────────────────────────────────────────
+
+type fillIndexedDoc struct {
+	idx int
+	doc bson.Raw
+}
+
+type fillOutputField struct {
+	field  string
+	method string      // "linear", "locf", or "" (value mode)
+	value  interface{} // used when method is "" — a bson.RawValue expression
+}
+
+type fillStage struct {
+	partitionBy       interface{} // expression (bson.RawValue) or nil
+	partitionByFields []string
+	sortBy            bson.Raw
+	output            []fillOutputField
+}
+
+func buildFillStage(spec bson.Raw) (*fillStage, error) {
+	s := &fillStage{}
+
+	// Parse partitionBy (expression).
+	if pbVal, err := spec.LookupErr("partitionBy"); err == nil {
+		s.partitionBy = pbVal
+	}
+
+	// Parse partitionByFields (array of strings).
+	if pbfVal, err := spec.LookupErr("partitionByFields"); err == nil {
+		if pbfVal.Type != bson.TypeArray {
+			return nil, fmt.Errorf("$fill partitionByFields must be an array")
+		}
+		arr := pbfVal.Array()
+		arrVals, _ := arr.Values()
+		for _, rv := range arrVals {
+			f, ok := rv.StringValueOK()
+			if !ok {
+				return nil, fmt.Errorf("$fill partitionByFields elements must be strings")
+			}
+			s.partitionByFields = append(s.partitionByFields, f)
+		}
+	}
+
+	// Parse sortBy (document).
+	if sbVal, err := spec.LookupErr("sortBy"); err == nil {
+		sbDoc, ok := sbVal.DocumentOK()
+		if !ok {
+			return nil, fmt.Errorf("$fill sortBy must be a document")
+		}
+		s.sortBy = sbDoc
+	}
+
+	// Parse output (required).
+	outVal, err := spec.LookupErr("output")
+	if err != nil {
+		return nil, fmt.Errorf("$fill requires 'output'")
+	}
+	outDoc, ok := outVal.DocumentOK()
+	if !ok {
+		return nil, fmt.Errorf("$fill output must be a document")
+	}
+
+	outElems, err := outDoc.Elements()
+	if err != nil {
+		return nil, fmt.Errorf("invalid $fill output: %w", err)
+	}
+
+	for _, elem := range outElems {
+		fieldName := elem.Key()
+		fieldVal := elem.Value()
+
+		fof := fillOutputField{field: fieldName}
+
+		fieldDoc, ok := fieldVal.DocumentOK()
+		if !ok {
+			return nil, fmt.Errorf("$fill output field '%s' must be a document", fieldName)
+		}
+
+		if mVal, mErr := fieldDoc.LookupErr("method"); mErr == nil {
+			mStr, ok := mVal.StringValueOK()
+			if !ok {
+				return nil, fmt.Errorf("$fill output '%s' method must be a string", fieldName)
+			}
+			if mStr != "linear" && mStr != "locf" {
+				return nil, fmt.Errorf("$fill output '%s' unknown method '%s'", fieldName, mStr)
+			}
+			if mStr == "linear" && len(s.sortBy) == 0 {
+				return nil, fmt.Errorf("$fill with method 'linear' requires sortBy")
+			}
+			if mStr == "locf" && len(s.sortBy) == 0 {
+				return nil, fmt.Errorf("$fill with method 'locf' requires sortBy")
+			}
+			fof.method = mStr
+		} else if vVal, vErr := fieldDoc.LookupErr("value"); vErr == nil {
+			fof.value = vVal
+		} else {
+			return nil, fmt.Errorf("$fill output '%s' requires 'method' or 'value'", fieldName)
+		}
+
+		s.output = append(s.output, fof)
+	}
+
+	if len(s.output) == 0 {
+		return nil, fmt.Errorf("$fill output must specify at least one field")
+	}
+
+	return s, nil
+}
+
+func (s *fillStage) Process(docs []bson.Raw) ([]bson.Raw, error) {
+	if len(docs) == 0 {
+		return docs, nil
+	}
+
+	// Group documents by partition key, preserving original indices.
+	type partition struct {
+		key  string
+		docs []fillIndexedDoc
+	}
+
+	partMap := make(map[string]*partition)
+	var partOrder []string
+
+	for i, doc := range docs {
+		pk, err := s.partitionKeyStr(doc)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := partMap[pk]; !ok {
+			partMap[pk] = &partition{key: pk}
+			partOrder = append(partOrder, pk)
+		}
+		partMap[pk].docs = append(partMap[pk].docs, fillIndexedDoc{idx: i, doc: doc})
+	}
+
+	// Process each partition.
+	result := make([]bson.Raw, len(docs))
+	copy(result, docs)
+
+	for _, pkStr := range partOrder {
+		p := partMap[pkStr]
+
+		// Sort within partition if sortBy is specified.
+		// We embed a temporary index tag into each doc so that after
+		// SortDocuments reorders them, we can recover the original
+		// result-array index for each doc.
+		if len(s.sortBy) > 0 {
+			const tagKey = "__fill_sort_idx"
+			taggedDocs := make([]bson.Raw, len(p.docs))
+			for j, id := range p.docs {
+				d, err := rawToD(id.doc)
+				if err != nil {
+					return nil, err
+				}
+				d = append(d, bson.E{Key: tagKey, Value: int32(j)})
+				raw, err := dToRaw(d)
+				if err != nil {
+					return nil, err
+				}
+				taggedDocs[j] = raw
+			}
+			if err := query.SortDocuments(taggedDocs, s.sortBy); err != nil {
+				return nil, fmt.Errorf("$fill sort failed: %w", err)
+			}
+			origIndices := make([]int, len(p.docs))
+			for j := range p.docs {
+				origIndices[j] = p.docs[j].idx
+			}
+			sorted := make([]fillIndexedDoc, len(taggedDocs))
+			for j, raw := range taggedDocs {
+				d, err := rawToD(raw)
+				if err != nil {
+					return nil, err
+				}
+				tagVal, _ := getDFieldValue(d, tagKey)
+				origJ, _ := toFloat64Interface(tagVal)
+				d = unsetFieldD(d, tagKey)
+				cleanRaw, err := dToRaw(d)
+				if err != nil {
+					return nil, err
+				}
+				sorted[j] = fillIndexedDoc{
+					idx: origIndices[int(origJ)],
+					doc: cleanRaw,
+				}
+			}
+			p.docs = sorted
+		}
+
+		// Fill each output field.
+		for _, fof := range s.output {
+			var err error
+			switch fof.method {
+			case "locf":
+				err = s.fillLOCF(p.docs, fof.field, result)
+			case "linear":
+				err = s.fillLinear(p.docs, fof.field, result)
+			default:
+				err = s.fillValue(p.docs, fof.field, fof.value, result)
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func (s *fillStage) partitionKeyStr(doc bson.Raw) (string, error) {
+	if s.partitionBy != nil {
+		val, err := EvalExpr(s.partitionBy, doc)
+		if err != nil {
+			return "", err
+		}
+		b, err := bson.Marshal(bson.D{{Key: "k", Value: val}})
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+
+	if len(s.partitionByFields) > 0 {
+		d, err := rawToD(doc)
+		if err != nil {
+			return "", err
+		}
+		pk := make(bson.D, 0, len(s.partitionByFields))
+		for _, f := range s.partitionByFields {
+			v, _ := getDFieldValue(d, f)
+			pk = append(pk, bson.E{Key: f, Value: v})
+		}
+		b, err := bson.Marshal(pk)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+
+	return "", nil // single partition
+}
+
+func (s *fillStage) isNull(doc bson.Raw, field string) bool {
+	d, err := rawToD(doc)
+	if err != nil {
+		return true
+	}
+	v, ok := getDFieldValue(d, field)
+	return !ok || v == nil
+}
+
+func (s *fillStage) fillValue(partDocs []fillIndexedDoc, field string, value interface{}, result []bson.Raw) error {
+	for _, id := range partDocs {
+		if !s.isNull(id.doc, field) {
+			continue
+		}
+		d, err := rawToD(result[id.idx])
+		if err != nil {
+			return err
+		}
+		val, err := EvalExpr(value, id.doc)
+		if err != nil {
+			return err
+		}
+		d = setFieldD(d, field, val)
+		raw, err := dToRaw(d)
+		if err != nil {
+			return err
+		}
+		result[id.idx] = raw
+	}
+	return nil
+}
+
+func (s *fillStage) fillLOCF(partDocs []fillIndexedDoc, field string, result []bson.Raw) error {
+	var lastKnown interface{}
+	hasLast := false
+
+	for _, id := range partDocs {
+		if !s.isNull(id.doc, field) {
+			d, err := rawToD(id.doc)
+			if err != nil {
+				return err
+			}
+			lastKnown, _ = getDFieldValue(d, field)
+			hasLast = true
+			continue
+		}
+		if !hasLast {
+			continue
+		}
+		d, err := rawToD(result[id.idx])
+		if err != nil {
+			return err
+		}
+		d = setFieldD(d, field, lastKnown)
+		raw, err := dToRaw(d)
+		if err != nil {
+			return err
+		}
+		result[id.idx] = raw
+	}
+	return nil
+}
+
+func (s *fillStage) fillLinear(partDocs []fillIndexedDoc, field string, result []bson.Raw) error {
+	// Collect (position, value) pairs for non-null entries.
+	type point struct {
+		pos int     // index within partDocs
+		val float64 // numeric value
+	}
+	var known []point
+	for i, id := range partDocs {
+		if s.isNull(id.doc, field) {
+			continue
+		}
+		d, err := rawToD(id.doc)
+		if err != nil {
+			return err
+		}
+		v, _ := getDFieldValue(d, field)
+		f, ok := toFloat64Interface(v)
+		if !ok {
+			continue
+		}
+		known = append(known, point{pos: i, val: f})
+	}
+
+	if len(known) < 2 {
+		return nil // not enough points to interpolate
+	}
+
+	// For each null, find surrounding known points and interpolate.
+	ki := 0
+	for i, id := range partDocs {
+		if !s.isNull(id.doc, field) {
+			continue
+		}
+		// Advance ki so known[ki] is the last point <= i.
+		for ki < len(known)-1 && known[ki+1].pos <= i {
+			ki++
+		}
+		// Need a point before and after.
+		if ki >= len(known)-1 || known[ki].pos >= i {
+			// No bracket — before first or after last known.
+			continue
+		}
+		lo := known[ki]
+		hi := known[ki+1]
+		if hi.pos <= lo.pos {
+			continue
+		}
+		// Linear interpolation.
+		frac := float64(i-lo.pos) / float64(hi.pos-lo.pos)
+		interpolated := lo.val + frac*(hi.val-lo.val)
+
+		d, err := rawToD(result[id.idx])
+		if err != nil {
+			return err
+		}
+		d = setFieldD(d, field, interpolated)
+		raw, err := dToRaw(d)
+		if err != nil {
+			return err
+		}
+		result[id.idx] = raw
+	}
+
+	return nil
 }
 
 // ─── bson.D helpers (imported from query package via exported wrappers) ───────

--- a/internal/aggregation/stages_test.go
+++ b/internal/aggregation/stages_test.go
@@ -1,6 +1,7 @@
 package aggregation
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -1892,6 +1893,387 @@ func TestStageDensify(t *testing.T) {
 		_, err = buildDensifyStage(spec)
 		if err == nil {
 			t.Error("expected error for fractional step with date unit")
+		}
+	})
+}
+
+// ─── $fill tests ──────────────────────���───────────────────────────────────────
+
+func TestStageFillValue(t *testing.T) {
+	docs := []bson.Raw{
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(1)}, {Key: "score", Value: int32(80)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(2)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(3)}, {Key: "score", Value: nil}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(4)}, {Key: "score", Value: int32(95)}}),
+	}
+
+	stageRaw := makeStageRaw(t, "$fill", bson.D{
+		{Key: "output", Value: bson.D{
+			{Key: "score", Value: bson.D{{Key: "value", Value: int32(0)}}},
+		}},
+	})
+
+	stage, err := buildStage(stageRaw, nil, "")
+	if err != nil {
+		t.Fatalf("buildStage: %v", err)
+	}
+
+	result, err := stage.Process(docs)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	if len(result) != 4 {
+		t.Fatalf("expected 4 docs, got %d", len(result))
+	}
+
+	// Doc 0: score=80 unchanged.
+	d0 := decodeResult(t, result[0])
+	if v := getFieldD(d0, "score"); v != int32(80) {
+		t.Errorf("doc 0 score: got %v, want 80", v)
+	}
+
+	// Doc 1: missing → filled with 0.
+	d1 := decodeResult(t, result[1])
+	if v := getFieldD(d1, "score"); v != int32(0) {
+		t.Errorf("doc 1 score: got %v (%T), want 0", v, v)
+	}
+
+	// Doc 2: null → filled with 0.
+	d2 := decodeResult(t, result[2])
+	if v := getFieldD(d2, "score"); v != int32(0) {
+		t.Errorf("doc 2 score: got %v (%T), want 0", v, v)
+	}
+
+	// Doc 3: score=95 unchanged.
+	d3 := decodeResult(t, result[3])
+	if v := getFieldD(d3, "score"); v != int32(95) {
+		t.Errorf("doc 3 score: got %v, want 95", v)
+	}
+}
+
+func TestStageFillLOCF(t *testing.T) {
+	docs := []bson.Raw{
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(1)}, {Key: "ts", Value: int32(1)}, {Key: "val", Value: int32(10)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(2)}, {Key: "ts", Value: int32(2)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(3)}, {Key: "ts", Value: int32(3)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(4)}, {Key: "ts", Value: int32(4)}, {Key: "val", Value: int32(40)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(5)}, {Key: "ts", Value: int32(5)}}),
+	}
+
+	stageRaw := makeStageRaw(t, "$fill", bson.D{
+		{Key: "sortBy", Value: bson.D{{Key: "ts", Value: int32(1)}}},
+		{Key: "output", Value: bson.D{
+			{Key: "val", Value: bson.D{{Key: "method", Value: "locf"}}},
+		}},
+	})
+
+	stage, err := buildStage(stageRaw, nil, "")
+	if err != nil {
+		t.Fatalf("buildStage: %v", err)
+	}
+
+	result, err := stage.Process(docs)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	expected := []interface{}{int32(10), int32(10), int32(10), int32(40), int32(40)}
+	for i, doc := range result {
+		d := decodeResult(t, doc)
+		v := getFieldD(d, "val")
+		if v != expected[i] {
+			t.Errorf("doc %d val: got %v (%T), want %v", i, v, v, expected[i])
+		}
+	}
+}
+
+func TestStageFillLinear(t *testing.T) {
+	docs := []bson.Raw{
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(1)}, {Key: "ts", Value: int32(1)}, {Key: "val", Value: float64(0)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(2)}, {Key: "ts", Value: int32(2)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(3)}, {Key: "ts", Value: int32(3)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(4)}, {Key: "ts", Value: int32(4)}, {Key: "val", Value: float64(30)}}),
+	}
+
+	stageRaw := makeStageRaw(t, "$fill", bson.D{
+		{Key: "sortBy", Value: bson.D{{Key: "ts", Value: int32(1)}}},
+		{Key: "output", Value: bson.D{
+			{Key: "val", Value: bson.D{{Key: "method", Value: "linear"}}},
+		}},
+	})
+
+	stage, err := buildStage(stageRaw, nil, "")
+	if err != nil {
+		t.Fatalf("buildStage: %v", err)
+	}
+
+	result, err := stage.Process(docs)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	// Expect linear interpolation: 0, 10, 20, 30
+	expected := []float64{0, 10, 20, 30}
+	for i, doc := range result {
+		d := decodeResult(t, doc)
+		v := getFieldD(d, "val")
+		f, ok := toFloat64Interface(v)
+		if !ok {
+			t.Errorf("doc %d: val not numeric: %v (%T)", i, v, v)
+			continue
+		}
+		if math.Abs(f-expected[i]) > 0.001 {
+			t.Errorf("doc %d val: got %f, want %f", i, f, expected[i])
+		}
+	}
+}
+
+func TestStageFillPartitioned(t *testing.T) {
+	docs := []bson.Raw{
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(1)}, {Key: "group", Value: "a"}, {Key: "ts", Value: int32(1)}, {Key: "val", Value: int32(10)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(2)}, {Key: "group", Value: "a"}, {Key: "ts", Value: int32(2)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(3)}, {Key: "group", Value: "b"}, {Key: "ts", Value: int32(1)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(4)}, {Key: "group", Value: "b"}, {Key: "ts", Value: int32(2)}, {Key: "val", Value: int32(99)}}),
+	}
+
+	stageRaw := makeStageRaw(t, "$fill", bson.D{
+		{Key: "partitionByFields", Value: bson.A{"group"}},
+		{Key: "sortBy", Value: bson.D{{Key: "ts", Value: int32(1)}}},
+		{Key: "output", Value: bson.D{
+			{Key: "val", Value: bson.D{{Key: "method", Value: "locf"}}},
+		}},
+	})
+
+	stage, err := buildStage(stageRaw, nil, "")
+	if err != nil {
+		t.Fatalf("buildStage: %v", err)
+	}
+
+	result, err := stage.Process(docs)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	// Group a: [10, 10(filled)], Group b: [nil(no prior), 99]
+	d1 := decodeResult(t, result[1])
+	if v := getFieldD(d1, "val"); v != int32(10) {
+		t.Errorf("doc 1 (group a, ts 2): got %v, want 10", v)
+	}
+
+	// Doc 2 (group b, ts 1): no prior value → stays null/missing.
+	d2 := decodeResult(t, result[2])
+	v2 := getFieldD(d2, "val")
+	if v2 != nil {
+		t.Errorf("doc 2 (group b, ts 1): got %v, want nil (no prior in partition)", v2)
+	}
+
+	d3 := decodeResult(t, result[3])
+	if v := getFieldD(d3, "val"); v != int32(99) {
+		t.Errorf("doc 3 (group b, ts 2): got %v, want 99", v)
+	}
+}
+
+func TestStageFillLOCFReverseSortOrder(t *testing.T) {
+	// Documents arrive in REVERSE sort order — exercises the index remapping logic.
+	docs := []bson.Raw{
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(1)}, {Key: "ts", Value: int32(5)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(2)}, {Key: "ts", Value: int32(4)}, {Key: "val", Value: int32(40)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(3)}, {Key: "ts", Value: int32(3)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(4)}, {Key: "ts", Value: int32(2)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(5)}, {Key: "ts", Value: int32(1)}, {Key: "val", Value: int32(10)}}),
+	}
+
+	stageRaw := makeStageRaw(t, "$fill", bson.D{
+		{Key: "sortBy", Value: bson.D{{Key: "ts", Value: int32(1)}}},
+		{Key: "output", Value: bson.D{
+			{Key: "val", Value: bson.D{{Key: "method", Value: "locf"}}},
+		}},
+	})
+
+	stage, err := buildStage(stageRaw, nil, "")
+	if err != nil {
+		t.Fatalf("buildStage: %v", err)
+	}
+
+	result, err := stage.Process(docs)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	// After sorting by ts ascending: ts=1(val=10), ts=2(nil), ts=3(nil), ts=4(val=40), ts=5(nil)
+	// LOCF: 10, 10, 10, 40, 40
+	// But result order matches input order (by _id), so:
+	// _id=1 (ts=5) → 40, _id=2 (ts=4) → 40, _id=3 (ts=3) → 10, _id=4 (ts=2) → 10, _id=5 (ts=1) → 10
+	expectedByID := map[int32]int32{1: 40, 2: 40, 3: 10, 4: 10, 5: 10}
+
+	for i, doc := range result {
+		d := decodeResult(t, doc)
+		id := getFieldD(d, "_id").(int32)
+		v := getFieldD(d, "val")
+		want := expectedByID[id]
+		if v != want {
+			t.Errorf("result[%d] _id=%d: val got %v (%T), want %d", i, id, v, v, want)
+		}
+	}
+}
+
+func TestStageFillLinearEdges(t *testing.T) {
+	// Nulls before first and after last known value should NOT be filled.
+	docs := []bson.Raw{
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(1)}, {Key: "ts", Value: int32(1)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(2)}, {Key: "ts", Value: int32(2)}, {Key: "val", Value: float64(10)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(3)}, {Key: "ts", Value: int32(3)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(4)}, {Key: "ts", Value: int32(4)}, {Key: "val", Value: float64(30)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(5)}, {Key: "ts", Value: int32(5)}}),
+	}
+
+	stageRaw := makeStageRaw(t, "$fill", bson.D{
+		{Key: "sortBy", Value: bson.D{{Key: "ts", Value: int32(1)}}},
+		{Key: "output", Value: bson.D{
+			{Key: "val", Value: bson.D{{Key: "method", Value: "linear"}}},
+		}},
+	})
+
+	stage, err := buildStage(stageRaw, nil, "")
+	if err != nil {
+		t.Fatalf("buildStage: %v", err)
+	}
+
+	result, err := stage.Process(docs)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	// Doc 0 (ts=1): before first known → stays nil.
+	d0 := decodeResult(t, result[0])
+	if v := getFieldD(d0, "val"); v != nil {
+		t.Errorf("doc 0: expected nil (before first known), got %v", v)
+	}
+
+	// Doc 2 (ts=3): between known 10 and 30 → interpolated to 20.
+	d2 := decodeResult(t, result[2])
+	f2, ok := toFloat64Interface(getFieldD(d2, "val"))
+	if !ok || math.Abs(f2-20) > 0.001 {
+		t.Errorf("doc 2: expected 20, got %v", getFieldD(d2, "val"))
+	}
+
+	// Doc 4 (ts=5): after last known → stays nil.
+	d4 := decodeResult(t, result[4])
+	if v := getFieldD(d4, "val"); v != nil {
+		t.Errorf("doc 4: expected nil (after last known), got %v", v)
+	}
+}
+
+func TestStageFillNoNulls(t *testing.T) {
+	docs := []bson.Raw{
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(1)}, {Key: "val", Value: int32(10)}}),
+		makeRaw(t, bson.D{{Key: "_id", Value: int32(2)}, {Key: "val", Value: int32(20)}}),
+	}
+
+	stageRaw := makeStageRaw(t, "$fill", bson.D{
+		{Key: "output", Value: bson.D{
+			{Key: "val", Value: bson.D{{Key: "value", Value: int32(0)}}},
+		}},
+	})
+
+	stage, err := buildStage(stageRaw, nil, "")
+	if err != nil {
+		t.Fatalf("buildStage: %v", err)
+	}
+
+	result, err := stage.Process(docs)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	// No nulls → no-op.
+	d0 := decodeResult(t, result[0])
+	if v := getFieldD(d0, "val"); v != int32(10) {
+		t.Errorf("doc 0: got %v, want 10", v)
+	}
+	d1 := decodeResult(t, result[1])
+	if v := getFieldD(d1, "val"); v != int32(20) {
+		t.Errorf("doc 1: got %v, want 20", v)
+	}
+}
+
+func TestStageFillEmptyInput(t *testing.T) {
+	stageRaw := makeStageRaw(t, "$fill", bson.D{
+		{Key: "output", Value: bson.D{
+			{Key: "val", Value: bson.D{{Key: "value", Value: int32(0)}}},
+		}},
+	})
+
+	stage, err := buildStage(stageRaw, nil, "")
+	if err != nil {
+		t.Fatalf("buildStage: %v", err)
+	}
+
+	result, err := stage.Process(nil)
+	if err != nil {
+		t.Fatalf("Process: %v", err)
+	}
+
+	if len(result) != 0 {
+		t.Errorf("expected 0 docs, got %d", len(result))
+	}
+}
+
+func TestStageFillBuildErrors(t *testing.T) {
+	t.Run("missing output", func(t *testing.T) {
+		spec, _ := bson.Marshal(bson.D{{Key: "sortBy", Value: bson.D{{Key: "ts", Value: 1}}}})
+		_, err := buildFillStage(bson.Raw(spec))
+		if err == nil {
+			t.Error("expected error for missing output")
+		}
+	})
+
+	t.Run("unknown method", func(t *testing.T) {
+		spec, _ := bson.Marshal(bson.D{
+			{Key: "output", Value: bson.D{
+				{Key: "val", Value: bson.D{{Key: "method", Value: "bogus"}}},
+			}},
+		})
+		_, err := buildFillStage(bson.Raw(spec))
+		if err == nil {
+			t.Error("expected error for unknown method")
+		}
+	})
+
+	t.Run("locf without sortBy", func(t *testing.T) {
+		spec, _ := bson.Marshal(bson.D{
+			{Key: "output", Value: bson.D{
+				{Key: "val", Value: bson.D{{Key: "method", Value: "locf"}}},
+			}},
+		})
+		_, err := buildFillStage(bson.Raw(spec))
+		if err == nil {
+			t.Error("expected error for locf without sortBy")
+		}
+	})
+
+	t.Run("linear without sortBy", func(t *testing.T) {
+		spec, _ := bson.Marshal(bson.D{
+			{Key: "output", Value: bson.D{
+				{Key: "val", Value: bson.D{{Key: "method", Value: "linear"}}},
+			}},
+		})
+		_, err := buildFillStage(bson.Raw(spec))
+		if err == nil {
+			t.Error("expected error for linear without sortBy")
+		}
+	})
+
+	t.Run("no method or value", func(t *testing.T) {
+		spec, _ := bson.Marshal(bson.D{
+			{Key: "output", Value: bson.D{
+				{Key: "val", Value: bson.D{{Key: "foo", Value: "bar"}}},
+			}},
+		})
+		_, err := buildFillStage(bson.Raw(spec))
+		if err == nil {
+			t.Error("expected error when neither method nor value specified")
 		}
 	})
 }


### PR DESCRIPTION
Closes #470

## What
Implements the `$fill` aggregation pipeline stage with full support for:
- **Value mode**: fill nulls/missing fields with a static value or expression
- **LOCF** (Last Observation Carried Forward): carry forward the last non-null value
- **Linear interpolation**: interpolate between surrounding known numeric values
- `partitionBy` / `partitionByFields` for grouped filling
- `sortBy` for ordered fill methods (required for locf and linear)

## Why
`$fill` is a key time-series and data-cleaning stage. Previously returned "not implemented" error.

## Tests
13 test cases covering:
- Value fill (missing + null fields)
- LOCF with sorted data
- LOCF with reverse-sorted input (exercises index remapping)
- Linear interpolation (happy path)
- Linear with edge nulls (before first / after last known — no extrapolation)
- Partitioned fill (cross-partition isolation)
- No-nulls no-op
- Empty input
- Build errors (missing output, unknown method, locf/linear without sortBy, missing method+value)

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#470"]
```

*Posted by the founder agent on behalf of @inder*