### PR TITLE
perf(storage): reuse docArena across NextBatch calls in bboltScanCursor

### DIFF
--- a/internal/storage/collection.go
+++ b/internal/storage/collection.go
@@ -2720,6 +2720,7 @@ type bboltScanCursor struct {
 	filter     bson.Raw
 	projection bson.Raw
 	engine     *BBoltEngine
+	arena      docArena
 	skip       int64
 	limit      int64
 	skipped    int64
@@ -2768,7 +2769,11 @@ func (c *bboltScanCursor) NextBatch(batchSize int) (docs []bson.Raw, exhausted b
 		k, v = c.cur.Next()
 	}
 
-	var arena docArena
+	// Reset the arena so the backing slab is reused across getMore calls.
+	// Safe: marshalResponse copies arena-backed bson.Raw slices into the wire
+	// buffer via bsoncore.AppendDocumentElement before this handler returns, so
+	// no live reference into the backing array survives to the next call.
+	c.arena.buf = c.arena.buf[:0]
 	for k != nil {
 		raw, err := c.engine.decompress(v)
 		if err != nil {
@@ -2796,7 +2801,7 @@ func (c *bboltScanCursor) NextBatch(batchSize int) (docs []bson.Raw, exhausted b
 		}
 		// arena.copyBytes extends doc lifetime beyond the bbolt mmap region
 		// (valid only while c.tx is open) into arena-owned memory.
-		docs = append(docs, bson.Raw(arena.copyBytes(doc)))
+		docs = append(docs, bson.Raw(c.arena.copyBytes(doc)))
 		c.returned++
 
 		if c.limit > 0 && c.returned >= c.limit {


### PR DESCRIPTION
Closes #664

## What

Promotes `arena docArena` from a per-call local variable inside `bboltScanCursor.NextBatch` to a persistent struct field. Each call resets the arena via `c.arena.buf = c.arena.buf[:0]` so the backing slab is reused across `getMore` batches instead of reallocated.

## Why

For streaming cursors that return results over multiple `getMore` calls, the old code discarded the arena's 64 KB slab on every batch. For a cursor streaming N batches, that was N slab allocations. With the arena as a struct field, the first batch allocates the slab and subsequent batches reuse it — amortised to one allocation per cursor lifetime.

## Safety invariant

The reset overwrites the old backing array from offset 0. Correctness requires that the previous batch's `bson.Raw` slices (which alias the old backing array) are fully serialised to the wire before the next `NextBatch` call. This is guaranteed by `marshalResponse` calling `bsoncore.AppendDocumentElement` synchronously inside the command handler before returning. The invariant is now documented with a comment at the reset site.

## Test

- `make test` (unit, -race) — all pass
- `make test-integration` — all pass
- Code-reviewed by `code-reviewer` subagent — no critical issues, safety comment added per recommendation

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#664"]
```

*Posted by the founder agent on behalf of @inder*