### PR TITLE
perf(wire): single-syscall WriteOpReply via bucketed buffer pool (closes #636)

### DIFF
--- a/internal/wire/bucket_pool.go
+++ b/internal/wire/bucket_pool.go
@@ -1,0 +1,71 @@
+package wire
+
+import "sync"
+
+// bucketBufPool is a tiered buffer pool. Get(n) rounds n up to the smallest
+// bucket that fits and serves it from that bucket's sync.Pool. Requests larger
+// than the biggest bucket fall through to a one-shot allocation that is not
+// returned to any pool.
+//
+// Buffers are stored as *[]byte so the pool sees a fixed-size pointer and the
+// underlying array does not escape. The exact *[]byte that Get returns must be
+// threaded back through Put so the pool reuses the slice header instead of
+// allocating a fresh one on every release.
+type bucketBufPool struct {
+	buckets []int
+	pools   []sync.Pool
+}
+
+// newBucketBufPool builds a pool with the given size tiers. The tiers should be
+// listed in ascending order; Get walks them in array order and stops at the
+// first fit.
+func newBucketBufPool(buckets []int) *bucketBufPool {
+	bp := &bucketBufPool{
+		buckets: buckets,
+		pools:   make([]sync.Pool, len(buckets)),
+	}
+	for i, size := range buckets {
+		size := size
+		bp.pools[i].New = func() any {
+			b := make([]byte, size)
+			return &b
+		}
+	}
+	return bp
+}
+
+// Get returns a buffer of at least n bytes plus a handle that the caller must
+// hand back to Put. The returned slice has len == cap == bucket size; callers
+// slice down to n before writing it out.
+//
+// If n exceeds the largest bucket, Get allocates a fresh slice and returns a
+// nil handle — Put is a no-op in that case and the GC reclaims the buffer.
+func (bp *bucketBufPool) Get(n int) ([]byte, *[]byte) {
+	for i, size := range bp.buckets {
+		if n <= size {
+			h, ok := bp.pools[i].Get().(*[]byte)
+			if !ok || h == nil {
+				b := make([]byte, size)
+				h = &b
+			}
+			return *h, h
+		}
+	}
+	return make([]byte, n), nil
+}
+
+// Put returns the buffer to its pool. handle must be the *[]byte returned by
+// Get; a nil handle means the buffer was an over-bucket allocation and should
+// not be pooled.
+func (bp *bucketBufPool) Put(handle *[]byte) {
+	if handle == nil {
+		return
+	}
+	c := cap(*handle)
+	for i, size := range bp.buckets {
+		if c == size {
+			bp.pools[i].Put(handle)
+			return
+		}
+	}
+}

--- a/internal/wire/op_msg.go
+++ b/internal/wire/op_msg.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"sync"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -22,65 +21,10 @@ import (
 //   - 65536 — wide aggregate frames before we'd rather not waste pool memory
 var opMsgBufBuckets = [...]int{512, 4096, 16384, 65536}
 
-// opMsgBufPools is one sync.Pool per bucket in opMsgBufBuckets, sharing the
-// same index. Buffers are stored as *[]byte so the pool sees a fixed-size
-// pointer and the underlying array does not escape. The array is populated by
-// init() — sync.Pool contains a noCopy guard, so we cannot return it from a
-// composite-literal helper.
-var opMsgBufPools [len(opMsgBufBuckets)]sync.Pool
+var opMsgBufPool = newBucketBufPool(opMsgBufBuckets[:])
 
-func init() {
-	for i, size := range opMsgBufBuckets {
-		size := size // capture by value for the closure
-		opMsgBufPools[i].New = func() any {
-			b := make([]byte, size)
-			return &b
-		}
-	}
-}
-
-// getOpMsgBuf returns a buffer of at least n bytes, plus a handle that the
-// caller must hand back to putOpMsgBuf. The returned slice has len == cap ==
-// bucket size; callers slice down to n before writing it out.
-//
-// If n exceeds the largest bucket, the function allocates a fresh slice and
-// returns a nil handle — putOpMsgBuf is a no-op in that case and the GC
-// reclaims the buffer.
-//
-// The handle is the same *[]byte the pool returned. We thread that exact
-// pointer back through Put() so the pool reuses the existing 24-byte slice
-// header and we don't allocate a fresh one on Put.
-func getOpMsgBuf(n int) ([]byte, *[]byte) {
-	for i, size := range opMsgBufBuckets {
-		if n <= size {
-			bp, ok := opMsgBufPools[i].Get().(*[]byte)
-			if !ok || bp == nil {
-				b := make([]byte, size)
-				bp = &b
-			}
-			return *bp, bp
-		}
-	}
-	return make([]byte, n), nil
-}
-
-// putOpMsgBuf returns buf to its pool. handle must be the *[]byte returned by
-// getOpMsgBuf; a nil handle means the buffer was an over-bucket allocation
-// and should not be pooled.
-func putOpMsgBuf(handle *[]byte) {
-	if handle == nil {
-		return
-	}
-	// Pick the right pool by the buffer's capacity. The bucket array is small
-	// and sorted, so a linear scan beats a map lookup.
-	c := cap(*handle)
-	for i, size := range opMsgBufBuckets {
-		if c == size {
-			opMsgBufPools[i].Put(handle)
-			return
-		}
-	}
-}
+func getOpMsgBuf(n int) ([]byte, *[]byte) { return opMsgBufPool.Get(n) }
+func putOpMsgBuf(handle *[]byte)          { opMsgBufPool.Put(handle) }
 
 // OpMsgMessage represents an OP_MSG wire protocol message (opcode 2013).
 // OP_MSG is the primary message format used by MongoDB 3.6+ drivers.

--- a/internal/wire/op_reply.go
+++ b/internal/wire/op_reply.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"sync"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
@@ -14,14 +13,12 @@ import (
 // startingFrom(4) + numberReturned(4) = 36.
 const opReplyHdrSize = HeaderSize + 4 + 8 + 4 + 4
 
-// opReplyHdrPool pools the fixed-size header buffer used by WriteOpReply so
-// that high-throughput query paths avoid a 36-byte allocation per response.
-var opReplyHdrPool = sync.Pool{
-	New: func() any {
-		b := make([]byte, opReplyHdrSize)
-		return &b
-	},
-}
+// opReplyBufBuckets mirrors opMsgBufBuckets — OP_REPLY responses ride the same
+// driver-frame size distribution as OP_MSG, so sharing the tier shape keeps
+// pool behavior predictable across the two write paths.
+var opReplyBufBuckets = [...]int{512, 4096, 16384, 65536}
+
+var opReplyBufPool = newBucketBufPool(opReplyBufBuckets[:])
 
 // OpReplyMessage represents an OP_REPLY wire protocol message (opcode 1).
 // OP_REPLY is the server-to-client response format used with legacy OP_QUERY.
@@ -34,7 +31,8 @@ type OpReplyMessage struct {
 	Documents      []bson.Raw
 }
 
-// WriteOpReply encodes and writes an OP_REPLY message to w.
+// WriteOpReply encodes and writes an OP_REPLY message to w in a single
+// w.Write call, regardless of how many documents are in docs.
 //
 // Wire layout:
 //
@@ -52,55 +50,48 @@ func WriteOpReply(
 	startingFrom int32,
 	docs []bson.Raw,
 ) error {
-	// Calculate the total document bytes so we can set messageLength correctly.
 	docBytes := 0
 	for _, d := range docs {
 		docBytes += len(d)
 	}
 
-	// messageLength = header(16) + responseFlags(4) + cursorID(8) +
-	//                 startingFrom(4) + numberReturned(4) + docs
 	msgLen := int32(opReplyHdrSize + docBytes)
 
-	// Borrow a pooled buffer for the fixed-size header portion.
-	bp, ok := opReplyHdrPool.Get().(*[]byte)
-	if !ok {
-		b := make([]byte, opReplyHdrSize)
-		bp = &b
-	}
-	hdrBuf := *bp // aliases the pooled array; do not retain beyond this function
-	defer opReplyHdrPool.Put(bp)
+	buf, handle := opReplyBufPool.Get(int(msgLen))
+	defer opReplyBufPool.Put(handle)
 
+	// Slice down to the exact message length — Get may have returned a larger
+	// bucket. Writing the full bucket would put trailing garbage on the wire.
+	buf = buf[:msgLen]
 	offset := 0
 
 	// Header
-	binary.LittleEndian.PutUint32(hdrBuf[offset:], uint32(msgLen))
+	binary.LittleEndian.PutUint32(buf[offset:], uint32(msgLen))
 	offset += 4
-	binary.LittleEndian.PutUint32(hdrBuf[offset:], uint32(requestID))
+	binary.LittleEndian.PutUint32(buf[offset:], uint32(requestID))
 	offset += 4
-	binary.LittleEndian.PutUint32(hdrBuf[offset:], uint32(responseTo))
+	binary.LittleEndian.PutUint32(buf[offset:], uint32(responseTo))
 	offset += 4
-	binary.LittleEndian.PutUint32(hdrBuf[offset:], uint32(OpReply))
+	binary.LittleEndian.PutUint32(buf[offset:], uint32(OpReply))
 	offset += 4
 
 	// Response fields
-	binary.LittleEndian.PutUint32(hdrBuf[offset:], uint32(responseFlags))
+	binary.LittleEndian.PutUint32(buf[offset:], uint32(responseFlags))
 	offset += 4
-	binary.LittleEndian.PutUint64(hdrBuf[offset:], uint64(cursorID))
+	binary.LittleEndian.PutUint64(buf[offset:], uint64(cursorID))
 	offset += 8
-	binary.LittleEndian.PutUint32(hdrBuf[offset:], uint32(startingFrom))
+	binary.LittleEndian.PutUint32(buf[offset:], uint32(startingFrom))
 	offset += 4
-	binary.LittleEndian.PutUint32(hdrBuf[offset:], uint32(len(docs)))
+	binary.LittleEndian.PutUint32(buf[offset:], uint32(len(docs)))
+	offset += 4
 
-	if _, err := w.Write(hdrBuf); err != nil {
-		return fmt.Errorf("WriteOpReply header: %w", err)
+	// Documents
+	for _, doc := range docs {
+		offset += copy(buf[offset:], doc)
 	}
 
-	for i, doc := range docs {
-		if _, err := w.Write(doc); err != nil {
-			return fmt.Errorf("WriteOpReply document %d: %w", i, err)
-		}
+	if _, err := w.Write(buf); err != nil {
+		return fmt.Errorf("WriteOpReply: %w", err)
 	}
-
 	return nil
 }

--- a/internal/wire/op_reply_test.go
+++ b/internal/wire/op_reply_test.go
@@ -3,6 +3,7 @@ package wire
 import (
 	"bytes"
 	"encoding/binary"
+	"io"
 	"testing"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -88,5 +89,154 @@ func TestWriteOpReply_PoolReuse(t *testing.T) {
 		if reqID != int32(i) {
 			t.Fatalf("iteration %d: requestID = %d", i, reqID)
 		}
+	}
+}
+
+// countingWriter records how many w.Write calls it received and concatenates
+// the bytes for later inspection. WriteOpReply must do exactly one Write
+// regardless of how many documents are in the batch.
+type countingWriter struct {
+	writes int
+	buf    bytes.Buffer
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	c.writes++
+	return c.buf.Write(p)
+}
+
+// TestWriteOpReply_SingleWrite asserts that WriteOpReply emits exactly one
+// w.Write call regardless of batch size. This is the whole point of issue #636:
+// the old implementation did N+1 syscalls (one for the header, one per doc).
+func TestWriteOpReply_SingleWrite(t *testing.T) {
+	doc := marshalDoc(t, bson.D{{Key: "n", Value: int32(1)}})
+
+	cases := []struct {
+		name string
+		n    int
+	}{
+		{"zero docs", 0},
+		{"single doc", 1},
+		{"small batch", 10},
+		{"large batch", 100},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			docs := make([]bson.Raw, tc.n)
+			for i := range docs {
+				docs[i] = doc
+			}
+
+			cw := &countingWriter{}
+			if err := WriteOpReply(cw, 1, 0, 0, 0, 0, docs); err != nil {
+				t.Fatalf("WriteOpReply: %v", err)
+			}
+
+			if cw.writes != 1 {
+				t.Errorf("got %d Write calls, want 1", cw.writes)
+			}
+
+			// Sanity-check the bytes actually round-trip — length matches header.
+			out := cw.buf.Bytes()
+			msgLen := int32(binary.LittleEndian.Uint32(out[0:4]))
+			if int(msgLen) != len(out) {
+				t.Errorf("messageLength = %d, total bytes = %d", msgLen, len(out))
+			}
+		})
+	}
+}
+
+// TestWriteOpReplyInBucketZeroAllocs asserts the steady-state WriteOpReply path
+// allocates zero bytes for in-bucket response sizes. Same north-star reason as
+// TestWriteOpMsgInBucketZeroAllocs: legacy drivers on OP_QUERY hit this path
+// once per response, so an alloc here is multiplied by request rate.
+func TestWriteOpReplyInBucketZeroAllocs(t *testing.T) {
+	doc := marshalDoc(t, bson.D{
+		{Key: "ok", Value: float64(1)},
+		{Key: "n", Value: int32(1)},
+	})
+	docs := []bson.Raw{doc}
+
+	// Warm the pool so the first iteration doesn't count its New() alloc.
+	if err := WriteOpReply(io.Discard, 1, 0, 0, 0, 0, docs); err != nil {
+		t.Fatalf("warmup WriteOpReply: %v", err)
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if err := WriteOpReply(io.Discard, 1, 0, 0, 0, 0, docs); err != nil {
+			t.Fatalf("WriteOpReply: %v", err)
+		}
+	})
+
+	if allocs != 0 {
+		t.Errorf("WriteOpReply should allocate 0 bytes for in-bucket sizes, got %.2f allocs/op", allocs)
+	}
+}
+
+// TestWriteOpReplyOverBucketWorks asserts that messages larger than the largest
+// bucket still encode correctly (they just don't pool).
+func TestWriteOpReplyOverBucketWorks(t *testing.T) {
+	// Build a doc big enough that the total message > 65536 bytes.
+	big := marshalDoc(t, bson.D{
+		{Key: "payload", Value: bytes.Repeat([]byte{'a'}, 70000)},
+	})
+	docs := []bson.Raw{big}
+
+	expectedLen := opReplyHdrSize + len(big)
+	if expectedLen <= opReplyBufBuckets[len(opReplyBufBuckets)-1] {
+		t.Skipf("test fixture too small to exercise over-bucket path (msgLen=%d, max bucket=%d)",
+			expectedLen, opReplyBufBuckets[len(opReplyBufBuckets)-1])
+	}
+
+	cw := &countingWriter{}
+	if err := WriteOpReply(cw, 1, 0, 0, 0, 0, docs); err != nil {
+		t.Fatalf("WriteOpReply: %v", err)
+	}
+	if cw.writes != 1 {
+		t.Errorf("got %d Write calls, want 1 even on over-bucket path", cw.writes)
+	}
+	out := cw.buf.Bytes()
+	if len(out) != expectedLen {
+		t.Errorf("wrote %d bytes, want %d", len(out), expectedLen)
+	}
+}
+
+// TestWriteOpReplyPooledBufferDoesNotLeakTrailingBytes guards against the same
+// foot-gun as TestWriteOpMsgPooledBufferDoesNotLeakTrailingBytes: if a pooled
+// buffer carries garbage past msgLen and we Write the full bucket instead of
+// buf[:msgLen], the wire output will contain trailing junk bytes.
+func TestWriteOpReplyPooledBufferDoesNotLeakTrailingBytes(t *testing.T) {
+	// Prime bucket 1 (4096 bytes) with a known marker.
+	primed, handle := opReplyBufPool.Get(1024) // lands in bucket 1 (4096)
+	if handle == nil {
+		t.Fatal("expected pooled buffer for size 1024")
+	}
+	if cap(primed) != 4096 {
+		t.Fatalf("expected bucket cap 4096, got %d", cap(primed))
+	}
+	for i := range primed {
+		primed[i] = 0xAB // marker
+	}
+	opReplyBufPool.Put(handle)
+
+	// Now WriteOpReply with a payload that lands in the same bucket.
+	doc := marshalDoc(t, bson.D{{Key: "ok", Value: float64(1)}})
+	docs := []bson.Raw{doc}
+
+	cw := &countingWriter{}
+	if err := WriteOpReply(cw, 1, 0, 0, 0, 0, docs); err != nil {
+		t.Fatalf("WriteOpReply: %v", err)
+	}
+
+	want := opReplyHdrSize + len(doc)
+	if cw.buf.Len() != want {
+		t.Errorf("wrote %d bytes, want %d (trailing pool garbage leaked to wire?)", cw.buf.Len(), want)
+	}
+
+	// Trailing byte must be the last byte of the BSON doc, not 0xAB.
+	last := cw.buf.Bytes()[cw.buf.Len()-1]
+	if last == 0xAB {
+		t.Errorf("last byte is 0xAB — pool marker leaked")
 	}
 }


### PR DESCRIPTION
Closes #636

## What

`WriteOpReply` previously did **N+1 `w.Write` calls** — one for the 36-byte header, one per BSON document. On a legacy OP_QUERY `find` returning a 100-doc batch over the raw `net.Conn` (the live config), that's **101 syscalls per response**.

This change factors the bucket-pool helper from `op_msg.go` into a shared `bucketBufPool` (`internal/wire/bucket_pool.go`) and reroutes both write paths through it. `WriteOpReply` now packs header + every doc into one pooled buffer and emits a single `w.Write`, matching the existing `WriteOpMsg` shape.

Same bucket tiers (`512 / 4096 / 16384 / 65536`) for both write paths. Over-bucket sizes fall through to a one-shot allocation — identical to prior behavior.

## Why

Issue #636. The orphan claim from the dead self-hosted contributor workflow (Invalid API key at 09:43:34Z) left this stranded; founder agent picking it up directly. This is a north-star perf item — part of epic #397.

## Risk Assessment

- [x] Low risk: refactor + additive tests. WriteOpMsg behavior unchanged (still uses the same bucket sizes, same handle plumbing — just via a constructor instead of `init()`). WriteOpReply wire bytes unchanged (verified by `TestWriteOpReply_RoundTrip`, `_EmptyDocs`, `_PoolReuse`).

## Test Plan

- [x] All existing wire tests pass (`go test ./internal/wire/`)
- [x] `TestWriteOpReply_SingleWrite` — exactly 1 `Write` for batches of 0, 1, 10, 100 docs
- [x] `TestWriteOpReplyInBucketZeroAllocs` — steady-state zero allocs on pool path
- [x] `TestWriteOpReplyOverBucketWorks` — encoding correct past 65536 bytes
- [x] `TestWriteOpReplyPooledBufferDoesNotLeakTrailingBytes` — guards against writing full bucket instead of `buf[:msgLen]`
- [x] `go test ./...` — full suite green
- [x] `go vet ./...` — clean
- [x] code-reviewer subagent: no findings (critical/major/minor all zero)

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: ["#636"]
```

*Posted by the founder agent on behalf of @inder*