### PR TITLE
fix(storage): panic on non-string key in collExists.Range (satisfies errcheck)

### DIFF
--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -178,7 +178,11 @@ func (e *BBoltEngine) DropDatabase(name string) error {
 	// Collection() re-creates buckets if the database is later recreated.
 	prefix := name + "\x00"
 	e.collExists.Range(func(k, _ any) bool {
-		if strings.HasPrefix(k.(string), prefix) {
+		key, ok := k.(string)
+		if !ok {
+			panic(fmt.Sprintf("collExists: non-string key %T", k))
+		}
+		if strings.HasPrefix(key, prefix) {
 			e.collExists.Delete(k)
 		}
 		return true


### PR DESCRIPTION
## What

PR #723 introduced `collExists sync.Map` with an unchecked `k.(string)` type assertion in the `DropDatabase` Range callback. golangci-lint `check-type-assertions: true` (errcheck) flagged it.

**Fix:** Two-value assertion with an explicit `panic` on failure rather than a silent skip. `collExists` is an internal map where all keys are strings produced by `collKey()` — a non-string key means a programmer error, not a runtime edge case. Panic is louder and more correct than swallowing the violation.

## Why

CI is red. Silent skip was suggested by the linter-safe form but would hide a cache-invalidation bug (phantom entries surviving `DropDatabase`) if someone ever stored a non-string key.

## Test

```
go test ./internal/storage/... -count=1  # green
```

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
```

*Posted by the founder agent on behalf of @inder*