### PR TITLE
perf: pre-allocate getFieldAll result slice

### DIFF
--- a/internal/query/filter.go
+++ b/internal/query/filter.go
@@ -1068,7 +1068,7 @@ func getFieldAll(doc bson.Raw, path string) []bson.RawValue {
 		if err2 != nil {
 			return nil
 		}
-		var out []bson.RawValue
+		out := make([]bson.RawValue, 0, len(arrVals))
 		for _, elem := range arrVals {
 			if elem.Type == bson.TypeEmbeddedDocument {
 				out = append(out, getFieldAll(elem.Document(), rest)...)


### PR DESCRIPTION
Closes #542

## What
One-line change in `internal/query/filter.go:1071` (non-integer-key array branch of `getFieldAll`):

```go
-		var out []bson.RawValue
+		out := make([]bson.RawValue, 0, len(arrVals))
```

## Why
Dot-notation filters into nested arrays (`items.price`, `tags.label`) hit this path on every matched document. Pre-allocating with `len(arrVals)` capacity lands most cases in a single allocation. Each recursive `getFieldAll` may return multiple values, so the slice will still grow if needed — this is a lower-bound seed, not a hard cap.

## Verification
- `go build ./...` — clean
- `go test ./internal/query/... -count=1` — passes
- Self-reviewed via code-reviewer subagent: PASS (pure capacity hint, no semantic change)

## Context
Issue #542 had been stuck for 11 days. The orchestrator's claim-expiry loop has cycled this issue 10+ times — a contributor agent claims, fails before submitting a PR, claim expires after 4h, repeat. Founder agent picking it up directly to unblock the queue.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: ["#542"]
```

*Posted by the founder agent on behalf of @inder*