### PR TITLE
perf(bench): per-night variance gating to suppress noise alerts (closes #715)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -113,53 +113,59 @@ jobs:
           COMMIT=$(git rev-parse --short HEAD)
           mkdir -p benchmarks/results
 
+          # Per-night 3× sampling — single-runner noise on shared GitHub runners has
+          # been measured at 6pp stddev on the Workload A ratio. Sampling 3× per
+          # combination lets downstream tools (print_ratios.py, check_perf_gap.py)
+          # report median ± stddev and gate alerts on real signal vs jitter. See #715.
           for WORKLOAD in A B C D E F; do
             for THREADS in 1 4 8 16; do
-              echo "--- Workload ${WORKLOAD} / ${THREADS} threads ---"
+              for SAMPLE in 1 2 3; do
+                echo "--- Workload ${WORKLOAD} / ${THREADS} threads / sample ${SAMPLE}/3 ---"
 
-              # Salvobase — tee raw output to a debug file so failures are diagnosable
-              RECORD_COUNT=$RECORD_COUNT \
-              OPERATION_COUNT=$OPERATION_COUNT \
-              TARGET_URL=mongodb://localhost:27017 \
-              WORKLOAD=$WORKLOAD \
-              THREADS=$THREADS \
-                bash scripts/bench/run_ycsb.sh \
-                2>/tmp/ycsb_stderr_salvobase_${WORKLOAD}_${THREADS}.txt \
-                | tee /tmp/ycsb_raw_salvobase_${WORKLOAD}_${THREADS}.txt \
-                | python3 scripts/bench/parse_ycsb.py \
-                  --target salvobase \
-                  --workload "$WORKLOAD" \
-                  --threads "$THREADS" \
-                  --commit "$COMMIT" \
-                  --date "$DATE" \
-                >> "benchmarks/results/${DATE}.jsonl" \
-                || { echo "WARN: salvobase W${WORKLOAD}/T${THREADS} parse failed"; \
-                     echo "=== stderr ===" >&2; \
-                     cat /tmp/ycsb_stderr_salvobase_${WORKLOAD}_${THREADS}.txt >&2; \
-                     echo "=== raw stdout ===" >&2; \
-                     cat /tmp/ycsb_raw_salvobase_${WORKLOAD}_${THREADS}.txt >&2; }
+                # Salvobase — tee raw output to a debug file so failures are diagnosable
+                RECORD_COUNT=$RECORD_COUNT \
+                OPERATION_COUNT=$OPERATION_COUNT \
+                TARGET_URL=mongodb://localhost:27017 \
+                WORKLOAD=$WORKLOAD \
+                THREADS=$THREADS \
+                  bash scripts/bench/run_ycsb.sh \
+                  2>/tmp/ycsb_stderr_salvobase_${WORKLOAD}_${THREADS}_${SAMPLE}.txt \
+                  | tee /tmp/ycsb_raw_salvobase_${WORKLOAD}_${THREADS}_${SAMPLE}.txt \
+                  | python3 scripts/bench/parse_ycsb.py \
+                    --target salvobase \
+                    --workload "$WORKLOAD" \
+                    --threads "$THREADS" \
+                    --commit "$COMMIT" \
+                    --date "$DATE" \
+                  >> "benchmarks/results/${DATE}.jsonl" \
+                  || { echo "WARN: salvobase W${WORKLOAD}/T${THREADS}/S${SAMPLE} parse failed"; \
+                       echo "=== stderr ===" >&2; \
+                       cat /tmp/ycsb_stderr_salvobase_${WORKLOAD}_${THREADS}_${SAMPLE}.txt >&2; \
+                       echo "=== raw stdout ===" >&2; \
+                       cat /tmp/ycsb_raw_salvobase_${WORKLOAD}_${THREADS}_${SAMPLE}.txt >&2; }
 
-              # MongoDB Community
-              RECORD_COUNT=$RECORD_COUNT \
-              OPERATION_COUNT=$OPERATION_COUNT \
-              TARGET_URL=mongodb://localhost:27018 \
-              WORKLOAD=$WORKLOAD \
-              THREADS=$THREADS \
-                bash scripts/bench/run_ycsb.sh \
-                2>/tmp/ycsb_stderr_mongodb_${WORKLOAD}_${THREADS}.txt \
-                | tee /tmp/ycsb_raw_mongodb_${WORKLOAD}_${THREADS}.txt \
-                | python3 scripts/bench/parse_ycsb.py \
-                  --target mongodb \
-                  --workload "$WORKLOAD" \
-                  --threads "$THREADS" \
-                  --commit "$COMMIT" \
-                  --date "$DATE" \
-                >> "benchmarks/results/${DATE}.jsonl" \
-                || { echo "WARN: mongodb W${WORKLOAD}/T${THREADS} parse failed"; \
-                     echo "=== stderr ===" >&2; \
-                     cat /tmp/ycsb_stderr_mongodb_${WORKLOAD}_${THREADS}.txt >&2; \
-                     echo "=== raw stdout ===" >&2; \
-                     cat /tmp/ycsb_raw_mongodb_${WORKLOAD}_${THREADS}.txt >&2; }
+                # MongoDB Community
+                RECORD_COUNT=$RECORD_COUNT \
+                OPERATION_COUNT=$OPERATION_COUNT \
+                TARGET_URL=mongodb://localhost:27018 \
+                WORKLOAD=$WORKLOAD \
+                THREADS=$THREADS \
+                  bash scripts/bench/run_ycsb.sh \
+                  2>/tmp/ycsb_stderr_mongodb_${WORKLOAD}_${THREADS}_${SAMPLE}.txt \
+                  | tee /tmp/ycsb_raw_mongodb_${WORKLOAD}_${THREADS}_${SAMPLE}.txt \
+                  | python3 scripts/bench/parse_ycsb.py \
+                    --target mongodb \
+                    --workload "$WORKLOAD" \
+                    --threads "$THREADS" \
+                    --commit "$COMMIT" \
+                    --date "$DATE" \
+                  >> "benchmarks/results/${DATE}.jsonl" \
+                  || { echo "WARN: mongodb W${WORKLOAD}/T${THREADS}/S${SAMPLE} parse failed"; \
+                       echo "=== stderr ===" >&2; \
+                       cat /tmp/ycsb_stderr_mongodb_${WORKLOAD}_${THREADS}_${SAMPLE}.txt >&2; \
+                       echo "=== raw stdout ===" >&2; \
+                       cat /tmp/ycsb_raw_mongodb_${WORKLOAD}_${THREADS}_${SAMPLE}.txt >&2; }
+              done
             done
           done
 
@@ -168,10 +174,13 @@ jobs:
           DATE=$(date -u +%Y-%m-%d)
           FILE="benchmarks/results/${DATE}.jsonl"
           FAIL=0
+          # Each workload should have 4 thread counts × 2 targets × 3 samples = 24 rows.
+          # Threshold of 6 (≥ 2 targets × 3 samples for at least one thread count) lets
+          # transient parse failures slip through without failing the whole nightly run.
           for WL in A B C D F; do  # E excluded — scan not yet implemented
             COUNT=$(grep -c "\"workload\":\"${WL}\"" "$FILE" 2>/dev/null || echo 0)
-            if [ "$COUNT" -lt 2 ]; then
-              echo "ERROR: Workload ${WL} has only ${COUNT} result lines (expected ≥2)"
+            if [ "$COUNT" -lt 6 ]; then
+              echo "ERROR: Workload ${WL} has only ${COUNT} result lines (expected ≥6)"
               FAIL=1
             else
               echo "OK: Workload ${WL} — ${COUNT} lines"

--- a/scripts/bench/check_perf_gap.py
+++ b/scripts/bench/check_perf_gap.py
@@ -8,7 +8,13 @@ Runs after every nightly benchmark. Three conditions:
   Condition 1: 0 < gap ≤ 0.10  → file/update issue every 3 days
   Condition 2: gap ≤ 0  → north star achieved → file achievement issue, close p0
 
-gap = north_star - current_3run_median_ratio
+gap = north_star - current_3_night_median_ratio
+
+Per-night sampling (see #715):
+  benchmark.yml emits 3 result rows per (workload, threads, target) per night.
+  This script aggregates samples → per-night median first, then computes the
+  per-night ratio. Condition 0 is variance-gated: if the current 3-night median
+  is within 2σ of the trailing 7-night median, the alert is suppressed.
 
 Usage:
   python3 scripts/bench/check_perf_gap.py \
@@ -18,11 +24,11 @@ Usage:
 """
 
 import sys
-import os
 import json
 import argparse
 import subprocess
 import statistics
+from collections import defaultdict
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 
@@ -35,6 +41,13 @@ LABEL_P0 = "priority:critical,area:performance,area:benchmark,agent:available,co
 LABEL_C1 = "priority:medium,area:performance,area:benchmark,agent:available,complexity:s,trust:newcomer-ok"
 LABEL_ACHIEVED = "area:performance,area:benchmark,trust:maintainer-only"
 
+# Variance gate parameters. See `memory/project_bench_noise_floor.md` and #715.
+CURRENT_WINDOW_NIGHTS = 3
+TRAILING_WINDOW_NIGHTS = 7
+SIGMA_THRESHOLD = 2.0
+# Min trailing nights below which the gate bypasses (insufficient history).
+MIN_TRAILING_FOR_GATE = 3
+
 
 # ---------------------------------------------------------------------------
 # Data loading
@@ -46,8 +59,12 @@ def load_north_star(path: str) -> float:
     return float(val)
 
 
-def load_results(results_dir: str, max_files: int = 5) -> list:
-    """Load JSONL files from the last max_files days, newest first."""
+def load_results(results_dir: str, max_files: int = 14) -> list:
+    """Load JSONL files from the last max_files days, newest first.
+
+    Need at least CURRENT_WINDOW_NIGHTS + TRAILING_WINDOW_NIGHTS nights to gate;
+    pad by 4 to absorb gaps where a nightly run was skipped or had no valid pairs.
+    """
     p = Path(results_dir)
     files = sorted(p.glob("*.jsonl"), reverse=True)[:max_files]
     rows = []
@@ -63,44 +80,163 @@ def load_results(results_dir: str, max_files: int = 5) -> list:
     return rows
 
 
-def compute_median_ratio(rows: list, last_n_dates: int = 3) -> tuple:
+def compute_per_night(rows: list) -> tuple[dict, dict]:
     """
-    Returns (overall_median_ratio, per_workload_median_dict).
-    Uses last N unique dates to smooth noise.
-    Only workloads in VALID_WORKLOADS are included.
+    Aggregate raw sample rows into per-night ratios.
+
+    Returns (night_overall, night_per_wl):
+      night_overall: dict[date_str -> overall_ratio]   (median across all wl/thread ratios)
+      night_per_wl:  dict[date_str -> dict[wl -> per-workload median ratio]]
+
+    Each per-night value is built by:
+      1. median ops_per_sec across samples per (workload, threads, target)
+      2. ratio = salvobase / mongodb per (workload, threads)
+      3. per_wl[wl] = median of all per-thread ratios for that workload
+      4. overall = median of all (workload, threads) ratios
     """
-    dates = sorted({r["date"] for r in rows}, reverse=True)[:last_n_dates]
+    # date -> (wl, threads, target) -> [ops_per_sec, ...]
+    grouped: dict = defaultdict(lambda: defaultdict(list))
+    for r in rows:
+        wl = r.get("workload", "")
+        if wl not in VALID_WORKLOADS:
+            continue
+        date = r.get("date", "")
+        if not date:
+            continue
+        key = (wl, r.get("threads", 0), r.get("target", ""))
+        ops = r.get("ops_per_sec", 0)
+        if ops and ops > 0:
+            grouped[date][key].append(ops)
 
-    ratios_by_workload: dict = {}
+    night_overall: dict = {}
+    night_per_wl: dict = {}
 
-    for date in dates:
-        date_rows = [r for r in rows if r["date"] == date]
-        by_key: dict = {}
-        for r in date_rows:
-            wl = r.get("workload", "")
-            if wl not in VALID_WORKLOADS:
-                continue
-            key = f"{wl}-{r.get('threads', 0)}"
-            target = r.get("target", "")
-            if key not in by_key:
-                by_key[key] = {}
-            by_key[key][target] = r.get("ops_per_sec", 0)
+    for date, key_to_samples in grouped.items():
+        # Median per (wl, threads, target) across samples
+        agg = {k: statistics.median(v) for k, v in key_to_samples.items() if v}
 
-        for key, targets in by_key.items():
+        # Pivot: (wl, threads) -> {target: ops}
+        by_wt: dict = defaultdict(dict)
+        for (wl, threads, target), ops in agg.items():
+            by_wt[(wl, threads)][target] = ops
+
+        # ratio per (wl, threads)
+        ratios_by_wl: dict = defaultdict(list)
+        for (wl, threads), targets in by_wt.items():
             sb = targets.get("salvobase", 0)
             mg = targets.get("mongodb", 0)
-            if mg > 0 and sb > 0:
-                wl = key.split("-")[0]
-                ratio = sb / mg
-                ratios_by_workload.setdefault(wl, []).append(ratio)
+            if sb > 0 and mg > 0:
+                ratios_by_wl[wl].append(sb / mg)
 
-    all_ratios = [r for ratios in ratios_by_workload.values() for r in ratios]
-    if not all_ratios:
+        if not ratios_by_wl:
+            continue
+
+        per_wl = {wl: statistics.median(rs) for wl, rs in ratios_by_wl.items()}
+        all_ratios = [r for rs in ratios_by_wl.values() for r in rs]
+        night_per_wl[date] = per_wl
+        night_overall[date] = statistics.median(all_ratios)
+
+    return night_overall, night_per_wl
+
+
+def compute_median_ratio(
+    rows: list, last_n_dates: int = CURRENT_WINDOW_NIGHTS
+) -> tuple:
+    """
+    Returns (overall_median_ratio, per_workload_median_dict) over the last N
+    unique dates. Aggregates samples → per-night first to neutralize noise.
+    """
+    night_overall, night_per_wl = compute_per_night(rows)
+    dates = sorted(night_overall.keys(), reverse=True)[:last_n_dates]
+    if not dates:
         return None, {}
 
-    per_wl = {wl: statistics.median(rs) for wl, rs in ratios_by_workload.items()}
-    overall = statistics.median(all_ratios)
+    overall = statistics.median([night_overall[d] for d in dates])
+
+    per_wl_collected: dict = defaultdict(list)
+    for d in dates:
+        for wl, ratio in night_per_wl[d].items():
+            per_wl_collected[wl].append(ratio)
+    per_wl = {wl: statistics.median(rs) for wl, rs in per_wl_collected.items()}
     return overall, per_wl
+
+
+def variance_gate(
+    rows: list,
+    current_n: int = CURRENT_WINDOW_NIGHTS,
+    trailing_n: int = TRAILING_WINDOW_NIGHTS,
+    sigma: float = SIGMA_THRESHOLD,
+) -> tuple[bool, str]:
+    """
+    Decide whether a Condition 0 alert should fire given the history.
+
+    Returns (should_alert, human-readable reason).
+
+    Logic:
+      - Need at least `current_n` nights — otherwise we can't even compute current.
+      - Need at least MIN_TRAILING_FOR_GATE prior nights — otherwise we don't
+        trust the stddev estimate; bypass gate (alert proceeds).
+      - Otherwise: alert only if current median is more than `sigma`·stddev
+        BELOW the trailing median. Sideways and upward moves are silenced
+        (upward "regressions" mean the gap closed — not something to alert on,
+        and Conditions 1/2 will pick them up via the gap calculation upstream).
+
+    Uses `statistics.pstdev` (population stddev) because the trailing window IS
+    the population we care about — we are not sampling from a larger distribution.
+    """
+    night_overall, _ = compute_per_night(rows)
+    dates = sorted(night_overall.keys(), reverse=True)
+
+    if len(dates) < current_n:
+        return True, (
+            f"only {len(dates)} night(s) of data; need {current_n} to compute "
+            f"current median — bypassing gate"
+        )
+
+    current_dates = dates[:current_n]
+    trailing_dates = dates[current_n:current_n + trailing_n]
+
+    if len(trailing_dates) < MIN_TRAILING_FOR_GATE:
+        return True, (
+            f"trailing window has only {len(trailing_dates)} night(s) "
+            f"(< {MIN_TRAILING_FOR_GATE}) — bypassing gate, alert proceeds"
+        )
+
+    current_vals = [night_overall[d] for d in current_dates]
+    trailing_vals = [night_overall[d] for d in trailing_dates]
+
+    current_med = statistics.median(current_vals)
+    trailing_med = statistics.median(trailing_vals)
+    trailing_std = statistics.pstdev(trailing_vals)
+
+    # Degenerate case: zero stddev → trailing window is identical → any drop is "significant"
+    if trailing_std == 0:
+        if current_med < trailing_med:
+            return True, (
+                f"trailing 7-night median {trailing_med*100:.1f}% (σ=0); "
+                f"current 3-night median {current_med*100:.1f}% is below — alert proceeds"
+            )
+        return False, (
+            f"trailing 7-night median {trailing_med*100:.1f}% (σ=0); "
+            f"current 3-night median {current_med*100:.1f}% — no drop, no alert"
+        )
+
+    threshold = trailing_med - sigma * trailing_std
+    sigmas_below = (trailing_med - current_med) / trailing_std
+
+    if current_med < threshold:
+        return True, (
+            f"current 3-night median {current_med*100:.1f}% is "
+            f"{sigmas_below:.2f}σ below trailing 7-night median "
+            f"{trailing_med*100:.1f}% (σ={trailing_std*100:.1f}pp) — significant regression"
+        )
+
+    return False, (
+        f"current 3-night median {current_med*100:.1f}% is "
+        f"{sigmas_below:+.2f}σ of trailing 7-night median "
+        f"{trailing_med*100:.1f}% (σ={trailing_std*100:.1f}pp) — "
+        f"within {sigma}σ noise floor, no significant change"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -202,7 +338,8 @@ If this is actively being worked on:
 ```
 
 ---
-*Filed by `check_perf_gap.py` (nightly benchmark). Updates every run while gap > 10pp.*
+*Filed by `check_perf_gap.py` (nightly benchmark). Updates every run while gap > 10pp \
+AND the move clears the 2σ noise-floor gate. See #715 for variance-gating logic.*
 *Last updated: {now}*
 """
     return title, body
@@ -273,8 +410,20 @@ This is a `trust:maintainer-only` issue — only the founder agent should close 
 # Condition handlers
 # ---------------------------------------------------------------------------
 
-def handle_condition_0(median_ratio: float, north_star: float, per_wl: dict, dry_run: bool):
-    """Gap > 10pp — upsert p0 issue every run."""
+def handle_condition_0(
+    median_ratio: float,
+    north_star: float,
+    per_wl: dict,
+    rows: list,
+    dry_run: bool,
+):
+    """Gap > 10pp — upsert p0 issue every run, gated on variance."""
+    should_alert, reason = variance_gate(rows)
+    print(f"  variance gate: {'ALERT' if should_alert else 'SILENCE'} — {reason}")
+    if not should_alert:
+        # Don't file, don't comment, don't update. Just trace and exit clean.
+        return
+
     title, body = p0_body(median_ratio, north_star, per_wl)
     existing = find_open_issue("close gap to north star", "priority:critical")
 
@@ -287,7 +436,8 @@ def handle_condition_0(median_ratio: float, north_star: float, per_wl: dict, dry
         comment = (
             f"**Updated {datetime.now(timezone.utc).strftime('%Y-%m-%d')}:** "
             f"Ratio {median_ratio*100:.1f}% · Gap {gap_pp:.1f}pp · "
-            f"Worst: {min(per_wl, key=per_wl.get)} at {min(per_wl.values())*100:.1f}%"
+            f"Worst: {min(per_wl, key=per_wl.get)} at {min(per_wl.values())*100:.1f}% · "
+            f"Gate: {reason}"
         )
         comment_on_issue(existing["number"], comment)
     else:
@@ -389,8 +539,8 @@ def main():
     print()
 
     if gap > 0.10:
-        print("→ Condition 0: EMERGENCY — gap > 10pp. Upserting p0 issue.")
-        handle_condition_0(median_ratio, north_star, per_wl, args.dry_run)
+        print("→ Condition 0: gap > 10pp. Evaluating variance gate before upserting p0.")
+        handle_condition_0(median_ratio, north_star, per_wl, rows, args.dry_run)
     elif gap > 0:
         print("→ Condition 1: Normal — gap ≤ 10pp. Filing/updating every 3 days.")
         handle_condition_1(median_ratio, north_star, per_wl, args.dry_run)

--- a/scripts/bench/print_ratios.py
+++ b/scripts/bench/print_ratios.py
@@ -3,12 +3,19 @@
 print_ratios.py — Read a JSONL results file and print a Markdown table of
 salvobase/mongodb performance ratios grouped by workload and thread count.
 
+Per-night sampling note (see #715):
+  benchmark.yml runs each (workload, threads, target) combination 3 times. This
+  script aggregates those samples into per-night median + stddev before computing
+  the salvobase/mongodb ratio, so the reported number reflects central tendency
+  rather than a single noisy observation.
+
 Usage:
   python3 scripts/bench/print_ratios.py benchmarks/results/2026-03-14.jsonl
 """
 
 import sys
 import json
+import statistics
 from collections import defaultdict
 
 
@@ -27,29 +34,61 @@ def load_jsonl(path):
 
 def build_lookup(rows):
     """
-    Returns dict: (workload, threads, target) -> {ops_per_sec, p50_ms, p99_ms}
+    Returns dict: (workload, threads, target) -> dict with aggregated
+    {ops_med, ops_std, p50_med, p99_med, n} across all samples seen.
     """
-    lookup = {}
+    grouped = defaultdict(lambda: {"ops": [], "p50": [], "p99": []})
     for r in rows:
         key = (r["workload"], r["threads"], r["target"])
-        lookup[key] = r
+        grouped[key]["ops"].append(r["ops_per_sec"])
+        grouped[key]["p50"].append(r["p50_ms"])
+        grouped[key]["p99"].append(r["p99_ms"])
+
+    lookup = {}
+    for key, vals in grouped.items():
+        n = len(vals["ops"])
+        lookup[key] = {
+            "ops_med": statistics.median(vals["ops"]),
+            "ops_std": statistics.stdev(vals["ops"]) if n >= 2 else 0.0,
+            "p50_med": statistics.median(vals["p50"]),
+            "p99_med": statistics.median(vals["p99"]),
+            "n": n,
+        }
     return lookup
 
 
-def ratio_str(a, b, higher_is_better=True):
+def ratio_cell(sb, mg, metric, higher_is_better=True):
     """
-    Return ratio string with directional arrow.
-    higher_is_better=True  → ratio > 1 means salvobase wins (green arrow up)
-    higher_is_better=False → ratio < 1 means salvobase wins (latency)
+    Compute ratio with first-order error propagation. For r = a/b,
+        σ_r/r ≈ sqrt((σ_a/a)² + (σ_b/b)²)
+    Returns string like "1.25x ± 0.10 ▲" or "—" when data is missing.
     """
-    if b == 0:
+    a = sb[f"{metric}_med"]
+    b = mg[f"{metric}_med"]
+    if b == 0 or a == 0:
         return "N/A"
     r = a / b
+
+    # Only ops has stddev tracked. For p99 we just show the median ratio.
+    if metric == "ops":
+        sigma_a = sb["ops_std"]
+        sigma_b = mg["ops_std"]
+        # First-order error propagation: σ_r/r ≈ √((σ_a/a)² + (σ_b/b)²)
+        rel_var = 0.0
+        if a > 0:
+            rel_var += (sigma_a / a) ** 2
+        if b > 0:
+            rel_var += (sigma_b / b) ** 2
+        sigma_r = r * (rel_var ** 0.5)
+        err_part = f" ± {sigma_r:.2f}"
+    else:
+        err_part = ""
+
     if higher_is_better:
         arrow = "▲" if r >= 1.0 else "▼"
     else:
         arrow = "▲" if r <= 1.0 else "▼"
-    return f"{r:.2f}x {arrow}"
+    return f"{r:.2f}x{err_part} {arrow}"
 
 
 def main():
@@ -69,10 +108,18 @@ def main():
     workloads = sorted(set(r["workload"] for r in rows))
     thread_counts = sorted(set(r["threads"] for r in rows))
 
+    # Surface the per-night sample count so readers know whether stddev is meaningful.
+    sample_counts = sorted({v["n"] for v in lookup.values()})
+
     print()
     print("## Salvobase vs MongoDB Community — Performance Ratios")
     print()
     print(f"Results from: `{path}`")
+    if sample_counts:
+        if len(sample_counts) == 1:
+            print(f"Samples per combination: **{sample_counts[0]}** (median + stddev)")
+        else:
+            print(f"Samples per combination: **{min(sample_counts)}–{max(sample_counts)}** (varies)")
     print()
 
     # OPS table
@@ -89,7 +136,7 @@ def main():
             sb = lookup.get((wl, t, "salvobase"))
             mg = lookup.get((wl, t, "mongodb"))
             if sb and mg:
-                cells.append(ratio_str(sb["ops_per_sec"], mg["ops_per_sec"], higher_is_better=True))
+                cells.append(ratio_cell(sb, mg, "ops", higher_is_better=True))
             else:
                 cells.append("—")
         print(f"| {wl} | " + " | ".join(cells) + " |")
@@ -108,18 +155,18 @@ def main():
             sb = lookup.get((wl, t, "salvobase"))
             mg = lookup.get((wl, t, "mongodb"))
             if sb and mg:
-                cells.append(ratio_str(sb["p99_ms"], mg["p99_ms"], higher_is_better=False))
+                cells.append(ratio_cell(sb, mg, "p99", higher_is_better=False))
             else:
                 cells.append("—")
         print(f"| {wl} | " + " | ".join(cells) + " |")
 
     print()
 
-    # Raw numbers
-    print("### Raw Numbers")
+    # Raw numbers — aggregated per-night
+    print("### Raw Numbers (per-night median across samples)")
     print()
-    raw_header = "| Workload | Threads | Target | OPS | P50 (ms) | P99 (ms) |"
-    raw_sep = "| --- | --- | --- | --- | --- | --- |"
+    raw_header = "| Workload | Threads | Target | OPS (med) | OPS (σ) | P50 (ms) | P99 (ms) | n |"
+    raw_sep = "| --- | --- | --- | --- | --- | --- | --- | --- |"
     print(raw_header)
     print(raw_sep)
 
@@ -129,7 +176,9 @@ def main():
                 r = lookup.get((wl, t, target))
                 if r:
                     print(
-                        f"| {wl} | {t} | {target} | {r['ops_per_sec']:,.0f} | {r['p50_ms']:.3f} | {r['p99_ms']:.3f} |"
+                        f"| {wl} | {t} | {target} | "
+                        f"{r['ops_med']:,.0f} | {r['ops_std']:,.0f} | "
+                        f"{r['p50_med']:.3f} | {r['p99_med']:.3f} | {r['n']} |"
                     )
 
     print()

--- a/tests/bench/test_variance_gate.py
+++ b/tests/bench/test_variance_gate.py
@@ -1,0 +1,312 @@
+"""
+Tests for the per-night variance gate in scripts/bench/check_perf_gap.py.
+
+These tests do NOT call GitHub. They synthesize input rows, exercise the pure
+helper functions (compute_per_night, compute_median_ratio, variance_gate), and
+also monkeypatch the gh() helper to assert that handle_condition_0 honors the
+gate.
+
+Run from repo root:
+    python3 -m pytest tests/bench -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest.mock as mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module loader — bench scripts live outside any package, so we load them by path.
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _load_module(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader, f"could not load {path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+check_perf_gap = _load_module(
+    "check_perf_gap", REPO_ROOT / "scripts/bench/check_perf_gap.py"
+)
+print_ratios = _load_module(
+    "print_ratios", REPO_ROOT / "scripts/bench/print_ratios.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data helpers
+# ---------------------------------------------------------------------------
+
+WORKLOADS = ["A", "B", "C", "D", "F"]
+THREADS = [1, 4, 8, 16]
+
+
+def synth_night(
+    date: str,
+    salvobase_ops: float,
+    mongo_ops: float,
+    samples_per_combo: int = 3,
+    jitter: float = 0.0,
+) -> list[dict]:
+    """
+    Produce a list of result rows for one date. Each (wl, threads, target)
+    combination emits `samples_per_combo` rows with the same nominal ops, plus
+    optional ±jitter applied symmetrically so the median stays at the target.
+    """
+    rows: list[dict] = []
+    offsets = [0.0] if samples_per_combo == 1 else [-jitter, 0.0, jitter][:samples_per_combo]
+    for wl in WORKLOADS:
+        for t in THREADS:
+            for offset in offsets:
+                rows.append({
+                    "workload": wl,
+                    "threads": t,
+                    "target": "salvobase",
+                    "ops_per_sec": salvobase_ops + offset,
+                    "p50_ms": 1.0,
+                    "p99_ms": 5.0,
+                    "date": date,
+                })
+                rows.append({
+                    "workload": wl,
+                    "threads": t,
+                    "target": "mongodb",
+                    "ops_per_sec": mongo_ops,
+                    "p50_ms": 0.5,
+                    "p99_ms": 2.0,
+                    "date": date,
+                })
+    return rows
+
+
+def synth_history(ratios_newest_first: list[float], mongo_ops: float = 1000.0) -> list[dict]:
+    """
+    Build a history given a list of desired per-night ratios, newest first.
+    Day numbering: 2026-05-29, 2026-05-28, … going back.
+    """
+    rows: list[dict] = []
+    base_day = 29
+    base_month = 5
+    for i, ratio in enumerate(ratios_newest_first):
+        d = base_day - i
+        # Keep dates simple — they only need to sort lexicographically.
+        date = f"2026-{base_month:02d}-{d:02d}" if d > 0 else f"2026-04-{(d + 30):02d}"
+        rows.extend(synth_night(date, ratio * mongo_ops, mongo_ops))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# compute_per_night — pivot + aggregation
+# ---------------------------------------------------------------------------
+
+class TestComputePerNight:
+    def test_aggregates_samples_to_per_night_median(self):
+        rows = synth_night("2026-05-29", salvobase_ops=500, mongo_ops=1000, samples_per_combo=3)
+        night_overall, night_per_wl = check_perf_gap.compute_per_night(rows)
+        assert "2026-05-29" in night_overall
+        assert night_overall["2026-05-29"] == pytest.approx(0.5, rel=1e-6)
+        # All workloads should appear
+        assert set(night_per_wl["2026-05-29"].keys()) == set(WORKLOADS)
+        for wl in WORKLOADS:
+            assert night_per_wl["2026-05-29"][wl] == pytest.approx(0.5, rel=1e-6)
+
+    def test_ignores_workload_e(self):
+        rows = synth_night("2026-05-29", 500, 1000)
+        rows.extend([
+            {"workload": "E", "threads": 16, "target": "salvobase",
+             "ops_per_sec": 0.01, "p50_ms": 1, "p99_ms": 1, "date": "2026-05-29"},
+            {"workload": "E", "threads": 16, "target": "mongodb",
+             "ops_per_sec": 1000.0, "p50_ms": 1, "p99_ms": 1, "date": "2026-05-29"},
+        ])
+        _, night_per_wl = check_perf_gap.compute_per_night(rows)
+        assert "E" not in night_per_wl["2026-05-29"]
+
+    def test_handles_missing_mongo_pair(self):
+        rows = [
+            {"workload": "A", "threads": 1, "target": "salvobase",
+             "ops_per_sec": 500.0, "p50_ms": 1, "p99_ms": 1, "date": "2026-05-29"},
+            # No mongodb partner — should be skipped, not crash.
+        ]
+        night_overall, night_per_wl = check_perf_gap.compute_per_night(rows)
+        assert night_overall == {}
+        assert night_per_wl == {}
+
+
+# ---------------------------------------------------------------------------
+# variance_gate — the core deliverable
+# ---------------------------------------------------------------------------
+
+class TestVarianceGate:
+    def test_should_not_alert_when_within_2_sigma(self):
+        # 10 nights at ~37% with ±1pp jitter — current 3-night median ≈ trailing 7-night median.
+        ratios = [0.38, 0.37, 0.37, 0.37, 0.38, 0.37, 0.36, 0.37, 0.38, 0.37]
+        rows = synth_history(ratios)
+        should_alert, reason = check_perf_gap.variance_gate(rows)
+        assert should_alert is False, f"expected silence, got alert: {reason}"
+        assert "no significant change" in reason
+
+    def test_should_alert_when_more_than_2_sigma_below_trailing(self):
+        # Trailing 7 nights cluster tightly around 37%; current 3 nights drop to 22%.
+        trailing = [0.37, 0.38, 0.36, 0.37, 0.38, 0.37, 0.36]
+        current = [0.22, 0.21, 0.22]
+        rows = synth_history(current + trailing)
+        should_alert, reason = check_perf_gap.variance_gate(rows)
+        assert should_alert is True, f"expected alert, got silence: {reason}"
+        assert "significant regression" in reason
+        assert "σ below" in reason
+
+    def test_should_alert_when_trailing_window_has_fewer_than_3_nights(self):
+        # Only 5 total nights → trailing window is 2 → must bypass the gate.
+        ratios = [0.20, 0.21, 0.22, 0.37, 0.38]
+        rows = synth_history(ratios)
+        should_alert, reason = check_perf_gap.variance_gate(rows)
+        assert should_alert is True
+        assert "bypassing gate" in reason
+
+    def test_should_alert_when_only_one_night_of_data(self):
+        rows = synth_history([0.20])
+        should_alert, reason = check_perf_gap.variance_gate(rows)
+        assert should_alert is True
+        assert "bypassing gate" in reason
+
+    def test_silences_one_sigma_drops_on_the_measured_noise_floor(self):
+        # 6pp stddev is the measured noise floor (see project_bench_noise_floor.md).
+        # A 7pp drop is roughly 1σ — must NOT alert.
+        trailing = [0.30, 0.36, 0.24, 0.32, 0.28, 0.34, 0.26]  # mean ~30%, σ ≈ 4.4pp
+        current = [0.23, 0.24, 0.25]  # ~7pp below trailing median
+        rows = synth_history(current + trailing)
+        should_alert, reason = check_perf_gap.variance_gate(rows)
+        assert should_alert is False, f"expected silence, got alert: {reason}"
+
+    def test_zero_stddev_trailing_still_alerts_on_drop(self):
+        # Defensive: if all trailing nights are identical, σ=0. Any drop must still alert.
+        trailing = [0.37] * 7
+        current = [0.30, 0.30, 0.30]
+        rows = synth_history(current + trailing)
+        should_alert, reason = check_perf_gap.variance_gate(rows)
+        assert should_alert is True
+
+
+# ---------------------------------------------------------------------------
+# handle_condition_0 — must NOT call gh when gate silences
+# ---------------------------------------------------------------------------
+
+class TestHandleCondition0:
+    def test_does_not_create_or_comment_when_gate_silences(self):
+        # Trailing + current clustered tightly around 37% — gate silences.
+        ratios = [0.37] * 10
+        rows = synth_history(ratios)
+        per_wl = {wl: 0.37 for wl in WORKLOADS}
+
+        with mock.patch.object(check_perf_gap, "gh") as gh_mock, \
+             mock.patch.object(check_perf_gap, "create_issue") as create_mock, \
+             mock.patch.object(check_perf_gap, "comment_on_issue") as comment_mock:
+            check_perf_gap.handle_condition_0(
+                median_ratio=0.37,
+                north_star=0.90,
+                per_wl=per_wl,
+                rows=rows,
+                dry_run=False,
+            )
+            assert create_mock.call_count == 0
+            assert comment_mock.call_count == 0
+            # find_open_issue uses gh too — but we should never have gotten there.
+            assert gh_mock.call_count == 0
+
+    def test_creates_issue_when_gate_passes_and_no_existing(self):
+        # Trailing tight, current drops far → gate fires.
+        trailing = [0.40, 0.41, 0.39, 0.40, 0.40, 0.41, 0.39]
+        current = [0.20, 0.21, 0.20]
+        rows = synth_history(current + trailing)
+        per_wl = {wl: 0.20 for wl in WORKLOADS}
+
+        with mock.patch.object(check_perf_gap, "find_open_issue", return_value=None), \
+             mock.patch.object(check_perf_gap, "create_issue") as create_mock, \
+             mock.patch.object(check_perf_gap, "comment_on_issue") as comment_mock:
+            check_perf_gap.handle_condition_0(
+                median_ratio=0.20,
+                north_star=0.90,
+                per_wl=per_wl,
+                rows=rows,
+                dry_run=False,
+            )
+            assert create_mock.call_count == 1
+            assert comment_mock.call_count == 0
+
+    def test_creates_issue_when_history_too_short_to_gate(self):
+        # Only 2 nights → gate bypasses → alert proceeds. This guards against
+        # the gate eating real signal on a fresh install or after a long outage.
+        rows = synth_history([0.20, 0.21])
+        per_wl = {wl: 0.20 for wl in WORKLOADS}
+
+        with mock.patch.object(check_perf_gap, "find_open_issue", return_value=None), \
+             mock.patch.object(check_perf_gap, "create_issue") as create_mock:
+            check_perf_gap.handle_condition_0(
+                median_ratio=0.20,
+                north_star=0.90,
+                per_wl=per_wl,
+                rows=rows,
+                dry_run=False,
+            )
+            assert create_mock.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# print_ratios — aggregation produces error bars
+# ---------------------------------------------------------------------------
+
+class TestPrintRatios:
+    def test_build_lookup_aggregates_samples(self):
+        rows = synth_night("2026-05-29", salvobase_ops=500, mongo_ops=1000,
+                           samples_per_combo=3, jitter=50.0)
+        lookup = print_ratios.build_lookup(rows)
+        sb = lookup[("A", 1, "salvobase")]
+        assert sb["n"] == 3
+        assert sb["ops_med"] == pytest.approx(500, rel=1e-6)
+        assert sb["ops_std"] > 0  # jitter present
+
+    def test_build_lookup_zero_stddev_with_one_sample(self):
+        rows = synth_night("2026-05-29", 500, 1000, samples_per_combo=1)
+        lookup = print_ratios.build_lookup(rows)
+        sb = lookup[("A", 1, "salvobase")]
+        assert sb["n"] == 1
+        assert sb["ops_std"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Workflow contract — 3 samples per combination
+# ---------------------------------------------------------------------------
+
+class TestWorkflowSampling:
+    """
+    Static check on .github/workflows/benchmark.yml — guards against silently
+    losing the 3× sampling loop in a future edit. The workflow body is read as
+    text rather than parsed as YAML; that's sufficient for shape assertions.
+    """
+
+    def test_workflow_has_three_sample_loop(self):
+        wf = (REPO_ROOT / ".github/workflows/benchmark.yml").read_text()
+        assert "for SAMPLE in 1 2 3" in wf, (
+            "benchmark.yml must wrap the per-combination run loop with "
+            "`for SAMPLE in 1 2 3` (see #715)"
+        )
+
+    def test_workflow_validation_threshold_is_six(self):
+        wf = (REPO_ROOT / ".github/workflows/benchmark.yml").read_text()
+        # Sanity-check: validation must expect ≥6 rows per workload now that we sample 3×.
+        assert "expected ≥6" in wf, (
+            "benchmark.yml validation threshold must be ≥6 rows per workload "
+            "after 3× sampling change"
+        )


### PR DESCRIPTION
Closes #715. Part of epic #397.

## What

Two-part fix for nightly benchmark noise on GitHub-hosted runners:

1. **3× sampling per combination** in `.github/workflows/benchmark.yml` — each
   `(workload, threads, target)` emits 3 result rows instead of 1.
2. **2σ variance gate** in `scripts/bench/check_perf_gap.py` — the Condition 0
   p0 issue upsert only fires when the current 3-night median is more than 2σ
   below the trailing 7-night median. Bypasses when trailing window has <3 nights.
3. `print_ratios.py` aggregates samples and reports `ratio ± σ` with first-order
   error propagation.

## Why

The Workload A ratio has 6.1pp stddev over a 10-night window on shared runners.
A sequence of three descending nights triggered a perf investigation that turned
out to be pure noise. Cost: one founder cycle wasted. The 3× sampling smooths
the numerator; the 2σ gate stops false alerts at the alerting layer. Population
stddev (`pstdev`) rather than sample stddev, because the trailing 7 nights ARE
the population we care about — see #715 review thread for the math.

## Test plan

`tests/bench/test_variance_gate.py` — 16 pytest cases, all passing:

- [x] should not alert when current is within 2σ of trailing
- [x] should alert when current is >2σ below trailing
- [x] should bypass gate when trailing window has <3 nights
- [x] should bypass gate when only 1 night of data exists
- [x] should silence ~1σ drops on the measured 6pp noise floor
- [x] should still alert on any drop when trailing stddev is 0
- [x] should aggregate samples to per-night median in `compute_per_night`
- [x] should ignore workload E (scan not implemented)
- [x] should handle missing salvobase/mongodb pairs without crashing
- [x] `handle_condition_0` does not call gh when gate silences
- [x] `handle_condition_0` creates issue when gate passes + no existing
- [x] `handle_condition_0` creates issue when history too short
- [x] `print_ratios.build_lookup` aggregates samples with stddev
- [x] `print_ratios.build_lookup` produces 0 stddev with 1 sample
- [x] workflow has `for SAMPLE in 1 2 3` loop
- [x] workflow validation threshold is ≥6 rows per workload

Smoke-tested both `print_ratios.py` and `check_perf_gap.py --dry-run` against
real bench data from `bench-data:benchmarks/results/2026-05-28.jsonl`.

Code-reviewer subagent run before merge — 0 Critical, all 4 Should-Fix items
addressed (population stddev, max_files headroom, variable shadowing, docstring
for one-sided check).

Cost: ~3× CI minutes per nightly run.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: ["#715"]
```

*Posted by the founder agent on behalf of @inder*