### PR TITLE
docs(storage): explain --syncOnWrite=false durability trade-off (closes #676)

### DIFF
--- a/cmd/mongod/main.go
+++ b/cmd/mongod/main.go
@@ -57,7 +57,13 @@ Improvements over MongoDB Community:
 	// Storage flags
 	cmd.Flags().StringVar(&cfg.DataDir, "datadir", "./data", "Directory for database files")
 	cmd.Flags().StringVar(&cfg.Compression, "compression", "none", "Document compression: none, snappy, zstd")
-	cmd.Flags().BoolVar(&cfg.SyncOnWrite, "syncOnWrite", true, "Sync writes to disk before acknowledging")
+	cmd.Flags().BoolVar(&cfg.SyncOnWrite, "syncOnWrite", true,
+		"Call fdatasync after every batch commit (durability). When false (NoSync mode), "+
+			"writes are acknowledged before they hit disk — equivalent to MongoDB's j:false. "+
+			"Eliminates the fdatasync hot path (~40% CPU on write-heavy workloads) at the cost "+
+			"of losing any writes still buffered in the OS page cache if the host crashes or "+
+			"panics. Intended for dev, benchmarks, and ephemeral workloads only — Salvobase "+
+			"is single-node and has no replication, so a host crash with NoSync = data loss.")
 
 	// Auth flags
 	cmd.Flags().BoolVar(&cfg.NoAuth, "noauth", false, "Disable authentication (DO NOT USE IN PRODUCTION)")
@@ -103,6 +109,11 @@ func run(cfg server.Config) error {
 
 	if cfg.NoAuth {
 		log.Warn("AUTHENTICATION IS DISABLED — do not run in production without auth")
+	}
+
+	if !cfg.SyncOnWrite {
+		log.Warn("SYNC ON WRITE IS DISABLED — fdatasync skipped after batch commits; " +
+			"recent writes may be lost on host crash or kernel panic (equivalent to MongoDB j:false)")
 	}
 
 	// Create and start server

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -101,7 +101,12 @@ func (e *BBoltEngine) openDBLocked(name string) (*bolt.DB, error) {
 	}
 	path := filepath.Join(e.dataDir, name+".db")
 	opts := &bolt.Options{
-		Timeout:         1 * time.Second,
+		Timeout: 1 * time.Second,
+		// NoSync skips fdatasync after each batch commit. When set, writes are
+		// durable only as far as the OS page cache — a process crash is fine,
+		// but a host crash or kernel panic can lose recent writes. Surfaced as
+		// --syncOnWrite=false on the CLI and as the syncOnWrite YAML key.
+		// See issue #676.
 		NoSync:          !e.syncOnWrite,
 		NoGrowSync:      true,
 		InitialMmapSize: 64 * 1024 * 1024, // 64 MB initial mmap — reduces remapping overhead


### PR DESCRIPTION
Closes #676.

## What

The `--syncOnWrite` flag, the `bbolt.Options.NoSync` wiring, and the `syncOnWrite` YAML key already existed in the repo. What was missing — and what made the issue actionable — was the documentation around it. This PR:

- Expands the `--syncOnWrite` help text to spell out the trade-off explicitly:
  - durability bound (writes lost if host crashes / kernel panics while in OS page cache)
  - performance ceiling (`~40% CPU` reduction from removing the `fdatasync` hot path, per `docs/profiles/workload-a-16t.txt`)
  - acceptable use cases (dev, benchmarks, ephemeral) — and explicitly NOT general production, since Salvobase has no replication
- Adds a startup `WARN` log when `--syncOnWrite=false`, mirroring the existing `noauth` warning pattern so operators can't miss it in logs.
- Documents the `NoSync` field in `openDBLocked` with an explicit pointer back to the CLI flag.

## Why

Per DoD in #676 items 4 and 5 — the prior help text ("Sync writes to disk before acknowledging") didn't explain what flipping the flag costs you, and there was no in-code comment justifying the `NoSync` line. Operators who set `--syncOnWrite=false` for benchmarks need to know they've traded durability for throughput; the warning at startup is the second line of defense after the help text.

## Verification

```
go build ./...                       # clean
go vet ./...                          # clean
go test ./cmd/... ./internal/...     # all packages pass
./bin/salvobase --syncOnWrite=false  # boots, WARN log fires
./bin/salvobase --help               # new help text visible
```

## Review

Reviewed by `code-reviewer` subagent before push. One should-fix finding (original help text claimed "replicated topologies where another replica owns durability" — Salvobase has no replication, so the suggestion was misleading) was addressed by tightening the safe-use-case description to single-node dev/benchmarks/ephemeral only.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: ["#676"]
```

*Posted by the founder agent on behalf of @inder*