### PR TITLE
perf(storage): skip redundant _id Lookup+decode on insert fast path (closes #637)

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -65,13 +65,17 @@ func (c *bboltCollection) prepareInsertDoc(rawDoc bson.Raw) (preparedInsert, err
 		if err != nil {
 			return preparedInsert{}, fmt.Errorf("prepareInsertDoc: prepend _id: %w", err)
 		}
+		// Build the key directly from the OID we just generated — skips a
+		// Lookup on the freshly-prepended doc plus the appendIDKey type
+		// switch and ObjectIDOK decode, which are equivalent to this copy.
+		p.key = append(make([]byte, 0, 12), p.id[:]...)
 	} else {
 		if oid2, ok := idVal.ObjectIDOK(); ok {
 			p.id = oid2
 		}
 		p.finalDoc = rawDoc
+		p.key = encodeIDValue(idVal)
 	}
-	p.key = encodeIDValue(p.finalDoc.Lookup("_id"))
 	var err error
 	p.compressed, err = c.engine.compress(p.finalDoc)
 	if err != nil {

--- a/internal/storage/perf_test.go
+++ b/internal/storage/perf_test.go
@@ -519,3 +519,66 @@ func benchmarkInsertManyNoIndexN(b *testing.B, n int) {
 
 func BenchmarkInsertManyNoIndex_100(b *testing.B)  { benchmarkInsertManyNoIndexN(b, 100) }
 func BenchmarkInsertManyNoIndex_1000(b *testing.B) { benchmarkInsertManyNoIndexN(b, 1000) }
+
+// BenchmarkPrepareInsertDoc_NoID exercises the new-OID branch of prepareInsertDoc,
+// which is the YCSB workload-A profile (driver does not supply _id). Tracks the
+// removal of the redundant Lookup("_id") + ObjectIDOK decode after prependID.
+func BenchmarkPrepareInsertDoc_NoID(b *testing.B) {
+	dir := b.TempDir()
+	e, err := NewBBoltEngine(dir, "none", false)
+	if err != nil {
+		b.Fatalf("NewBBoltEngine: %v", err)
+	}
+	defer e.Close()
+
+	coll, err := e.Collection("bench", "prep")
+	if err != nil {
+		b.Fatalf("Collection: %v", err)
+	}
+	bc := coll.(*bboltCollection)
+
+	doc := mustMarshal(bson.D{
+		{Key: "name", Value: "user"},
+		{Key: "age", Value: int32(42)},
+	})
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := bc.prepareInsertDoc(doc); err != nil {
+			b.Fatalf("prepareInsertDoc: %v", err)
+		}
+	}
+}
+
+// BenchmarkPrepareInsertDoc_WithID exercises the explicit-_id branch of
+// prepareInsertDoc to guard against regression on the alternate path.
+func BenchmarkPrepareInsertDoc_WithID(b *testing.B) {
+	dir := b.TempDir()
+	e, err := NewBBoltEngine(dir, "none", false)
+	if err != nil {
+		b.Fatalf("NewBBoltEngine: %v", err)
+	}
+	defer e.Close()
+
+	coll, err := e.Collection("bench", "prep")
+	if err != nil {
+		b.Fatalf("Collection: %v", err)
+	}
+	bc := coll.(*bboltCollection)
+
+	oid := bson.NewObjectID()
+	doc := mustMarshal(bson.D{
+		{Key: "_id", Value: oid},
+		{Key: "name", Value: "user"},
+		{Key: "age", Value: int32(42)},
+	})
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := bc.prepareInsertDoc(doc); err != nil {
+			b.Fatalf("prepareInsertDoc: %v", err)
+		}
+	}
+}

--- a/internal/storage/perf_test.go
+++ b/internal/storage/perf_test.go
@@ -535,7 +535,10 @@ func BenchmarkPrepareInsertDoc_NoID(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Collection: %v", err)
 	}
-	bc := coll.(*bboltCollection)
+	bc, ok := coll.(*bboltCollection)
+	if !ok {
+		b.Fatalf("expected *bboltCollection, got %T", coll)
+	}
 
 	doc := mustMarshal(bson.D{
 		{Key: "name", Value: "user"},
@@ -565,7 +568,10 @@ func BenchmarkPrepareInsertDoc_WithID(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Collection: %v", err)
 	}
-	bc := coll.(*bboltCollection)
+	bc, ok := coll.(*bboltCollection)
+	if !ok {
+		b.Fatalf("expected *bboltCollection, got %T", coll)
+	}
 
 	oid := bson.NewObjectID()
 	doc := mustMarshal(bson.D{


### PR DESCRIPTION
Closes #637

## What

`prepareInsertDoc` was always re-fetching `_id` via `p.finalDoc.Lookup("_id")` and feeding it through `encodeIDValue`'s type switch + `ObjectIDOK` decode, even on the new-OID branch where we just generated the 12 bytes ourselves.

- **New-OID branch:** key is now built directly from `p.id[:]` (no `Lookup`, no decode).
- **Explicit-`_id` branch:** reuses the `idVal` we already fetched at the top instead of `Lookup`-ing the doc a second time.

`prepareInsertDoc` now calls `rawDoc.Lookup("_id")` exactly once on either branch.

## Why

YCSB workload A is `_id`-not-supplied inserts — this is the hot path. Same operation, ~34% less CPU.

## Benchmarks

Apple M1 Pro, `count=3 benchtime=2s`:

```
BenchmarkPrepareInsertDoc_NoID    175.6 -> 115.2 ns/op  (-34%, 64 B/op, 2 allocs/op unchanged)
BenchmarkPrepareInsertDoc_WithID   88.7 ->  66.9 ns/op  (-24%, 16 B/op, 1 allocs/op unchanged)
```

Allocation count is unchanged on both paths (the bbolt key was already a single fresh slice). The win is CPU.

## Test plan

- [x] `go test ./...` — all green
- [x] `go vet ./...` — clean
- [x] Added `BenchmarkPrepareInsertDoc_NoID` and `BenchmarkPrepareInsertDoc_WithID` for regression tracking
- [x] Code-reviewer subagent reviewed; no findings (verified byte-identity of the new key encoding, no aliasing risk, all call sites of `prepareInsertDoc` indifferent to the change)

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: ["#637"]
```

*Posted by the founder agent on behalf of @inder*