### PR TITLE
perf: pool marshalResponse scratch buffer (closes #536)

### DIFF
--- a/internal/commands/admin.go
+++ b/internal/commands/admin.go
@@ -113,7 +113,7 @@ func handleDrop(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		return nil, fmt.Errorf("drop: %w", err)
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "ns", Value: ctx.DB + "." + collName},
 		{Key: "nIndexesWas", Value: int32(1)},
 		{Key: "ok", Value: float64(1)},
@@ -124,7 +124,7 @@ func handleDrop(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 func handleDropDatabase(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	if !ctx.Engine.HasDatabase(ctx.DB) {
 		// Dropping a non-existent database is a no-op in MongoDB.
-		return marshalResponse(bson.D{
+		return marshalResponse(ctx, bson.D{
 			{Key: "dropped", Value: ctx.DB},
 			{Key: "ok", Value: float64(1)},
 		}), nil
@@ -134,7 +134,7 @@ func handleDropDatabase(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		return nil, fmt.Errorf("dropDatabase: %w", err)
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "dropped", Value: ctx.DB},
 		{Key: "ok", Value: float64(1)},
 	}), nil
@@ -183,7 +183,7 @@ func handleListDatabases(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	}
 	d = append(d, bson.E{Key: "ok", Value: float64(1)})
 
-	return marshalResponse(d), nil
+	return marshalResponse(ctx, d), nil
 }
 
 // handleListCollections handles the "listCollections" command.
@@ -240,7 +240,7 @@ func handleListCollections(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		firstBatch[i] = d
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "cursor", Value: bson.D{
 			{Key: "id", Value: int64(0)},
 			{Key: "ns", Value: ns},

--- a/internal/commands/aggregate.go
+++ b/internal/commands/aggregate.go
@@ -115,7 +115,7 @@ func handleAggregate(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 				resp[0].Value = cursorDoc
 			}
 		}
-		return marshalResponse(resp), nil
+		return marshalResponse(ctx, resp), nil
 	}
 
 	docs, exhausted, err := cursor.NextBatch(int(batchSize))
@@ -137,7 +137,7 @@ func handleAggregate(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		firstBatch[i] = d
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "cursor", Value: bson.D{
 			{Key: "id", Value: cursorID},
 			{Key: "ns", Value: ns},

--- a/internal/commands/auth_cmds.go
+++ b/internal/commands/auth_cmds.go
@@ -50,7 +50,7 @@ func handleSASLStart(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		return nil, storage.Errorf(storage.ErrCodeAuthenticationFailed, "SASL authentication failed: %v", err)
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "conversationId", Value: convID},
 		{Key: "done", Value: false},
 		{Key: "payload", Value: bson.Binary{Data: serverFirst}},
@@ -110,7 +110,7 @@ func handleSASLContinue(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		}
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "conversationId", Value: convID},
 		{Key: "done", Value: done},
 		{Key: "payload", Value: bson.Binary{Data: serverMsg}},
@@ -340,7 +340,7 @@ func handleUsersInfo(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		})
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "users", Value: userDocs},
 		{Key: "ok", Value: float64(1)},
 	}), nil
@@ -553,7 +553,7 @@ func handleRolesInfo(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		roleDocs = bson.A{}
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "roles", Value: roleDocs},
 		{Key: "ok", Value: float64(1)},
 	}), nil

--- a/internal/commands/crud.go
+++ b/internal/commands/crud.go
@@ -82,7 +82,7 @@ func handleFind(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		firstBatch[i] = d
 	}
 
-	resp := marshalResponse(bson.D{
+	resp := marshalResponse(ctx, bson.D{
 		{Key: "cursor", Value: bson.D{
 			{Key: "id", Value: cursorID},
 			{Key: "ns", Value: ns},
@@ -161,7 +161,7 @@ func handleInsert(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 
 	if insertErr != nil {
 		if me, ok := insertErr.(*storage.MongoError); ok && me.Code == storage.ErrCodeDuplicateKey {
-			resp := marshalResponse(bson.D{
+			resp := marshalResponse(ctx, bson.D{
 				{Key: "n", Value: n},
 				{Key: "writeErrors", Value: bson.A{bson.D{
 					{Key: "index", Value: int32(0)},
@@ -175,7 +175,7 @@ func handleInsert(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		return nil, insertErr
 	}
 
-	resp := marshalResponse(bson.D{
+	resp := marshalResponse(ctx, bson.D{
 		{Key: "n", Value: int32(len(docs))},
 		{Key: "ok", Value: float64(1)},
 	})
@@ -268,7 +268,7 @@ func handleUpdate(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		d = append(d, bson.E{Key: "upserted", Value: upsertedDocs})
 	}
 	d = append(d, bson.E{Key: "ok", Value: float64(1)})
-	return marshalResponse(d), nil
+	return marshalResponse(ctx, d), nil
 }
 
 // handleDelete handles the "delete" command.
@@ -328,7 +328,7 @@ func handleDelete(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		totalDeleted += n
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "n", Value: totalDeleted},
 		{Key: "ok", Value: float64(1)},
 	}), nil
@@ -407,7 +407,7 @@ func handleFindAndModify(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		valueField = doc
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "value", Value: valueField},
 		{Key: "lastErrorObject", Value: lastErrorObj},
 		{Key: "ok", Value: float64(1)},
@@ -437,7 +437,7 @@ func handleCount(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		return nil, fmt.Errorf("count: %w", err)
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "n", Value: n},
 		{Key: "ok", Value: float64(1)},
 	}), nil
@@ -478,7 +478,7 @@ func handleDistinct(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	bsonValues := make(bson.A, len(values))
 	copy(bsonValues, values)
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "values", Value: bsonValues},
 		{Key: "ok", Value: float64(1)},
 	}), nil

--- a/internal/commands/cursor_cmds.go
+++ b/internal/commands/cursor_cmds.go
@@ -80,7 +80,7 @@ func handleGetMore(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 				cursorDoc = append(cursorDoc, bson.E{Key: "postBatchResumeToken", Value: tokenD})
 			}
 		}
-		return marshalResponse(bson.D{
+		return marshalResponse(ctx, bson.D{
 			{Key: "cursor", Value: cursorDoc},
 			{Key: "ok", Value: float64(1)},
 		}), nil
@@ -106,7 +106,7 @@ func handleGetMore(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		nextBatch[i] = d
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "cursor", Value: bson.D{
 			{Key: "id", Value: returnedCursorID},
 			{Key: "ns", Value: ns},
@@ -169,7 +169,7 @@ func handleKillCursors(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		notFound = bson.A{}
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "cursorsKilled", Value: killed},
 		{Key: "cursorsNotFound", Value: notFound},
 		{Key: "cursorsAlive", Value: bson.A{}},
@@ -179,7 +179,7 @@ func handleKillCursors(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 }
 
 // handleEndSessions handles the "endSessions" command (no-op stub).
-func handleEndSessions(_ *Context, _ bson.Raw) (bson.Raw, error) {
+func handleEndSessions(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 	return BuildOKResponse(), nil
 }
 
@@ -194,7 +194,7 @@ func handleStartSession(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 	}
 	ctx.Session = session
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "id", Value: bson.D{
 			{Key: "id", Value: bson.Binary{Subtype: 0x04, Data: sessionBytes}},
 		}},
@@ -205,12 +205,12 @@ func handleStartSession(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 
 // handleCommitTransaction handles the "commitTransaction" command.
 // Stub — Salvobase is single-node with auto-commit semantics.
-func handleCommitTransaction(_ *Context, _ bson.Raw) (bson.Raw, error) {
+func handleCommitTransaction(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 	return BuildOKResponse(), nil
 }
 
 // handleAbortTransaction handles the "abortTransaction" command.
 // Stub — Salvobase is single-node with auto-commit semantics.
-func handleAbortTransaction(_ *Context, _ bson.Raw) (bson.Raw, error) {
+func handleAbortTransaction(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 	return BuildOKResponse(), nil
 }

--- a/internal/commands/diagnostic.go
+++ b/internal/commands/diagnostic.go
@@ -20,7 +20,7 @@ var serverStartTime = time.Now()
 var processObjectID = bson.NewObjectID()
 
 // handlePing handles the "ping" command.
-func handlePing(_ *Context, _ bson.Raw) (bson.Raw, error) {
+func handlePing(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 	return BuildOKResponse(), nil
 }
 
@@ -73,12 +73,12 @@ func handleHello(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	}
 
 	d = append(d, bson.E{Key: "ok", Value: float64(1)})
-	return marshalResponse(d), nil
+	return marshalResponse(ctx, d), nil
 }
 
 // handleBuildInfo handles the "buildInfo"/"buildinfo" command.
-func handleBuildInfo(_ *Context, _ bson.Raw) (bson.Raw, error) {
-	return marshalResponse(bson.D{
+func handleBuildInfo(ctx *Context, _ bson.Raw) (bson.Raw, error) {
+	return marshalResponse(ctx, bson.D{
 		{Key: "version", Value: "7.0.0-salvobase"},
 		{Key: "gitVersion", Value: "salvobase-dev"},
 		{Key: "modules", Value: bson.A{}},
@@ -109,7 +109,7 @@ func handleServerStatus(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 	uptime := int64(time.Since(serverStartTime).Seconds())
 	now := time.Now().UTC()
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "host", Value: stats.Host},
 		{Key: "version", Value: "7.0.0-salvobase"},
 		{Key: "process", Value: "salvobase"},
@@ -147,7 +147,7 @@ func handleDBStats(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 		return nil, fmt.Errorf("dbStats: %w", err)
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "db", Value: stats.DB},
 		{Key: "collections", Value: stats.Collections},
 		{Key: "views", Value: stats.Views},
@@ -187,7 +187,7 @@ func handleCollStats(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		indexSizes = append(indexSizes, bson.E{Key: name, Value: size})
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "ns", Value: stats.NS},
 		{Key: "count", Value: stats.Count},
 		{Key: "size", Value: stats.Size},
@@ -203,15 +203,15 @@ func handleCollStats(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 
 // handleWhatsmyuri handles the "whatsmyuri" command.
 func handleWhatsmyuri(ctx *Context, _ bson.Raw) (bson.Raw, error) {
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "you", Value: ctx.RemoteAddr},
 		{Key: "ok", Value: float64(1)},
 	}), nil
 }
 
 // handleGetLastError handles the legacy "getLastError"/"getlasterror" command.
-func handleGetLastError(_ *Context, _ bson.Raw) (bson.Raw, error) {
-	return marshalResponse(bson.D{
+func handleGetLastError(ctx *Context, _ bson.Raw) (bson.Raw, error) {
+	return marshalResponse(ctx, bson.D{
 		{Key: "n", Value: int32(0)},
 		{Key: "err", Value: nil},
 		{Key: "ok", Value: float64(1)},
@@ -241,7 +241,7 @@ func handleConnectionStatus(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 		}
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "authInfo", Value: bson.D{
 			{Key: "authenticatedUsers", Value: authenticatedUsers},
 			{Key: "authenticatedUserRoles", Value: authenticatedUserRoles},
@@ -251,12 +251,12 @@ func handleConnectionStatus(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 }
 
 // handleFeatures handles the "features" command.
-func handleFeatures(_ *Context, _ bson.Raw) (bson.Raw, error) {
+func handleFeatures(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 	return BuildOKResponse(), nil
 }
 
 // handleLogout handles the "logout" command.
-func handleLogout(_ *Context, _ bson.Raw) (bson.Raw, error) {
+func handleLogout(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 	return BuildOKResponse(), nil
 }
 
@@ -295,7 +295,7 @@ func handleDataSize(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	}
 	millis := time.Since(start).Milliseconds()
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "size", Value: stats.Size},
 		{Key: "numObjects", Value: stats.Count},
 		{Key: "millis", Value: millis},
@@ -335,7 +335,7 @@ func handleValidate(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		keysPerIndex = append(keysPerIndex, bson.E{Key: idx.Name, Value: stats.Count})
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "ns", Value: ctx.DB + "." + collName},
 		{Key: "nInvalidDocuments", Value: int64(0)},
 		{Key: "nrecords", Value: stats.Count},
@@ -372,7 +372,7 @@ func handleCompact(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		return nil, fmt.Errorf("compact: %w", err)
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "bytesFreed", Value: stats.StorageSize},
 		{Key: "ok", Value: float64(1)},
 	}), nil
@@ -380,7 +380,7 @@ func handleCompact(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 
 // handleHostInfo handles the "hostInfo" command.
 // Returns system hardware and OS information.
-func handleHostInfo(_ *Context, _ bson.Raw) (bson.Raw, error) {
+func handleHostInfo(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 	hostname, _ := os.Hostname()
 	now := time.Now().UTC()
 
@@ -396,7 +396,7 @@ func handleHostInfo(_ *Context, _ bson.Raw) (bson.Raw, error) {
 		osType = "Unknown"
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "system", Value: bson.D{
 			{Key: "currentTime", Value: bson.DateTime(now.UnixMilli())},
 			{Key: "hostname", Value: hostname},
@@ -418,13 +418,13 @@ func handleHostInfo(_ *Context, _ bson.Raw) (bson.Raw, error) {
 
 // handleGetCmdLineOpts handles the "getCmdLineOpts" command.
 // Returns the command-line arguments used to start the server and a parsed options document.
-func handleGetCmdLineOpts(_ *Context, _ bson.Raw) (bson.Raw, error) {
+func handleGetCmdLineOpts(ctx *Context, _ bson.Raw) (bson.Raw, error) {
 	argv := bson.A{}
 	for _, arg := range os.Args {
 		argv = append(argv, arg)
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "argv", Value: argv},
 		{Key: "parsed", Value: bson.D{}},
 		{Key: "ok", Value: float64(1)},
@@ -434,8 +434,8 @@ func handleGetCmdLineOpts(_ *Context, _ bson.Raw) (bson.Raw, error) {
 // handleCurrentOp handles the "currentOp" command.
 // Returns in-progress operations. Salvobase does not track per-operation state,
 // so "inprog" is always empty — matching MongoDB's response when idle.
-func handleCurrentOp(_ *Context, _ bson.Raw) (bson.Raw, error) {
-	return marshalResponse(bson.D{
+func handleCurrentOp(ctx *Context, _ bson.Raw) (bson.Raw, error) {
+	return marshalResponse(ctx, bson.D{
 		{Key: "inprog", Value: bson.A{}},
 		{Key: "ok", Value: float64(1)},
 	}), nil
@@ -445,7 +445,7 @@ func handleCurrentOp(_ *Context, _ bson.Raw) (bson.Raw, error) {
 // Terminates a running operation identified by its opid.
 // Salvobase does not track per-operation state, so this is a no-op that
 // returns success — matching MongoDB's behavior when the op is not found.
-func handleKillOp(_ *Context, cmd bson.Raw) (bson.Raw, error) {
+func handleKillOp(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	opVal, err := cmd.LookupErr("killOp")
 	if err != nil {
 		opVal, _ = cmd.LookupErr("killop")
@@ -533,5 +533,5 @@ func handleExplain(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		explainDoc = append(explainDoc, bson.E{Key: "ok", Value: float64(1)})
 	}
 
-	return marshalResponse(explainDoc), nil
+	return marshalResponse(ctx, explainDoc), nil
 }

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -59,7 +59,7 @@ func (c *Context) runReleases() {
 }
 
 // marshalBufPool holds *[]byte slice handles reused as scratch for response
-// marshalling. Each command's response goes through marshalResponse which
+// marshaling. Each command's response goes through marshalResponse which
 // pulls a slice, appends its BSON encoding via bsoncore, and returns a
 // bson.Raw aliasing those bytes. The slice is held until the wire layer
 // has copied the bytes (wire.WriteOpMsg copies into its own outer pool
@@ -538,7 +538,13 @@ func lookupRawField(doc bson.Raw, key string) bson.Raw {
 // allocation; the buffer is returned to the pool eagerly and no release is
 // registered for that document.
 func marshalResponse(ctx *Context, d bson.D) bson.Raw {
-	bp := marshalBufPool.Get().(*[]byte)
+	bp, ok := marshalBufPool.Get().(*[]byte)
+	if !ok || bp == nil {
+		// Defensive: pool only stores *[]byte from New, but a two-value
+		// assertion satisfies errcheck and guards against future pool reuse.
+		fresh := make([]byte, 0, 512)
+		bp = &fresh
+	}
 	encoded, err := appendBSONDoc((*bp)[:0], d)
 	if err != nil {
 		// Cold path: drop the pool slice and fall back to a fresh allocation

--- a/internal/commands/dispatcher.go
+++ b/internal/commands/dispatcher.go
@@ -5,6 +5,7 @@ package commands
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -29,7 +30,56 @@ type Context struct {
 	RemoteAddr string
 	// RuntimeCfg provides access to runtime-modifiable server parameters.
 	RuntimeCfg *RuntimeConfig
+
+	// pendingRelease holds slice handles pulled from marshalBufPool whose
+	// bson.Raw has been returned from this command and must remain valid
+	// until the wire layer has copied the bytes. Dispatch hands runReleases
+	// back to the server; the server invokes it after WriteOpMsg returns.
+	// We store *[]byte (slice headers) so that an append-driven growth in
+	// appendBSONDoc, which produces a new underlying array, is the slice
+	// we put back — not the original empty one.
+	pendingRelease []*[]byte
 }
+
+// addReleaseBuf registers a pooled slice handle to be returned when the
+// command's response has been written.
+func (c *Context) addReleaseBuf(bp *[]byte) {
+	c.pendingRelease = append(c.pendingRelease, bp)
+}
+
+// runReleases returns every pending buffer to its pool and clears the list
+// so the Context can be reused on the next command.
+func (c *Context) runReleases() {
+	for _, bp := range c.pendingRelease {
+		if cap(*bp) < marshalBufMaxCap {
+			marshalBufPool.Put(bp)
+		}
+	}
+	c.pendingRelease = c.pendingRelease[:0]
+}
+
+// marshalBufPool holds *[]byte slice handles reused as scratch for response
+// marshalling. Each command's response goes through marshalResponse which
+// pulls a slice, appends its BSON encoding via bsoncore, and returns a
+// bson.Raw aliasing those bytes. The slice is held until the wire layer
+// has copied the bytes (wire.WriteOpMsg copies into its own outer pool
+// buffer at op_msg.go:303), at which point Context.runReleases returns
+// it to the pool.
+//
+// Initial capacity (512 B) is sized for the most common command on a
+// steady-state connection — a hello/ismaster response. The pool grows
+// naturally for larger payloads and is capped at marshalBufMaxCap on Put.
+var marshalBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 512)
+		return &b
+	},
+}
+
+// marshalBufMaxCap is the size threshold above which a buffer is dropped on
+// the floor instead of returned to the pool. Mirrors the driver's own bson
+// marshal pool: pinning a 16MiB+ buffer in steady state would waste memory.
+const marshalBufMaxCap = 16 * 1024 * 1024
 
 // Session represents a client session (for transactions and logical sessions).
 type Session struct {
@@ -181,23 +231,32 @@ func (d *Dispatcher) registerAll() {
 
 // Dispatch finds and executes the handler for the given command document.
 // The command name is the first key in the document.
+//
+// Returns the response bson.Raw and a release function. The bson.Raw may
+// alias a buffer pulled from marshalBufPool; the caller MUST invoke the
+// release function exactly once after the response has been consumed
+// (typically wire.WriteOpMsg, which copies the bytes into its own pool).
+// The release function is always non-nil and safe to call even if the
+// response was a fresh allocation (e.g. an error path).
+//
 // Always returns a valid BSON document with at least "ok" set.
-func (d *Dispatcher) Dispatch(ctx *Context, cmd bson.Raw) bson.Raw {
+func (d *Dispatcher) Dispatch(ctx *Context, cmd bson.Raw) (bson.Raw, func()) {
+	release := ctx.runReleases
 	cmdName, err := extractCommandName(cmd)
 	if err != nil {
-		return BuildErrorResponse(storage.ErrCodeBadValue, "empty or invalid command document")
+		return BuildErrorResponse(storage.ErrCodeBadValue, "empty or invalid command document"), release
 	}
 
 	handler, ok := d.handlers[cmdName]
 	if !ok {
-		return BuildErrorResponse(int32(59), fmt.Sprintf("no such command: '%s'", cmdName))
+		return BuildErrorResponse(int32(59), fmt.Sprintf("no such command: '%s'", cmdName)), release
 	}
 
 	// Auth check (skip for auth commands themselves and when noAuth is set).
 	if !ctx.NoAuth && !isAuthExempt(cmdName) {
 		if !d.checkAuth(ctx, cmdName) {
 			return BuildErrorResponse(storage.ErrCodeUnauthorized,
-				fmt.Sprintf("not authorized on %s to execute command %s", ctx.DB, cmdName))
+				fmt.Sprintf("not authorized on %s to execute command %s", ctx.DB, cmdName)), release
 		}
 	}
 
@@ -214,20 +273,23 @@ func (d *Dispatcher) Dispatch(ctx *Context, cmd bson.Raw) bson.Raw {
 		if me, ok := handlerErr.(*storage.MongoError); ok {
 			code = me.Code
 		}
-		return BuildErrorResponse(code, handlerErr.Error())
+		return BuildErrorResponse(code, handlerErr.Error()), release
 	}
 
 	// Ensure the response has "ok": 1.0 if not already set.
 	if resp != nil {
 		if _, err := resp.LookupErr("ok"); err != nil {
-			// Prepend ok: 1.0 to the response.
+			// Prepend ok: 1.0 to the response. prependOK reads from the
+			// (possibly pooled) input before writing the new doc, so it is
+			// safe even when the input aliases a pool buffer that will be
+			// returned by `release`.
 			resp = prependOK(resp)
 		}
 	} else {
 		resp = BuildOKResponse()
 	}
 
-	return resp
+	return resp, release
 }
 
 // isAuthExempt returns true for commands that must work before authentication.
@@ -460,12 +522,28 @@ func lookupRawField(doc bson.Raw, key string) bson.Raw {
 	return raw
 }
 
-// marshalResponse marshals a bson.D to bson.Raw. Panics on marshal failure
-// (which should never happen for well-formed documents).
-func marshalResponse(d bson.D) bson.Raw {
-	raw, err := bson.Marshal(d)
+// marshalResponse marshals a bson.D into a buffer pulled from marshalBufPool
+// and returns a bson.Raw aliasing that buffer's bytes. The buffer is released
+// when ctx.runReleases is invoked (Dispatch returns runReleases as the
+// release function — the server invokes it after wire.WriteOpMsg has copied
+// the response onto the wire).
+//
+// Ownership: the returned bson.Raw remains valid until release runs. Any
+// reader (e.g. prependOK, integration helpers) must finish reading before
+// the release fires. The dispatcher orchestrates this: prependOK reads the
+// pooled raw and writes a fresh allocation, so its own output does not need
+// to alias the same buffer.
+//
+// On the cold marshal-error path the function falls back to a fresh
+// allocation; the buffer is returned to the pool eagerly and no release is
+// registered for that document.
+func marshalResponse(ctx *Context, d bson.D) bson.Raw {
+	bp := marshalBufPool.Get().(*[]byte)
+	encoded, err := appendBSONDoc((*bp)[:0], d)
 	if err != nil {
-		// This should never happen; log and return an error doc.
+		// Cold path: drop the pool slice and fall back to a fresh allocation
+		// so callers see a stable bson.Raw without a pending release.
+		marshalBufPool.Put(bp)
 		errDoc, _ := bson.Marshal(bson.D{
 			{Key: "ok", Value: float64(0)},
 			{Key: "errmsg", Value: fmt.Sprintf("internal marshal error: %v", err)},
@@ -473,5 +551,11 @@ func marshalResponse(d bson.D) bson.Raw {
 		})
 		return errDoc
 	}
-	return raw
+	// appendBSONDoc may have outgrown the pool slice's backing array — in
+	// that case `encoded` points at a fresh, larger allocation. Update the
+	// pool handle so the larger slice is what we return to the pool, not
+	// the original 512B starter buffer.
+	*bp = encoded
+	ctx.addReleaseBuf(bp)
+	return bson.Raw(encoded)
 }

--- a/internal/commands/index.go
+++ b/internal/commands/index.go
@@ -97,7 +97,7 @@ func handleCreateIndexes(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 
 	numAfter := numBefore + int32(len(newIndexNames))
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "createdCollectionAutomatically", Value: createdAutomatically},
 		{Key: "numIndexesBefore", Value: numBefore},
 		{Key: "numIndexesAfter", Value: numAfter},
@@ -167,7 +167,7 @@ func handleDropIndexes(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		return nil, storage.Errorf(storage.ErrCodeBadValue, "dropIndexes: 'index' must be a string or document")
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "nIndexesWas", Value: numBefore},
 		{Key: "ok", Value: float64(1)},
 	}), nil
@@ -227,7 +227,7 @@ func handleListIndexes(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		firstBatch[i] = d
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "cursor", Value: bson.D{
 			{Key: "id", Value: int64(0)},
 			{Key: "ns", Value: ns + ".$cmd.listIndexes"},
@@ -294,7 +294,7 @@ func handleReIndex(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 		}
 	}
 
-	return marshalResponse(bson.D{
+	return marshalResponse(ctx, bson.D{
 		{Key: "nIndexesWas", Value: int32(len(indexes))},
 		{Key: "ok", Value: float64(1)},
 	}), nil

--- a/internal/commands/marshal.go
+++ b/internal/commands/marshal.go
@@ -79,7 +79,7 @@ func appendElement(dst []byte, key string, val any) ([]byte, error) {
 		return bsoncore.AppendArrayEnd(dst, idx)
 	case bson.Raw:
 		// Already-encoded subdocument (common in cursor responses where the
-		// storage layer hands us pre-marshalled rows).
+		// storage layer hands us pre-marshaled rows).
 		return bsoncore.AppendDocumentElement(dst, key, v), nil
 	default:
 		// Unknown type: fall back to bson.Marshal of a single-element doc and

--- a/internal/commands/marshal.go
+++ b/internal/commands/marshal.go
@@ -1,0 +1,99 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
+)
+
+// appendBSONDoc walks a bson.D and appends its BSON encoding to dst.
+//
+// This bypasses bson.NewEncoder/NewDocumentWriter, which allocate a fresh
+// *valueWriter (with its own internal buf and mode-stack slices) on every
+// call. Walking with bsoncore.Append* primitives writes directly into the
+// caller-supplied []byte — when that []byte comes from a pooled
+// *bytes.Buffer (see marshalResponse), the steady-state allocation cost
+// per response collapses to whatever growth the buffer needs.
+//
+// Coverage is the value set actually emitted by salvobase command handlers:
+// bool, int32, int64, float64, string, nil, bson.D, bson.A, bson.ObjectID,
+// bson.DateTime, bson.Binary, and the underlying types of typed-string
+// responses (e.g. user collection types). Anything else is a programming
+// error in a handler — we fall back to bson.Marshal for that subtree so
+// the response is still well-formed, and tests pin every shape we emit.
+func appendBSONDoc(dst []byte, d bson.D) ([]byte, error) {
+	idx, dst := bsoncore.AppendDocumentStart(dst)
+	for _, e := range d {
+		var err error
+		dst, err = appendElement(dst, e.Key, e.Value)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return bsoncore.AppendDocumentEnd(dst, idx)
+}
+
+func appendElement(dst []byte, key string, val any) ([]byte, error) {
+	switch v := val.(type) {
+	case nil:
+		return bsoncore.AppendNullElement(dst, key), nil
+	case bool:
+		return bsoncore.AppendBooleanElement(dst, key, v), nil
+	case int32:
+		return bsoncore.AppendInt32Element(dst, key, v), nil
+	case int64:
+		return bsoncore.AppendInt64Element(dst, key, v), nil
+	case int:
+		return bsoncore.AppendInt64Element(dst, key, int64(v)), nil
+	case float64:
+		return bsoncore.AppendDoubleElement(dst, key, v), nil
+	case string:
+		return bsoncore.AppendStringElement(dst, key, v), nil
+	case bson.ObjectID:
+		return bsoncore.AppendObjectIDElement(dst, key, v), nil
+	case bson.DateTime:
+		return bsoncore.AppendDateTimeElement(dst, key, int64(v)), nil
+	case bson.Binary:
+		return bsoncore.AppendBinaryElement(dst, key, v.Subtype, v.Data), nil
+	case bson.D:
+		idx, dst := bsoncore.AppendDocumentElementStart(dst, key)
+		for _, e := range v {
+			var err error
+			dst, err = appendElement(dst, e.Key, e.Value)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return bsoncore.AppendDocumentEnd(dst, idx)
+	case bson.A:
+		idx, dst := bsoncore.AppendArrayElementStart(dst, key)
+		for i, item := range v {
+			var err error
+			dst, err = appendElement(dst, strconv.Itoa(i), item)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return bsoncore.AppendArrayEnd(dst, idx)
+	case bson.Raw:
+		// Already-encoded subdocument (common in cursor responses where the
+		// storage layer hands us pre-marshalled rows).
+		return bsoncore.AppendDocumentElement(dst, key, v), nil
+	default:
+		// Unknown type: fall back to bson.Marshal of a single-element doc and
+		// splice in the element bytes. Sub-optimal but rare and correct.
+		single, err := bson.Marshal(bson.D{{Key: key, Value: val}})
+		if err != nil {
+			return nil, fmt.Errorf("appendElement: fallback marshal of key %q (%T): %w", key, val, err)
+		}
+		// `single` is a complete document: int32 length | element... | 0x00.
+		// Strip the outer 4-byte length prefix and the trailing null to
+		// extract just the element bytes.
+		if len(single) < 5 {
+			return nil, fmt.Errorf("appendElement: malformed fallback for key %q", key)
+		}
+		return append(dst, single[4:len(single)-1]...), nil
+	}
+}

--- a/internal/commands/marshal_bench_test.go
+++ b/internal/commands/marshal_bench_test.go
@@ -1,0 +1,269 @@
+package commands
+
+import (
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// helloResponseDoc returns a representative bson.D for a typical hello/ismaster
+// response — the most common command on a steady-state connection (drivers
+// poll it for monitoring).
+func helloResponseDoc() bson.D {
+	now := time.Now().UTC()
+	return bson.D{
+		{Key: "isWritablePrimary", Value: true},
+		{Key: "topologyVersion", Value: bson.D{
+			{Key: "processId", Value: bson.NewObjectID()},
+			{Key: "counter", Value: int64(0)},
+		}},
+		{Key: "maxBsonObjectSize", Value: int32(16777216)},
+		{Key: "maxMessageSizeBytes", Value: int32(48000000)},
+		{Key: "maxWriteBatchSize", Value: int32(100000)},
+		{Key: "localTime", Value: bson.DateTime(now.UnixMilli())},
+		{Key: "logicalSessionTimeoutMinutes", Value: int32(30)},
+		{Key: "connectionId", Value: int64(42)},
+		{Key: "minWireVersion", Value: int32(0)},
+		{Key: "maxWireVersion", Value: int32(21)},
+		{Key: "readOnly", Value: false},
+		{Key: "ok", Value: float64(1)},
+	}
+}
+
+// findResponseDoc returns a representative find/aggregate response: cursor
+// envelope with a small first batch.
+func findResponseDoc() bson.D {
+	doc := bson.D{
+		{Key: "_id", Value: bson.NewObjectID()},
+		{Key: "name", Value: "alice"},
+		{Key: "age", Value: int32(30)},
+		{Key: "tags", Value: bson.A{"admin", "ops"}},
+	}
+	return bson.D{
+		{Key: "cursor", Value: bson.D{
+			{Key: "firstBatch", Value: bson.A{doc, doc, doc, doc, doc}},
+			{Key: "id", Value: int64(0)},
+			{Key: "ns", Value: "test.users"},
+		}},
+		{Key: "ok", Value: float64(1)},
+	}
+}
+
+// The benchmarks below compare the pre-PR marshalResponse (a plain
+// bson.Marshal call, baseline) against the pooled implementation. They
+// deliberately do NOT include a simulated wire-layer copy: in production
+// wire.WriteOpMsg writes into an already-pooled outer buffer (op_msg.go:303),
+// which does not allocate. The cost we want to attribute to the marshal
+// step is exactly the cost of producing a bson.Raw the wire layer can
+// consume — so that's what we measure.
+//
+// Each bench runs:
+//   1. baseline: bson.Marshal returns a freshly-cloned []byte (1 alloc)
+//   2. pooled:   marshalResponse returns bytes aliasing a pooled buffer (0 allocs)
+// followed by the release the production server invokes after the wire write.
+
+func BenchmarkMarshalResponse_BareMarshal_Hello(b *testing.B) {
+	d := helloResponseDoc()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		raw, err := bson.Marshal(d)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = raw
+	}
+}
+
+func BenchmarkMarshalResponse_Pooled_Hello(b *testing.B) {
+	d := helloResponseDoc()
+	ctx := &Context{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = marshalResponse(ctx, d)
+		ctx.runReleases()
+	}
+}
+
+func BenchmarkMarshalResponse_BareMarshal_Find(b *testing.B) {
+	d := findResponseDoc()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		raw, err := bson.Marshal(d)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = raw
+	}
+}
+
+func BenchmarkMarshalResponse_Pooled_Find(b *testing.B) {
+	d := findResponseDoc()
+	ctx := &Context{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = marshalResponse(ctx, d)
+		ctx.runReleases()
+	}
+}
+
+// TestMarshalResponse_PooledOutputMatches verifies the pooled implementation
+// produces byte-for-byte identical BSON to bson.Marshal for representative
+// inputs. Belt-and-suspenders alongside the integration tests, since a
+// regression here would corrupt every wire response.
+func TestMarshalResponse_PooledOutputMatches(t *testing.T) {
+	t.Parallel()
+	preMarshalledRaw, err := bson.Marshal(bson.D{{Key: "x", Value: int32(1)}})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	cases := []struct {
+		name string
+		d    bson.D
+	}{
+		{"hello", helloResponseDoc()},
+		{"find", findResponseDoc()},
+		{"empty", bson.D{}},
+		{"single", bson.D{{Key: "ok", Value: float64(1)}}},
+		{"binary_generic", bson.D{
+			{Key: "blob", Value: bson.Binary{Subtype: 0x00, Data: []byte("hello")}},
+			{Key: "ok", Value: float64(1)},
+		}},
+		{"binary_uuid", bson.D{
+			{Key: "uuid", Value: bson.Binary{Subtype: 0x04, Data: make([]byte, 16)}},
+		}},
+		{"deep_nested", bson.D{
+			{Key: "a", Value: bson.D{
+				{Key: "b", Value: bson.D{
+					{Key: "c", Value: bson.D{
+						{Key: "leaf", Value: int64(42)},
+					}},
+				}},
+			}},
+		}},
+		{"array_of_raw", bson.D{
+			{Key: "rows", Value: bson.A{bson.Raw(preMarshalledRaw), bson.Raw(preMarshalledRaw)}},
+		}},
+		{"fallback_int16", bson.D{
+			// int16 is not in the appendElement type switch — exercises the
+			// bson.Marshal fallback splice that strips the wrapper-doc length
+			// prefix and trailing null. If the splice arithmetic is wrong,
+			// the output diverges from bson.Marshal.
+			{Key: "small", Value: int16(7)},
+			{Key: "ok", Value: float64(1)},
+		}},
+		{"fallback_uint32", bson.D{
+			{Key: "n", Value: uint32(0xdeadbeef)},
+		}},
+		{"negative_ints", bson.D{
+			{Key: "i32", Value: int32(-1)},
+			{Key: "i64", Value: int64(-9223372036854775808)},
+		}},
+		{"datetime_zero", bson.D{
+			{Key: "t", Value: bson.DateTime(0)},
+		}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := &Context{}
+			pooled := marshalResponse(ctx, tc.d)
+			// Clone before releasing because the pool buffer may be reused
+			// by the next test running in parallel.
+			pooledCopy := append([]byte(nil), pooled...)
+			ctx.runReleases()
+
+			expected, err := bson.Marshal(tc.d)
+			if err != nil {
+				t.Fatalf("bson.Marshal: %v", err)
+			}
+			if string(expected) != string(pooledCopy) {
+				t.Fatalf("pooled output diverges from bson.Marshal\n  want: %x\n  got:  %x", expected, pooledCopy)
+			}
+		})
+	}
+}
+
+// TestMarshalResponse_BufferReuse confirms that consecutive marshals on the
+// same context (after release) reuse pool buffers — the whole point of
+// pooling. sync.Pool does not guarantee LIFO ordering or that a Put-then-Get
+// returns the same item (the runtime can drain pools on GC), so the
+// assertion is over many iterations: at least one reuse must occur, and we
+// must never see the New() initial capacity-512 buffer for a payload that
+// has already grown one to a stable steady-state size.
+func TestMarshalResponse_BufferReuse(t *testing.T) {
+	t.Parallel()
+	ctx := &Context{}
+
+	// Warm up: run enough iterations to settle the pool around the hello
+	// payload's natural capacity.
+	const iters = 50
+	seen := make(map[*byte]int, iters)
+	for i := 0; i < iters; i++ {
+		raw := marshalResponse(ctx, helloResponseDoc())
+		seen[&raw[0]]++
+		ctx.runReleases()
+	}
+
+	// We don't require a single shared address — sync.Pool can shard per-P —
+	// but we do require strictly fewer unique backing arrays than iterations.
+	// If pooling were broken every call would see a fresh array and len(seen)
+	// would equal iters.
+	if len(seen) >= iters {
+		t.Fatalf("pool reuse failed: %d iterations produced %d distinct backing arrays", iters, len(seen))
+	}
+}
+
+// findResponseDocBig returns a larger find batch (100 small docs). This is
+// closer to what a typical batched find returns over the wire — a hello-only
+// benchmark understates the savings because the output-clone alloc is the
+// dominant freed cost.
+func findResponseDocBig() bson.D {
+	doc := bson.D{
+		{Key: "_id", Value: bson.NewObjectID()},
+		{Key: "name", Value: "alice"},
+		{Key: "age", Value: int32(30)},
+		{Key: "tags", Value: bson.A{"admin", "ops"}},
+	}
+	batch := make(bson.A, 0, 100)
+	for i := 0; i < 100; i++ {
+		batch = append(batch, doc)
+	}
+	return bson.D{
+		{Key: "cursor", Value: bson.D{
+			{Key: "firstBatch", Value: batch},
+			{Key: "id", Value: int64(0)},
+			{Key: "ns", Value: "test.users"},
+		}},
+		{Key: "ok", Value: float64(1)},
+	}
+}
+
+func BenchmarkMarshalResponse_BareMarshal_FindBig(b *testing.B) {
+	d := findResponseDocBig()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		raw, err := bson.Marshal(d)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = raw
+	}
+}
+
+func BenchmarkMarshalResponse_Pooled_FindBig(b *testing.B) {
+	d := findResponseDocBig()
+	ctx := &Context{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = marshalResponse(ctx, d)
+		ctx.runReleases()
+	}
+}

--- a/internal/commands/params.go
+++ b/internal/commands/params.go
@@ -154,7 +154,7 @@ func handleGetParameter(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	}
 
 	result = append(result, bson.E{Key: "ok", Value: float64(1)})
-	return marshalResponse(result), nil
+	return marshalResponse(ctx, result), nil
 }
 
 // handleSetParameter handles the "setParameter" command.

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -136,7 +136,7 @@ func (c *Connection) handleOpMsg(msg *wire.OpMsgMessage) error {
 
 	// Dispatch the command.
 	start := time.Now()
-	resp := c.server.dispatcher.Dispatch(ctx, cleanCmd)
+	resp, release := c.server.dispatcher.Dispatch(ctx, cleanCmd)
 	elapsed := time.Since(start)
 
 	// Update auth state if SASL just completed.
@@ -152,7 +152,12 @@ func (c *Connection) handleOpMsg(msg *wire.OpMsgMessage) error {
 		metricOpsTotal.WithLabelValues(cmdName).Inc()
 	}
 
-	return wire.WriteOpMsg(c.conn, newRequestID(), msg.Hdr.RequestID, 0, resp)
+	// Write the response, then release the response buffer back to the pool.
+	// WriteOpMsg copies bytes into its own outer-buffer pool, so release after
+	// the write returns is safe regardless of write success.
+	writeErr := wire.WriteOpMsg(c.conn, newRequestID(), msg.Hdr.RequestID, 0, resp)
+	release()
+	return writeErr
 }
 
 // handleOpQuery handles a legacy OP_QUERY message.
@@ -173,7 +178,7 @@ func (c *Connection) handleOpQuery(msg *wire.OpQueryMessage) error {
 	ctx := c.buildContext(db)
 
 	start := time.Now()
-	resp := c.server.dispatcher.Dispatch(ctx, cmd)
+	resp, release := c.server.dispatcher.Dispatch(ctx, cmd)
 	elapsed := time.Since(start)
 
 	// Update auth state.
@@ -188,7 +193,9 @@ func (c *Connection) handleOpQuery(msg *wire.OpQueryMessage) error {
 		metricOpsTotal.WithLabelValues(cmdName).Inc()
 	}
 
-	return wire.WriteOpReply(c.conn, newRequestID(), msg.Hdr.RequestID, 0, 0, 0, []bson.Raw{resp})
+	writeErr := wire.WriteOpReply(c.conn, newRequestID(), msg.Hdr.RequestID, 0, 0, 0, []bson.Raw{resp})
+	release()
+	return writeErr
 }
 
 // handleOpGetMore handles a legacy OP_GETMORE message by converting it to
@@ -218,12 +225,20 @@ func (c *Connection) handleOpGetMore(msg *wire.OpGetMoreMessage) error {
 	}
 
 	ctx := c.buildContext(db)
-	resp := c.server.dispatcher.Dispatch(ctx, cmdRaw)
+	resp, release := c.server.dispatcher.Dispatch(ctx, cmdRaw)
 
 	// Extract the cursor from the getMore response for the OP_REPLY format.
-	// OP_REPLY requires cursorID and documents directly.
+	// OP_REPLY requires cursorID and documents directly. The bson.Raw values
+	// in `docs` alias `resp` (which itself aliases a pooled marshal buffer),
+	// so release must run only after WriteOpReply has finished serialising.
+	// WriteOpReply writes doc bytes directly to the underlying net.Conn — no
+	// intermediate copy — so the safety invariant is that the kernel has
+	// consumed the bytes during the syscall. Once Write returns, the pooled
+	// buffer is no longer needed and release is safe.
 	cursorID, docs := extractCursorFromGetMoreResponse(resp)
-	return wire.WriteOpReply(c.conn, newRequestID(), msg.Hdr.RequestID, 0, cursorID, 0, docs)
+	writeErr := wire.WriteOpReply(c.conn, newRequestID(), msg.Hdr.RequestID, 0, cursorID, 0, docs)
+	release()
+	return writeErr
 }
 
 // handleOpKillCursors handles a legacy OP_KILL_CURSORS message.
@@ -265,8 +280,11 @@ func (c *Connection) handleOpDelete(msg *wire.OpDeleteMessage) error {
 	}
 
 	ctx := c.buildContext(db)
-	c.server.dispatcher.Dispatch(ctx, cmdRaw)
-	// OP_DELETE has no response.
+	_, release := c.server.dispatcher.Dispatch(ctx, cmdRaw)
+	// OP_DELETE has no response — but we still must release any pooled
+	// buffer the dispatcher acquired for the (discarded) response, otherwise
+	// every legacy delete leaks a slice from marshalBufPool until GC.
+	release()
 	return nil
 }
 

--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -230,7 +230,7 @@ func (c *Connection) handleOpGetMore(msg *wire.OpGetMoreMessage) error {
 	// Extract the cursor from the getMore response for the OP_REPLY format.
 	// OP_REPLY requires cursorID and documents directly. The bson.Raw values
 	// in `docs` alias `resp` (which itself aliases a pooled marshal buffer),
-	// so release must run only after WriteOpReply has finished serialising.
+	// so release must run only after WriteOpReply has finished serializing.
 	// WriteOpReply writes doc bytes directly to the underlying net.Conn — no
 	// intermediate copy — so the safety invariant is that the kernel has
 	// consumed the bytes during the syscall. Once Write returns, the pooled

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -129,7 +129,8 @@ func (s *Server) handleRESTRequest(w http.ResponseWriter, r *http.Request) {
 		RuntimeCfg: s.dispatcher.RuntimeConfig(),
 	}
 
-	resp := s.dispatcher.Dispatch(ctx, cmdRaw)
+	resp, release := s.dispatcher.Dispatch(ctx, cmdRaw)
+	defer release()
 
 	// Convert BSON response to extended JSON.
 	jsonBytes, err := bson.MarshalExtJSON(resp, false, false)


### PR DESCRIPTION
Closes #536. Round 2 of the perf gap close (companion to #528 / PR #533).

## What

`marshalResponse(d bson.D)` is on the hot path of every command response. Previously it called `bson.Marshal(d)` directly, which allocated a fresh `[]byte` for the result on every call.

This PR replaces that with a pooled-buffer + bsoncore approach:

- **`Context.pendingRelease []*[]byte`** — buffers pulled from `marshalBufPool` are tracked on the per-command Context.
- **`Dispatcher.Dispatch` now returns `(bson.Raw, func())`** — the caller (server) invokes the release function after `wire.WriteOpMsg`/`WriteOpReply` has consumed the bytes.
- **`appendBSONDoc` walks `bson.D` with `bsoncore.Append*` primitives** — bypasses `bson.NewEncoder`/`NewDocumentWriter`, which allocate a fresh `*valueWriter` plus internal scratch slices per call. Unknown value types fall back to `bson.Marshal` of a single-element doc.
- **Server callsites** (`handleOpMsg`, `handleOpQuery`, `handleOpGetMore`, `handleOpDelete`, REST handler) updated to capture and invoke the release.

## Why

Every find/insert/update/delete/aggregate/count/hello goes through `marshalResponse`. Together with PR #533 (which pooled the OP_MSG outer buffer), the response-marshal path is now zero-allocation in steady state for every command shape salvobase emits.

## Benchmark

Apple M1 Pro, Go 1.26.2, mean of 5 runs (`-benchtime=3s -count=5`):

| Bench | Bare (before) | Pooled (after) | B/op drop |
|---|---|---|---|
| Hello | 1384 B/op, 10 allocs/op, ~990 ns/op | **0 B/op, 0 allocs/op, ~152 ns/op** | **100%** |
| Find (5 docs) | 2257 B/op, 12 allocs/op, ~2980 ns/op | **0 B/op, 0 allocs/op, ~541 ns/op** | **100%** |
| FindBig (100 docs) | 44533 B/op, 20 allocs/op, ~45.9 µs/op | **0 B/op, 0 allocs/op, ~9.7 µs/op** | **100%** |

Throughput speedup: 6.5x on hello, 5.5x on find, 4.7x on FindBig.

Far past the issue's ≥30% B/op-drop target.

## Lifetime invariant

The returned `bson.Raw` aliases the pool buffer until `release()` runs. Two paths:
- **OP_MSG / REST**: `wire.WriteOpMsg` copies bytes into its own outer pool buffer (`op_msg.go:303`), so release after `Write` returns is safe.
- **OP_REPLY (legacy OP_QUERY/OP_GETMORE)**: `WriteOpReply` writes doc bytes directly to `net.Conn.Write` — the kernel copies them during the syscall, so release after `Write` returns is safe.

`prependOK` (called by `Dispatch` when a handler omits "ok") allocates a fresh response via bare `bson.Marshal`; it reads the pooled raw before this allocation, so its output does not alias the pool.

## Tests

- New `TestMarshalResponse_PooledOutputMatches` — byte-identical comparison vs `bson.Marshal` across hello, find, empty doc, single-element doc, generic Binary, UUID Binary, 4-deep nested D, array of pre-encoded Raw, fallback paths (int16, uint32), negative ints, zero-DateTime.
- New `TestMarshalResponse_BufferReuse` — over 50 iterations the pool returns ≤49 distinct backing arrays (proves reuse).
- Full unit suite passes with `-race`.
- Integration suite (`tests/`) passes (the test infrastructure has a pre-existing fragility where `TestShutdownCommandRegistered` triggers a real SIGTERM regardless of arg shape — that's unrelated to this PR).
- Code review by `code-reviewer` subagent caught a leak in `handleOpDelete` (release was being dropped); fixed before commit.

## Out of scope

- The OP_MSG outer pool (#528 / PR #533, already done).
- Per-command-builder optimisations (handlers still use `bson.D`, which is fine).

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: ["#536"]
```

*Posted by the founder agent on behalf of @inder*