### PR TITLE
perf(storage): replace bytes.HasPrefix with inline hasPrefix in index scan loops

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -1089,7 +1089,7 @@ func (c *bboltCollection) indexScanTx(
 	// This correctly distinguishes "foo" (prefix) from "foobar" (longer string) because
 	// the 0xFF separator byte cannot be part of a partial field encoding.
 	cur := idxB.Cursor()
-	for k, _ := cur.Seek(prefixKey); k != nil && bytes.HasPrefix(k, prefixKey); k, _ = cur.Next() {
+	for k, _ := cur.Seek(prefixKey); k != nil && hasPrefix(k, prefixKey); k, _ = cur.Next() {
 		if len(k) <= len(prefixKey) || k[len(prefixKey)] != 0xFF {
 			// Longer field value shares our byte prefix — not an exact match.
 			continue
@@ -1173,7 +1173,7 @@ func (c *bboltCollection) rangeIndexScanTx(
 
 	for k := startK; k != nil; k, _ = cur.Next() {
 		// Stop if key no longer begins with the equality prefix.
-		if len(outerPrefix) > 0 && !bytes.HasPrefix(k, outerPrefix) {
+		if len(outerPrefix) > 0 && !hasPrefix(k, outerPrefix) {
 			break
 		}
 
@@ -1287,7 +1287,7 @@ func (c *bboltCollection) rangeIndexScanUniqueTx(
 	var docs []bson.Raw
 	var arena docArena
 	for k, v := startK, startV; k != nil; k, v = cur.Next() {
-		if len(outerPrefix) > 0 && !bytes.HasPrefix(k, outerPrefix) {
+		if len(outerPrefix) > 0 && !hasPrefix(k, outerPrefix) {
 			break
 		}
 		if len(outerPrefix) > 0 {


### PR DESCRIPTION
Closes #663

## What

Replaces three `bytes.HasPrefix` (stdlib) calls with the package-local `hasPrefix` helper in `indexScanTx` and `rangeIndexScanTx` — the two index scan functions called on every matched document during index lookups.

The `hasPrefix` helper was already present in `engine.go:1080` and used on line 860 of `collection.go` for the same purpose. These three sites just hadn't been updated.

`bytes` import is retained — `bytes.Compare` is still used at 4 other sites.

## Why

Reduces one indirect stdlib call per key in tight bbolt cursor loops. Marginal per-call, but index scans run millions of iterations in read workloads (B/C).

## Test

`go test ./internal/storage/... -count=1` → ok in 3.17s

Code-reviewed by code-reviewer subagent: 0 critical, 0 should-fix.

```yaml
agent:
  id: "founder-agent-local"
  type: "claude-code"
  model: "claude-sonnet-4-6"
  operator: "inder"
  trust_tier: "maintainer"
  issues: ["#663"]
```

*Posted by the founder agent on behalf of @inder*