### PR TITLE
perf(storage): drop redundant outerPrefix copy in range index scans (closes #646)

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -1142,9 +1142,10 @@ func (c *bboltCollection) rangeIndexScanTx(
 	// If no lower bound and no prefix, seekKey is empty — we start from the bucket start.
 
 	// outerPrefix is the part of the key we always require: the equality fields portion.
-	// We stop scanning when the key no longer starts with this prefix.
-	outerPrefix := make([]byte, len(plan.prefix))
-	copy(outerPrefix, plan.prefix)
+	// We stop scanning when the key no longer starts with this prefix. plan.prefix is
+	// already an owned heap allocation produced by encodeEqualityPrefix (see index.go),
+	// and we only read it below — no defensive copy needed.
+	outerPrefix := plan.prefix
 
 	// rangeOffset is the offset in the index key where the range field encoded bytes start.
 	rangeOffset := len(plan.prefix)
@@ -1259,8 +1260,9 @@ func (c *bboltCollection) rangeIndexScanUniqueTx(
 		seekKey = append(seekKey, plan.loBound...)
 	}
 
-	outerPrefix := make([]byte, len(plan.prefix))
-	copy(outerPrefix, plan.prefix)
+	// plan.prefix is already an owned heap allocation (see encodeEqualityPrefix in
+	// index.go) and is only read in the loop below. No defensive copy needed.
+	outerPrefix := plan.prefix
 
 	rangeOffset := len(plan.prefix)
 	if len(plan.prefix) > 0 {


### PR DESCRIPTION
Closes #646

## What
Removes the redundant `outerPrefix` heap copy in `rangeIndexScanTx` and `rangeIndexScanUniqueTx` in `internal/storage/collection.go`. The copy was introduced to "hold the prefix stable across cursor iterations," but `plan.prefix` is produced by `encodeEqualityPrefix` which returns a freshly heap-allocated `[]byte` that is never modified by bbolt cursor operations — so the copy was pure waste.

Before:
```go
outerPrefix := make([]byte, len(plan.prefix))
copy(outerPrefix, plan.prefix)
```

After:
```go
outerPrefix := plan.prefix
```

Same fix applied to `rangeIndexScanUniqueTx`.

## Why
Zero-alloc win on every range index scan. No behavior change — the prefix was read-only before and after.

## Test plan
- All existing index-scan and range-query integration tests pass (`make test`, `make test-integration`)
- No new tests needed — purely dead-copy removal

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#646"]
```

*Posted by the founder agent on behalf of @inder*