### PR TITLE
perf(storage): read-check before write tx on Collection() slow path (closes #722)

### DIFF
--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -446,6 +446,27 @@ func (e *BBoltEngine) Collection(db, coll string) (Collection, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Read-check: if both buckets already exist skip the write transaction and
+	// its fdatasync cost. This is the common case after a restart when collExists
+	// is cold but the data is already on disk.
+	// View errors are intentionally ignored: a read failure falls through to
+	// the write path which will surface the real error.
+	var alreadyExists bool
+	_ = boltDB.View(func(tx *bolt.Tx) error {
+		meta := tx.Bucket([]byte(bucketMetaCollections))
+		if meta != nil && meta.Get(metaCollKey(coll)) != nil {
+			if tx.Bucket([]byte(collBucket(coll))) != nil {
+				alreadyExists = true
+			}
+		}
+		return nil
+	})
+	if alreadyExists {
+		e.collExists.Store(collKey(db, coll), struct{}{})
+		return &bboltCollection{db: db, coll: coll, engine: e}, nil
+	}
+
 	err = boltDB.Update(func(tx *bolt.Tx) error {
 		meta, err := tx.CreateBucketIfNotExists([]byte(bucketMetaCollections))
 		if err != nil {

--- a/internal/storage/fastpath_test.go
+++ b/internal/storage/fastpath_test.go
@@ -288,6 +288,66 @@ func TestDeleteByIndexScan(t *testing.T) {
 	}
 }
 
+// TestCollectionReadCheckPath verifies that Collection() uses the read-only
+// View before the write Update on the slow path, so a restart over existing
+// data warms the cache without paying an fdatasync.
+func TestCollectionReadCheckPath(t *testing.T) {
+	dir := t.TempDir()
+
+	// First engine: create the collection on disk.
+	e1, err := NewBBoltEngine(dir, "none", false)
+	if err != nil {
+		t.Fatalf("NewBBoltEngine (e1): %v", err)
+	}
+	if _, err := e1.Collection("testdb", "col1"); err != nil {
+		t.Fatalf("e1.Collection: %v", err)
+	}
+	if err := e1.Close(); err != nil {
+		t.Fatalf("e1.Close: %v", err)
+	}
+
+	// Second engine: same dir, cold collExists cache.
+	e2, err := NewBBoltEngine(dir, "none", false)
+	if err != nil {
+		t.Fatalf("NewBBoltEngine (e2): %v", err)
+	}
+	t.Cleanup(func() { _ = e2.Close() })
+
+	// Cache must be empty at this point.
+	if _, ok := e2.collExists.Load(collKey("testdb", "col1")); ok {
+		t.Fatal("expected empty collExists on fresh engine")
+	}
+
+	// Open the underlying boltDB so we can snapshot write stats before
+	// Collection() touches it (openDB is idempotent).
+	boltDB, err := e2.openDB("testdb")
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	before := boltDB.Stats().TxStats.Write
+
+	// Collection() slow path: read-check finds both buckets, no write tx needed.
+	if _, err := e2.Collection("testdb", "col1"); err != nil {
+		t.Fatalf("e2.Collection: %v", err)
+	}
+
+	// No write transaction should have been committed: the read-check path
+	// skips boltDB.Update entirely when both buckets already exist.
+	if after := boltDB.Stats().TxStats.Write; after != before {
+		t.Errorf("write count changed: before=%d after=%d — write tx ran when read-check should have been sufficient", before, after)
+	}
+
+	// Cache must now be warm.
+	if _, ok := e2.collExists.Load(collKey("testdb", "col1")); !ok {
+		t.Fatal("expected collExists warm after read-check slow path")
+	}
+
+	// Second access must hit the fast path (cache already warm).
+	if _, err := e2.Collection("testdb", "col1"); err != nil {
+		t.Fatalf("e2.Collection (second): %v", err)
+	}
+}
+
 // TestCollExistsCacheInvalidation verifies that collExists is correctly
 // invalidated across drop, rename, and DropDatabase operations so the
 // fast path never serves a stale handle to a non-existent bucket.


### PR DESCRIPTION
Closes #722

## What

On a `collExists` cache miss in `Collection()`, insert a read-only `boltDB.View` before the `boltDB.Update`. If both the `_meta.collections` entry and the data bucket already exist on disk, skip the write transaction (and its `fdatasync`) entirely.

This is the common case after a process restart: the cache is empty but the collections were written in a prior run.

## Why

Every `boltDB.Update` commits a write transaction which calls `fdatasync`. PR #723 added the `collExists` fast path to skip this for subsequent requests, but the **first** request after restart still paid the fdatasync. This eliminates it for all collections that already exist.

Combined with PR #723:
- 1st request after restart (cold cache): View only — no fdatasync
- All subsequent requests: direct cache hit — no transaction at all

## Test

`TestCollectionReadCheckPath` in `fastpath_test.go` verifies:
1. Fresh engine over existing data has empty cache
2. `Collection()` warms the cache **without** incrementing `boltDB.Stats().TxStats.Write` (proves write tx was not committed)
3. Second call hits the fast path

```
go test ./internal/storage/... -count=1 -run TestCollectionReadCheckPath -v
# --- PASS: TestCollectionReadCheckPath (0.02s)
```

## Code review

Code-reviewed by `code-reviewer` subagent: 0 Critical, 0 Major. Two findings addressed:
- Test now asserts `TxStats.Write` didn't increment (not just that cache is warm)
- Added comment explaining why the `View` error is intentionally ignored

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-sonnet-4-6
  operator: inder
  trust_tier: maintainer
  issues: ["#722"]
```

*Posted by the founder agent on behalf of @inder*