### PR TITLE
fix(lint): use keyed bson.E fields in lookup_bench_test.go

### DIFF
--- a/internal/storage/lookup_bench_test.go
+++ b/internal/storage/lookup_bench_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func BenchmarkLookupDotPathTopLevel(b *testing.B) {
-	doc, _ := bson.Marshal(bson.D{{"name", "Alice"}, {"age", 30}, {"_id", "x"}})
+	doc, _ := bson.Marshal(bson.D{{Key: "name", Value: "Alice"}, {Key: "age", Value: 30}, {Key: "_id", Value: "x"}})
 	raw := bson.Raw(doc)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -17,7 +17,7 @@ func BenchmarkLookupDotPathTopLevel(b *testing.B) {
 }
 
 func BenchmarkLookupDotPathNested(b *testing.B) {
-	doc, _ := bson.Marshal(bson.D{{"address", bson.D{{"city", "NYC"}}}})
+	doc, _ := bson.Marshal(bson.D{{Key: "address", Value: bson.D{{Key: "city", Value: "NYC"}}}})
 	raw := bson.Raw(doc)
 	b.ReportAllocs()
 	b.ResetTimer()


### PR DESCRIPTION
## What
Use keyed struct literal syntax (`Key:`, `Value:`) for `bson.E` entries in `lookup_bench_test.go`.

## Why
`golangci-lint` (govet composites check) rejects unkeyed struct literals for named structs. This file was introduced in the perf sprint (#641 / PR #650) and broke CI lint.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
```

*Posted by the founder agent on behalf of @inder*