### PR TITLE
ci: add on-demand pprof profile-capture workflow (refs #721)

### DIFF
--- a/.github/workflows/profile-capture.yml
+++ b/.github/workflows/profile-capture.yml
@@ -1,0 +1,192 @@
+name: Profile Capture (Workload A)
+
+# On-demand pprof CPU + heap profile capture against current master.
+# Triggered manually; does not run on schedule. Use this to refresh
+# docs/profiles/workload-a-16t-vN.txt baselines after a perf optimization
+# lands. Captures on ubuntu-latest x86_64 so the result is directly
+# comparable to the v1/v2 profiles already in the repo.
+#
+# Workload A (50/50 read/update), 16 client threads, 100k records, 100k ops.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: "Profile version tag (e.g. v3) — used in artifact filenames"
+        required: true
+        default: "v3"
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  RECORD_COUNT: "100000"
+  OPERATION_COUNT: "100000"
+  THREADS: "16"
+  WORKLOAD: "A"
+
+jobs:
+  capture:
+    name: Capture pprof profiles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Build salvobase
+        run: go build -o ./bin/salvobase ./cmd/mongod
+
+      - name: Start salvobase
+        run: |
+          mkdir -p /tmp/salvobase-data
+          nohup ./bin/salvobase \
+            --datadir /tmp/salvobase-data \
+            --port 27017 \
+            --httpPort 27080 \
+            --bind_ip 0.0.0.0 \
+            --noauth \
+            > /tmp/salvobase.log 2>&1 &
+          echo $! > /tmp/salvobase.pid
+          for i in $(seq 1 30); do
+            if wget -qO- http://localhost:27080/health >/dev/null 2>&1; then
+              echo "salvobase ready after ${i}x1s"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Install go-ycsb
+        run: |
+          git clone --depth=1 https://github.com/pingcap/go-ycsb.git /tmp/go-ycsb
+          cd /tmp/go-ycsb && go build -o /usr/local/bin/go-ycsb ./cmd/go-ycsb
+
+      - name: Load 100k records
+        run: |
+          TARGET_URL=mongodb://localhost:27017 \
+          WORKLOAD=$WORKLOAD \
+          THREADS=$THREADS \
+          RECORD_COUNT=$RECORD_COUNT \
+          OPERATION_COUNT=$OPERATION_COUNT \
+            bash scripts/bench/run_ycsb.sh \
+            > /tmp/load.log 2>&1 || true
+          # The above script also runs the workload; we want load-then-profile.
+          # The script's combined behavior is acceptable for warming the bbolt
+          # working set before the dedicated profile run below.
+
+      - name: Capture CPU profile during Workload A run
+        run: |
+          # Start a 30s CPU profile capture in the background, then drive load
+          # for 30s+ via go-ycsb against the same dataset.
+          mkdir -p /tmp/profiles
+          curl -sS --max-time 45 -o /tmp/profiles/cpu.pprof \
+            "http://localhost:27080/debug/pprof/profile?seconds=30" &
+          CURL_PID=$!
+
+          # Drive load. Use a fresh namespace so this is independent of the
+          # warm-up run above. 100k ops at 16 threads typically runs ~30-60s
+          # on ubuntu-latest, which is the right shape for a 30s CPU sample.
+          DB_NAME="profile_run_$(date +%s)"
+          cat > /tmp/wla.properties <<'EOF'
+          workload=core
+          readallfields=true
+          fieldcount=10
+          fieldlength=100
+          readproportion=0.5
+          updateproportion=0.5
+          readmodifywriteproportion=0
+          scanproportion=0
+          insertproportion=0
+          requestdistribution=zipfian
+          EOF
+          go-ycsb load mongodb -P /tmp/wla.properties \
+            -p mongodb.url=mongodb://localhost:27017 \
+            -p mongodb.namespace=${DB_NAME}.usertable \
+            -p recordcount=${RECORD_COUNT} \
+            -p threadcount=${THREADS} > /tmp/profile_load.log 2>&1
+          go-ycsb run mongodb -P /tmp/wla.properties \
+            -p mongodb.url=mongodb://localhost:27017 \
+            -p mongodb.namespace=${DB_NAME}.usertable \
+            -p recordcount=${RECORD_COUNT} \
+            -p operationcount=${OPERATION_COUNT} \
+            -p threadcount=${THREADS} > /tmp/profile_run.log 2>&1
+
+          # Wait for the pprof capture to finish (max 45s).
+          wait $CURL_PID
+          ls -la /tmp/profiles/cpu.pprof
+          file /tmp/profiles/cpu.pprof
+
+      - name: Capture heap/alloc profile
+        run: |
+          curl -sS -o /tmp/profiles/heap.pprof \
+            "http://localhost:27080/debug/pprof/heap"
+          curl -sS -o /tmp/profiles/allocs.pprof \
+            "http://localhost:27080/debug/pprof/allocs"
+          ls -la /tmp/profiles/
+
+      - name: Generate text summaries
+        run: |
+          VERSION="${{ github.event.inputs.version_tag }}"
+          {
+            echo "# CPU profile — Workload A, 16 threads, 100k ops"
+            echo
+            echo "## go tool pprof -top -cum (top 30)"
+            echo '```'
+            go tool pprof -top -cum -nodecount=30 /tmp/profiles/cpu.pprof 2>&1 | head -60
+            echo '```'
+            echo
+            echo "## go tool pprof -top (flat, top 30)"
+            echo '```'
+            go tool pprof -top -nodecount=30 /tmp/profiles/cpu.pprof 2>&1 | head -60
+            echo '```'
+          } > /tmp/profiles/cpu-summary.md
+
+          {
+            echo "# Allocation profile — Workload A, 16 threads, 100k ops"
+            echo
+            echo "## go tool pprof -alloc_objects -top (top 30)"
+            echo '```'
+            go tool pprof -alloc_objects -top -nodecount=30 /tmp/profiles/allocs.pprof 2>&1 | head -60
+            echo '```'
+            echo
+            echo "## go tool pprof -alloc_space -top (top 30)"
+            echo '```'
+            go tool pprof -alloc_space -top -nodecount=30 /tmp/profiles/allocs.pprof 2>&1 | head -60
+            echo '```'
+          } > /tmp/profiles/alloc-summary.md
+
+          # Re-gzip the raw profile files to match the existing .txt convention
+          # used by docs/profiles/workload-a-16t-v2.txt (gzipped pprof binary).
+          gzip -kf /tmp/profiles/cpu.pprof
+          gzip -kf /tmp/profiles/allocs.pprof
+          mv /tmp/profiles/cpu.pprof.gz /tmp/profiles/workload-a-16t-${VERSION}.txt
+          mv /tmp/profiles/allocs.pprof.gz /tmp/profiles/workload-a-16t-${VERSION}-alloc.txt
+          ls -la /tmp/profiles/
+
+      - name: Stop salvobase
+        if: always()
+        run: |
+          if [ -f /tmp/salvobase.pid ]; then
+            kill $(cat /tmp/salvobase.pid) 2>/dev/null || true
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pprof-profiles-${{ github.event.inputs.version_tag }}
+          path: |
+            /tmp/profiles/workload-a-16t-*.txt
+            /tmp/profiles/cpu-summary.md
+            /tmp/profiles/alloc-summary.md
+          retention-days: 30
+
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: salvobase-log
+          path: /tmp/salvobase.log
+          retention-days: 7

--- a/.github/workflows/profile-capture.yml
+++ b/.github/workflows/profile-capture.yml
@@ -56,6 +56,11 @@ jobs:
               echo "salvobase ready after ${i}x1s"
               break
             fi
+            if [ "$i" -eq 30 ]; then
+              echo "ERROR: salvobase never became healthy" >&2
+              cat /tmp/salvobase.log >&2 || true
+              exit 1
+            fi
             sleep 1
           done
 
@@ -64,32 +69,12 @@ jobs:
           git clone --depth=1 https://github.com/pingcap/go-ycsb.git /tmp/go-ycsb
           cd /tmp/go-ycsb && go build -o /usr/local/bin/go-ycsb ./cmd/go-ycsb
 
-      - name: Load 100k records
+      - name: Prepare workload properties and load dataset
         run: |
-          TARGET_URL=mongodb://localhost:27017 \
-          WORKLOAD=$WORKLOAD \
-          THREADS=$THREADS \
-          RECORD_COUNT=$RECORD_COUNT \
-          OPERATION_COUNT=$OPERATION_COUNT \
-            bash scripts/bench/run_ycsb.sh \
-            > /tmp/load.log 2>&1 || true
-          # The above script also runs the workload; we want load-then-profile.
-          # The script's combined behavior is acceptable for warming the bbolt
-          # working set before the dedicated profile run below.
-
-      - name: Capture CPU profile during Workload A run
-        run: |
-          # Start a 30s CPU profile capture in the background, then drive load
-          # for 30s+ via go-ycsb against the same dataset.
           mkdir -p /tmp/profiles
-          curl -sS --max-time 45 -o /tmp/profiles/cpu.pprof \
-            "http://localhost:27080/debug/pprof/profile?seconds=30" &
-          CURL_PID=$!
-
-          # Drive load. Use a fresh namespace so this is independent of the
-          # warm-up run above. 100k ops at 16 threads typically runs ~30-60s
-          # on ubuntu-latest, which is the right shape for a 30s CPU sample.
-          DB_NAME="profile_run_$(date +%s)"
+          # Generate the properties file with no leading whitespace — bash
+          # heredocs with quoted EOF preserve indentation literally, and
+          # go-ycsb would treat "          workload" as the key.
           cat > /tmp/wla.properties <<'EOF'
           workload=core
           readallfields=true
@@ -102,11 +87,32 @@ jobs:
           insertproportion=0
           requestdistribution=zipfian
           EOF
+          # Strip leading whitespace introduced by YAML block scalar indent.
+          sed -i 's/^[[:space:]]*//' /tmp/wla.properties
+          echo "--- properties ---"
+          cat /tmp/wla.properties
+          echo "------------------"
+
+          DB_NAME="profile_run_$(date +%s)"
+          echo "$DB_NAME" > /tmp/profile_db_name
           go-ycsb load mongodb -P /tmp/wla.properties \
             -p mongodb.url=mongodb://localhost:27017 \
             -p mongodb.namespace=${DB_NAME}.usertable \
             -p recordcount=${RECORD_COUNT} \
             -p threadcount=${THREADS} > /tmp/profile_load.log 2>&1
+
+      - name: Capture CPU profile during Workload A run
+        run: |
+          DB_NAME=$(cat /tmp/profile_db_name)
+          # Fire the 30s CPU sample in the background, then drive the run phase
+          # synchronously. The run phase is where we want CPU attribution —
+          # firing the sample AFTER load ensures the 30s window overlaps the
+          # steady-state read/update mix, not the bulk insert path.
+          # -f: fail on HTTP errors so a 500 doesn't get gzipped silently.
+          curl -fsS --max-time 45 -o /tmp/profiles/cpu.pprof \
+            "http://localhost:27080/debug/pprof/profile?seconds=30" &
+          CURL_PID=$!
+
           go-ycsb run mongodb -P /tmp/wla.properties \
             -p mongodb.url=mongodb://localhost:27017 \
             -p mongodb.namespace=${DB_NAME}.usertable \
@@ -114,17 +120,31 @@ jobs:
             -p operationcount=${OPERATION_COUNT} \
             -p threadcount=${THREADS} > /tmp/profile_run.log 2>&1
 
-          # Wait for the pprof capture to finish (max 45s).
           wait $CURL_PID
           ls -la /tmp/profiles/cpu.pprof
           file /tmp/profiles/cpu.pprof
+          # Hard-fail if the file is not the expected pprof binary format.
+          # pprof binaries are gzip-wrapped protobuf; `file` reports them as
+          # "gzip compressed data" or just "data" depending on the runner.
+          if ! file /tmp/profiles/cpu.pprof | grep -qE 'gzip compressed data|data$'; then
+            echo "ERROR: cpu.pprof is not a valid pprof binary" >&2
+            head -c 500 /tmp/profiles/cpu.pprof >&2 || true
+            exit 1
+          fi
 
       - name: Capture heap/alloc profile
         run: |
-          curl -sS -o /tmp/profiles/heap.pprof \
+          # -f so HTTP errors fail the step instead of being silently saved.
+          curl -fsS -o /tmp/profiles/heap.pprof \
             "http://localhost:27080/debug/pprof/heap"
-          curl -sS -o /tmp/profiles/allocs.pprof \
+          curl -fsS -o /tmp/profiles/allocs.pprof \
             "http://localhost:27080/debug/pprof/allocs"
+          for f in heap allocs; do
+            if ! file /tmp/profiles/${f}.pprof | grep -qE 'gzip compressed data|data$'; then
+              echo "ERROR: ${f}.pprof is not a valid pprof binary" >&2
+              exit 1
+            fi
+          done
           ls -la /tmp/profiles/
 
       - name: Generate text summaries


### PR DESCRIPTION
Refs #721.

## What

Adds `.github/workflows/profile-capture.yml` — a `workflow_dispatch`-only job that:

1. Builds `salvobase` and starts it on `:27017` + `:27080`.
2. Installs `go-ycsb` from source (same method as `benchmark.yml`).
3. Loads 100k records, then runs Workload A (16 threads, 100k ops).
4. Captures a 30s CPU profile via `/debug/pprof/profile?seconds=30` during the run phase.
5. Captures heap + alloc profiles after.
6. Generates `go tool pprof -top -cum` and `-alloc_objects` text summaries.
7. Uploads four artifacts: `workload-a-16t-${version_tag}.txt` (gzipped CPU pprof), `…-alloc.txt` (gzipped alloc pprof), `cpu-summary.md`, `alloc-summary.md`.

## Why

#721 asked for a one-shot v3 profile capture after #720 (net.Buffers). We've also had #670 ask for the same thing after the prior optimization sprint. This recurring ask should be a workflow, not a manual ritual. Running on `ubuntu-latest` x86_64 means future v4, v5, … profiles will be byte-format compatible with v1/v2 already in `docs/profiles/`.

Does not touch `benchmark.yml` — the existing nightly is unaffected.

## How to trigger

```bash
gh workflow run profile-capture.yml -F version_tag=v3
```

## Review fixes applied

Code-reviewer subagent flagged 4 issues, all addressed in commit `f8b12a1`:

1. **Heredoc indentation** — YAML block scalar preserved 10 spaces of leading whitespace on every property line. Fixed with a `sed` strip.
2. **Healthcheck timeout silent** — original loop never `exit 1`'d when salvobase failed to start. Fixed.
3. **CPU profile window racing the load phase** — the 30s sample now fires *after* load completes, guaranteeing overlap with steady-state read/update mix.
4. **Silent corruption of artifacts** — `curl -sS` (no `-f`) would silently save HTTP error bodies which `gzip` then wrapped. Added `-f` and a `file` magic check.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: ["#721"]
```

*Posted by the founder agent on behalf of @inder*