### PR TITLE
fix(ci): repair perf-agent.yml YAML parse error

### DIFF
--- a/.github/workflows/perf-agent.yml
+++ b/.github/workflows/perf-agent.yml
@@ -68,49 +68,39 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
         run: |
-          python3 - << 'EOF'
-          import os, subprocess, datetime
+          DATE_STR=$(date -u +%Y-%m-%d)
+          SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-7)
 
-          repo = os.environ.get('GITHUB_REPOSITORY', 'inder/salvobase')
-          run_url = os.environ.get('RUN_URL', '')
-          commit_sha = os.environ.get('COMMIT_SHA', '')[:7]
-          date_str = datetime.date.today().isoformat()
+          cat > /tmp/perf-agent-failure-body.md <<MARKDOWN
+          ## Performance Agent Cycle Failed
 
-          body = f"""## Performance Agent Cycle Failed
+          The scheduled perf-agent cycle failed on **$DATE_STR**.
 
-The scheduled perf-agent cycle failed on **{date_str}**.
+          **Run:** $RUN_URL
+          **Commit:** \`$SHORT_SHA\`
 
-**Run:** {run_url}
-**Commit:** `{commit_sha}`
+          ### How to investigate
 
-### How to investigate
+          1. Open the run URL above and check which step failed.
+          2. Common failure modes:
+             - Claude Code exited non-zero: check the 'Run perf agent cycle' step logs
+             - ANTHROPIC_API_KEY quota exceeded or expired
+             - FOUNDER_TOKEN expired (rotate at GitHub Settings > Developer settings > PATs)
+             - Plan state JSON corrupted: restore from git history with \`git show HEAD~1:docs/perf-plan-state.json\`
+             - Benchmark data not available on bench-data branch yet
 
-1. Open the run URL above and check which step failed.
-2. Common failure modes:
-   - Claude Code exited non-zero: check the 'Run perf agent cycle' step logs
-   - ANTHROPIC_API_KEY quota exceeded or expired
-   - FOUNDER_TOKEN expired (rotate at GitHub Settings > Developer settings > PATs)
-   - Plan state JSON corrupted: restore from git history with `git show HEAD~1:docs/perf-plan-state.json`
-   - Benchmark data not available on bench-data branch yet
+          3. Manual trigger after fixing:
+             \`\`\`
+             gh workflow run perf-agent.yml --repo inder/salvobase
+             \`\`\`
 
-3. Manual trigger after fixing:
-   ```
-   gh workflow run perf-agent.yml --repo inder/salvobase
-   ```
+          4. The plan state is safe in git — even if this cycle failed, previous state is recoverable.
 
-4. The plan state is safe in git — even if this cycle failed, previous state is recoverable.
+          *Filed automatically by the perf-agent workflow.*
+          MARKDOWN
 
-*Filed automatically by the perf-agent workflow.*"""
-
-          result = subprocess.run([
-              'gh', 'issue', 'create',
-              '--repo', repo,
-              '--title', f'bug: perf-agent cycle failed ({date_str})',
-              '--label', 'bug,priority:high,area:performance',
-              '--body', body,
-          ], capture_output=True, text=True)
-
-          print(result.stdout)
-          if result.returncode != 0:
-              print(result.stderr)
-          EOF
+          gh issue create \
+            --repo "${GITHUB_REPOSITORY:-inder/salvobase}" \
+            --title "bug: perf-agent cycle failed ($DATE_STR)" \
+            --label "bug,priority:high,area:performance" \
+            --body-file /tmp/perf-agent-failure-body.md


### PR DESCRIPTION
## What

The `File failure issue` step in `.github/workflows/perf-agent.yml` contained a Python heredoc whose multi-line f-string body had lines starting at column 1. That terminated the YAML `run: |` literal block scalar early, so GitHub Actions rejected the workflow file on every push validation — visible as zero-job `failure` runs named after the file path.

Replaced the embedded Python with a bash heredoc into a temp file plus `gh issue create --body-file`. All lines now sit at ≥10 spaces of indentation inside the block scalar.

## Why

Every push to master since this file landed (Mar 21) has produced a phantom failure run for `.github/workflows/perf-agent.yml`. Three more failed today alone. They were getting attributed to the dead `ANTHROPIC_API_KEY` (#426), but the workflow was never even reaching the API call — GitHub's YAML parser was rejecting it at validation. Two failure modes were stacked; this fixes the structural one.

When the API key is rotated (still pending in #426), the perf-agent will actually be able to run instead of erroring at parse.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('...'))"` parses cleanly (confirmed broken on master, fixed on this branch)
- Dry-run of the rendered bash with fake env vars produced the expected issue body — SHA truncated to 7 chars, dates substituted, backticks and code fences render correctly

## Risk

Low. This step only fires `if: failure()`, so the only behavior change is the file written when the perf-agent step itself fails. Body content is byte-identical to the previous Python implementation (verified by diff of expected output).

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: []
```

*Posted by the founder agent on behalf of @inder*