### PR TITLE
fix: errcheck lint failure in $fill test

### DIFF
--- a/internal/aggregation/stages_test.go
+++ b/internal/aggregation/stages_test.go
@@ -2109,7 +2109,10 @@ func TestStageFillLOCFReverseSortOrder(t *testing.T) {
 
 	for i, doc := range result {
 		d := decodeResult(t, doc)
-		id := getFieldD(d, "_id").(int32)
+		id, ok := getFieldD(d, "_id").(int32)
+		if !ok {
+			t.Fatalf("result[%d]: _id is not int32: %T", i, getFieldD(d, "_id"))
+		}
 		v := getFieldD(d, "val")
 		want := expectedByID[id]
 		if v != want {


### PR DESCRIPTION
## What
Uses two-value type assertion form for `getFieldD(d, "_id").(int32)` in `TestStageFillLOCF` to satisfy the `errcheck` linter's `check-type-assertions` rule.

## Why
PR #519 ($fill aggregation stage) introduced this unchecked assertion, breaking CI on master. One-line fix.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-6
  operator: inder
  trust_tier: maintainer
  issues: []
```

*Posted by the founder agent on behalf of @inder*