### PR TITLE
perf: drop redundant _id key copies in updateDocs/deleteDocs

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -1630,11 +1630,12 @@ func (c *bboltCollection) updateDocs(filter, update bson.Raw, opts UpdateOptions
 				if err != nil {
 					return err
 				}
-				kc := make([]byte, len(idKey))
-				copy(kc, idKey)
+				// idKey is already a freshly-allocated, caller-owned slice (encodeIDValue
+				// passes nil dst to appendIDKey). raw may alias the mmap-backed bucket
+				// value when compression is "none", so it must still be copied.
 				dc := make([]byte, len(raw))
 				copy(dc, raw)
-				toUpdate = append(toUpdate, docToUpdate{key: kc, doc: bson.Raw(dc)})
+				toUpdate = append(toUpdate, docToUpdate{key: idKey, doc: bson.Raw(dc)})
 			}
 		} else if plan, planOK := c.chooseIndex(tx, filter); planOK {
 			// Secondary index scan within the write transaction.
@@ -1647,12 +1648,11 @@ func (c *bboltCollection) updateDocs(filter, update bson.Raw, opts UpdateOptions
 				return scanErr
 			}
 			for _, doc := range idxDocs {
+				// idKey is freshly allocated by encodeIDValue; no extra copy needed.
 				idKey := encodeIDValue(doc.Lookup("_id"))
-				kc := make([]byte, len(idKey))
-				copy(kc, idKey)
 				dc := make([]byte, len(doc))
 				copy(dc, doc)
-				toUpdate = append(toUpdate, docToUpdate{kc, dc})
+				toUpdate = append(toUpdate, docToUpdate{idKey, dc})
 			}
 		} else if err := b.ForEach(func(k, v []byte) error {
 			raw, err := c.engine.decompress(v)
@@ -2111,11 +2111,12 @@ func (c *bboltCollection) deleteDocs(filter bson.Raw, multi bool) (int64, error)
 				if err != nil {
 					return err
 				}
-				kc := make([]byte, len(idKey))
-				copy(kc, idKey)
+				// idKey is already a freshly-allocated, caller-owned slice; no extra copy.
+				// raw may alias the mmap-backed bucket value when compression is "none",
+				// so it must still be copied.
 				dc := make([]byte, len(raw))
 				copy(dc, raw)
-				toDelete = append(toDelete, docInfo{key: kc, doc: bson.Raw(dc)})
+				toDelete = append(toDelete, docInfo{key: idKey, doc: bson.Raw(dc)})
 			}
 		} else if plan, planOK := c.chooseIndex(tx, filter); planOK {
 			// Secondary index scan within the write transaction.
@@ -2128,12 +2129,11 @@ func (c *bboltCollection) deleteDocs(filter bson.Raw, multi bool) (int64, error)
 				return scanErr
 			}
 			for _, doc := range idxDocs {
+				// idKey is freshly allocated by encodeIDValue; no extra copy needed.
 				idKey := encodeIDValue(doc.Lookup("_id"))
-				kc := make([]byte, len(idKey))
-				copy(kc, idKey)
 				dc := make([]byte, len(doc))
 				copy(dc, doc)
-				toDelete = append(toDelete, docInfo{kc, dc})
+				toDelete = append(toDelete, docInfo{idKey, dc})
 			}
 		} else if err := b.ForEach(func(k, v []byte) error {
 			raw, err := c.engine.decompress(v)


### PR DESCRIPTION
Closes #632

## What

Removes 4 redundant `kc := make([]byte, len(idKey)); copy(kc, idKey)` patterns in `internal/storage/collection.go`:
- `updateDocs` `_id`-equality fast path
- `updateDocs` secondary-index-scan path
- `deleteDocs` `_id`-equality fast path
- `deleteDocs` secondary-index-scan path

In all four cases, `idKey` was the return value of `encodeIDValue(...)`, which calls `appendIDKey(nil, v)`. The nil dst forces a fresh allocation, so the slice is already caller-owned — the immediate `make + copy` was pure double-allocation.

## Why

YCSB Workload A is the worst-performing benchmark (27.8% of MongoDB throughput per the latest perf-gap report on #397). It is 50% reads + 50% `_id`-filtered `$set` updates — every single update hits the `_id` fast path here. Removing the redundant key alloc+copy eliminates one allocation per update on the absolute hot path. Same win on every `deleteOne({_id: x})`.

## What was deliberately NOT changed

- **`dc` (document) copies are kept.** When compression is `none` (the default), `decompress` returns the bbolt mmap-backed bucket value directly. Aliasing past subsequent `b.Put`/`b.Delete` within the same tx is unsafe.
- **`ForEach` fallback path is untouched.** `k` there is the cursor-supplied mmap-backed slice and must be copied.

## Verification

- Code-reviewer subagent: PASS on all four correctness checkpoints (no aliasing risk, `b.Delete` doesn't retain caller's key slice per bbolt contract, no heap-escape regression, no other issues).
- Full unit test suite green: `go test ./...` — aggregation, auth, commands, query, server, storage, wire all pass.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: ["#632"]
```

*Posted by the founder agent on behalf of @inder*
