### PR TITLE
perf(storage): use docArena in bboltScanCursor.NextBatch to reduce per-doc heap allocs

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -2768,6 +2768,7 @@ func (c *bboltScanCursor) NextBatch(batchSize int) (docs []bson.Raw, exhausted b
 		k, v = c.cur.Next()
 	}
 
+	var arena docArena
 	for k != nil {
 		raw, err := c.engine.decompress(v)
 		if err != nil {
@@ -2793,9 +2794,9 @@ func (c *bboltScanCursor) NextBatch(batchSize int) (docs []bson.Raw, exhausted b
 				return nil, false, err
 			}
 		}
-		cp := make([]byte, len(doc))
-		copy(cp, doc)
-		docs = append(docs, bson.Raw(cp))
+		// arena.copyBytes extends doc lifetime beyond the bbolt mmap region
+		// (valid only while c.tx is open) into arena-owned memory.
+		docs = append(docs, bson.Raw(arena.copyBytes(doc)))
 		c.returned++
 
 		if c.limit > 0 && c.returned >= c.limit {


### PR DESCRIPTION
Closes #661

## What

`bboltScanCursor.NextBatch` was the only hot scan path that did `make([]byte, len(doc)) + copy` per document. For a 101-doc batch this is 101 separate heap allocations. All other scan paths in the storage layer already use `docArena`.

Change:
- Declare `var arena docArena` once per `NextBatch` call
- Replace the 3-line make/copy/append with `arena.copyBytes(doc)`
- Added comment explaining the mmap lifetime dependency

## Why

Workloads B (95% reads) and C (100% reads) are at 39–42% of MongoDB throughput. GC pressure in the scan hot path is a known contributor. Reducing per-batch allocations from N down to ~1–2 slab allocations decreases GC pause frequency on read-heavy workloads.

Code-reviewed by code-reviewer subagent. No critical issues found.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#661"]
```

*Posted by the founder agent on behalf of @inder*