### PR TITLE
perf(server): bsoncore byte-splice extractAndStripMeta — 51% fewer allocs (closes #730)

### DIFF
--- a/internal/server/connection.go
+++ b/internal/server/connection.go
@@ -326,16 +326,49 @@ func (c *Connection) close() {
 // extractAndStripMeta removes well-known metadata fields from an OP_MSG command
 // document and returns (db, cleanedCmd).
 // MongoDB drivers inject: $db, lsid, $clusterTime, $readPreference, txnNumber, startTransaction, autocommit
+//
+// Fast path: walks the document element-by-element via bsoncore.ReadElement
+// (which returns slice views, no allocation) and appends the bytes of every
+// non-stripped element verbatim into a single pre-sized output buffer. The
+// length prefix is patched at the end. This avoids the bson.D round-trip the
+// previous implementation paid on every OP_MSG (v3 profile attributed 4.9% of
+// allocated objects + 15.77% cum bytes to extractAndStripMeta + injectField;
+// PR #732 fixed injectField, this fixes the other half).
+//
+// On a malformed document the function falls back to returning the original
+// cmd unchanged with whatever db has been extracted so far ("admin" if $db has
+// not yet been seen) — matching the original error semantics.
 func extractAndStripMeta(cmd bson.Raw, c *Connection) (string, bson.Raw) {
-	elems, err := cmd.Elements()
-	if err != nil {
+	// Minimal validation: 4-byte length prefix + at least the trailing 0x00,
+	// and the length field must equal the slice length.
+	if len(cmd) < 5 || cmd[len(cmd)-1] != 0x00 {
+		return "admin", cmd
+	}
+	if int(binary.LittleEndian.Uint32(cmd[:4])) != len(cmd) {
 		return "admin", cmd
 	}
 
 	db := "admin"
-	stripped := make(bson.D, 0, len(elems))
+	// Output is at most as large as input (we only strip, never add). Pre-sizing
+	// to len(cmd) keeps the append loop allocation-free.
+	out := make([]byte, 4, len(cmd))
 
-	for _, elem := range elems {
+	elements := cmd[4 : len(cmd)-1]
+	for len(elements) > 0 {
+		coreElem, after, ok := bsoncore.ReadElement(elements)
+		if !ok {
+			// Malformed interior — return whatever db we have and pass the
+			// original cmd through; the dispatcher will reject it downstream.
+			return db, cmd
+		}
+		elements = after
+
+		// bson.RawElement is the same underlying []byte as bsoncore.Element
+		// but its Value() returns bson.RawValue, keeping the switch arms
+		// identical to the slow path (compares against bson.TypeXxx constants
+		// and assigns bson.Raw to commands.Session.ID).
+		elem := bson.RawElement(coreElem)
+
 		switch elem.Key() {
 		case "$db":
 			if s, ok := elem.Value().StringValueOK(); ok {
@@ -372,6 +405,67 @@ func extractAndStripMeta(cmd bson.Raw, c *Connection) (string, bson.Raw) {
 			}
 		case "autocommit":
 			// Ignore — we auto-commit everything.
+		default:
+			// coreElem is a bsoncore.Element ([]byte view) covering exactly
+			// [type][key\x00][value]. Copy verbatim into the output buffer.
+			out = append(out, coreElem...)
+		}
+	}
+
+	// Trailing 0x00 doc terminator, then patch the length prefix.
+	out = append(out, 0x00)
+	binary.LittleEndian.PutUint32(out[0:4], uint32(len(out)))
+	return db, out
+}
+
+// extractAndStripMetaSlow is the pre-optimization reference implementation kept
+// solely to verify that extractAndStripMeta produces byte-identical output for
+// the cleaned command and identical side effects for session state. Tests
+// compare fast/slow outputs and benchmarks A/B them. Not called by production
+// code — handleOpMsg always uses the fast path above.
+func extractAndStripMetaSlow(cmd bson.Raw, c *Connection) (string, bson.Raw) {
+	elems, err := cmd.Elements()
+	if err != nil {
+		return "admin", cmd
+	}
+
+	db := "admin"
+	stripped := make(bson.D, 0, len(elems))
+
+	for _, elem := range elems {
+		switch elem.Key() {
+		case "$db":
+			if s, ok := elem.Value().StringValueOK(); ok {
+				db = s
+			}
+		case "lsid":
+			if doc, ok := elem.Value().DocumentOK(); ok {
+				if c.session == nil {
+					c.session = &commands.Session{}
+				}
+				c.session.ID = doc
+				if idVal, err := doc.LookupErr("id"); err == nil {
+					c.session.LSID = fmt.Sprintf("%v", idVal)
+				}
+			}
+		case "$clusterTime", "$readPreference", "$readConcern":
+		case "txnNumber":
+			if c.session == nil {
+				c.session = &commands.Session{}
+			}
+			switch elem.Value().Type {
+			case bson.TypeInt64:
+				c.session.TxnNumber = elem.Value().Int64()
+			case bson.TypeInt32:
+				c.session.TxnNumber = int64(elem.Value().Int32())
+			}
+		case "startTransaction":
+			if c.session != nil {
+				if b, ok := elem.Value().BooleanOK(); ok && b {
+					c.session.InTransaction = true
+				}
+			}
+		case "autocommit":
 		default:
 			stripped = append(stripped, bson.E{Key: elem.Key(), Value: elem.Value()})
 		}

--- a/internal/server/connection_test.go
+++ b/internal/server/connection_test.go
@@ -294,3 +294,235 @@ func mustMarshalForBench(d bson.D) bson.Raw {
 	raw, _ := bson.Marshal(d)
 	return raw
 }
+
+// ----------------------------------------------------------------------------
+// extractAndStripMeta — fast path vs slow path equivalence + benchmarks.
+// The slow path (extractAndStripMetaSlow) lives in connection.go as the pre-
+// optimization reference implementation. The fast path is the production
+// byte-splice walker that avoids the bson.D round-trip on every OP_MSG.
+// ----------------------------------------------------------------------------
+
+// typicalOpMsgCmd builds a representative command document that a Mongo driver
+// would send: a real command name + a few real fields + the standard
+// metadata fields that get stripped. Used by tests and benchmarks.
+func typicalOpMsgCmd(t testing.TB) bson.Raw {
+	t.Helper()
+	lsid, err := bson.Marshal(bson.D{
+		{Key: "id", Value: bson.Binary{Subtype: 0x04, Data: bytes.Repeat([]byte{0xAB}, 16)}},
+	})
+	if err != nil {
+		t.Fatalf("marshal lsid: %v", err)
+	}
+	clusterTime, err := bson.Marshal(bson.D{
+		{Key: "clusterTime", Value: bson.Timestamp{T: 1700000000, I: 1}},
+	})
+	if err != nil {
+		t.Fatalf("marshal clusterTime: %v", err)
+	}
+	readPref, err := bson.Marshal(bson.D{{Key: "mode", Value: "primary"}})
+	if err != nil {
+		t.Fatalf("marshal readPref: %v", err)
+	}
+	readConcern, err := bson.Marshal(bson.D{{Key: "level", Value: "local"}})
+	if err != nil {
+		t.Fatalf("marshal readConcern: %v", err)
+	}
+	// Fixture covers all 8 stripped field names so the byte-equality test acts
+	// as a regression net for changes to the strip list itself.
+	raw, err := bson.Marshal(bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "active", Value: true}}},
+		{Key: "limit", Value: int32(10)},
+		{Key: "lsid", Value: bson.RawValue{Type: bson.TypeEmbeddedDocument, Value: lsid}},
+		{Key: "$clusterTime", Value: bson.RawValue{Type: bson.TypeEmbeddedDocument, Value: clusterTime}},
+		{Key: "$readPreference", Value: bson.RawValue{Type: bson.TypeEmbeddedDocument, Value: readPref}},
+		{Key: "$readConcern", Value: bson.RawValue{Type: bson.TypeEmbeddedDocument, Value: readConcern}},
+		{Key: "txnNumber", Value: int64(7)},
+		{Key: "startTransaction", Value: true},
+		{Key: "autocommit", Value: false},
+		{Key: "$db", Value: "appdb"},
+	})
+	if err != nil {
+		t.Fatalf("marshal cmd: %v", err)
+	}
+	return raw
+}
+
+// newTestConn returns a Connection stub good enough for extractAndStripMeta
+// (which only touches c.session — never c.conn, c.server, etc.).
+func newTestConn() *Connection {
+	return &Connection{}
+}
+
+func TestExtractAndStripMeta_MatchesSlowPath(t *testing.T) {
+	cmd := typicalOpMsgCmd(t)
+
+	cFast := newTestConn()
+	dbFast, cleanFast := extractAndStripMeta(cmd, cFast)
+
+	cSlow := newTestConn()
+	dbSlow, cleanSlow := extractAndStripMetaSlow(cmd, cSlow)
+
+	if dbFast != dbSlow {
+		t.Fatalf("db differs: fast=%q slow=%q", dbFast, dbSlow)
+	}
+	if dbFast != "appdb" {
+		t.Fatalf("db: got %q, want \"appdb\"", dbFast)
+	}
+	if !bytes.Equal(cleanFast, cleanSlow) {
+		t.Fatalf("cleaned cmd bytes differ\nfast: %x\nslow: %x", cleanFast, cleanSlow)
+	}
+
+	// Session state must match between fast and slow paths.
+	if cFast.session == nil || cSlow.session == nil {
+		t.Fatalf("expected session populated in both paths: fast=%v slow=%v", cFast.session, cSlow.session)
+	}
+	if cFast.session.TxnNumber != cSlow.session.TxnNumber {
+		t.Fatalf("session.TxnNumber differs: fast=%d slow=%d", cFast.session.TxnNumber, cSlow.session.TxnNumber)
+	}
+	if cFast.session.TxnNumber != 7 {
+		t.Fatalf("session.TxnNumber: got %d, want 7", cFast.session.TxnNumber)
+	}
+	if cFast.session.InTransaction != cSlow.session.InTransaction {
+		t.Fatalf("session.InTransaction differs: fast=%v slow=%v", cFast.session.InTransaction, cSlow.session.InTransaction)
+	}
+	if !cFast.session.InTransaction {
+		t.Fatalf("session.InTransaction: got false, want true")
+	}
+	if !reflect.DeepEqual(cFast.session.ID, cSlow.session.ID) {
+		t.Fatalf("session.ID differs: fast=%x slow=%x", cFast.session.ID, cSlow.session.ID)
+	}
+
+	// Cleaned cmd must round-trip and contain only the non-meta fields.
+	var parsed bson.D
+	if err := bson.Unmarshal(cleanFast, &parsed); err != nil {
+		t.Fatalf("cleaned cmd does not parse: %v", err)
+	}
+	wantKeys := map[string]bool{"find": true, "filter": true, "limit": true}
+	stripped := map[string]bool{
+		"$db": true, "lsid": true, "$clusterTime": true, "$readPreference": true,
+		"$readConcern": true, "txnNumber": true, "startTransaction": true, "autocommit": true,
+	}
+	for _, e := range parsed {
+		if stripped[e.Key] {
+			t.Errorf("cleaned cmd unexpectedly retained meta field %q", e.Key)
+		}
+		if !wantKeys[e.Key] {
+			t.Errorf("cleaned cmd contains unexpected key %q", e.Key)
+		}
+		delete(wantKeys, e.Key)
+	}
+	for k := range wantKeys {
+		t.Errorf("cleaned cmd missing expected key %q", k)
+	}
+}
+
+func TestExtractAndStripMeta_NoMetaFields_RoundTrips(t *testing.T) {
+	// A command with no metadata fields at all — every element must survive.
+	cmd, err := bson.Marshal(bson.D{
+		{Key: "ping", Value: int32(1)},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	cFast := newTestConn()
+	dbFast, cleanFast := extractAndStripMeta(cmd, cFast)
+	cSlow := newTestConn()
+	dbSlow, cleanSlow := extractAndStripMetaSlow(cmd, cSlow)
+
+	if dbFast != "admin" || dbSlow != "admin" {
+		t.Fatalf("expected admin db default, got fast=%q slow=%q", dbFast, dbSlow)
+	}
+	if !bytes.Equal(cleanFast, cleanSlow) {
+		t.Fatalf("cleaned bytes differ\nfast: %x\nslow: %x", cleanFast, cleanSlow)
+	}
+}
+
+func TestExtractAndStripMeta_OnlyMetaFields_ProducesEmptyDoc(t *testing.T) {
+	// Document containing nothing but metadata — output must be a valid
+	// 5-byte empty BSON document.
+	cmd, err := bson.Marshal(bson.D{
+		{Key: "$db", Value: "x"},
+		{Key: "autocommit", Value: true},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	cFast := newTestConn()
+	db, clean := extractAndStripMeta(cmd, cFast)
+	if db != "x" {
+		t.Fatalf("db: got %q, want \"x\"", db)
+	}
+	emptyDoc := bson.Raw{0x05, 0x00, 0x00, 0x00, 0x00}
+	if !bytes.Equal(clean, emptyDoc) {
+		t.Fatalf("expected empty BSON doc, got %x", clean)
+	}
+}
+
+func TestExtractAndStripMeta_TooShort_ReturnsAdminAndPassthrough(t *testing.T) {
+	short := bson.Raw{0x01, 0x02}
+	c := newTestConn()
+	db, clean := extractAndStripMeta(short, c)
+	if db != "admin" {
+		t.Fatalf("db: got %q, want \"admin\"", db)
+	}
+	if !bytes.Equal(clean, short) {
+		t.Fatalf("expected passthrough of short input, got %x", clean)
+	}
+}
+
+func TestExtractAndStripMeta_MalformedInterior_DoesNotProduceCorruption(t *testing.T) {
+	// Valid envelope, claims an 0x02 (string) element with a 100-byte payload
+	// that doesn't exist. The fast path must NOT emit a longer-than-input
+	// document; on ReadElement failure it must pass the original cmd through.
+	corrupt := bson.Raw{
+		0x0C, 0x00, 0x00, 0x00, // length = 12
+		0x02,       // type = string
+		0x78, 0x00, // key = "x"
+		0x64, 0x00, 0x00, 0x00, // string length = 100 (lies)
+		0x00, // doc terminator
+	}
+	c := newTestConn()
+	db, clean := extractAndStripMeta(corrupt, c)
+	if db != "admin" {
+		t.Fatalf("db: got %q, want \"admin\"", db)
+	}
+	if len(clean) > len(corrupt) {
+		t.Fatalf("fast path silently produced a longer-than-input doc on corrupt interior (would propagate corruption)")
+	}
+}
+
+// BenchmarkExtractAndStripMeta_FastPath measures the new bsoncore byte-splice
+// walker. DoD for #730: ≥30% reduction in allocations vs the slow-path
+// reference below.
+//
+// A fresh Connection is constructed per iteration: extractAndStripMeta lazily
+// allocates c.session on first call, and reusing c across iterations would
+// amortize that allocation to zero from iteration 2 onward — understating the
+// steady-state per-request cost (which is what handleOpMsg actually pays,
+// since c.session is a *connection*-lifetime field but every new TCP
+// connection starts with c.session == nil).
+func BenchmarkExtractAndStripMeta_FastPath(b *testing.B) {
+	cmd := typicalOpMsgCmd(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := newTestConn()
+		_, _ = extractAndStripMeta(cmd, c)
+	}
+}
+
+// BenchmarkExtractAndStripMeta_SlowPath_Reference is the pre-optimization
+// implementation (bson.D builder + bson.Marshal round-trip), retained as the
+// A/B baseline. The fast path must show substantially fewer allocations.
+func BenchmarkExtractAndStripMeta_SlowPath_Reference(b *testing.B) {
+	cmd := typicalOpMsgCmd(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c := newTestConn()
+		_, _ = extractAndStripMetaSlow(cmd, c)
+	}
+}


### PR DESCRIPTION
Closes #730

## What

Replace `extractAndStripMeta`'s `bson.D` round-trip with a single-pass
`bsoncore.ReadElement` walker that copies non-stripped element bytes verbatim
into a pre-sized output buffer and patches the int32 length prefix at the end.

The old impl is preserved as `extractAndStripMetaSlow` (mirrors PR #732's
`injectFieldSlow` pattern) so byte-equality tests + an A/B benchmark guard
against regression.

## Why

Same architectural fix #732 applied to `injectField`, applied to its sibling
function. The v3 pprof baseline attributed 4.9% of all allocated objects and
15.77% cum bytes to `extractAndStripMeta + injectField`; #732 fixed half,
this fixes the other half. Net: hot OP_MSG path no longer does
`bson.D → bson.Marshal` on every request.

## Bench

Apple M1 Pro, fresh `Connection` per iteration (matches the steady-state cost
`handleOpMsg` pays on every new TCP connection — `c.session` is per-connection,
allocated lazily on first metadata field):

| | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| `extractAndStripMeta` (fast) | 770 | 712 | 19 |
| `extractAndStripMetaSlow` (ref) | 1970 | 2459 | 39 |
| Δ | **2.6× faster** | **71% less** | **51% fewer** |

DoD is ≥30% alloc reduction. Achieved 51%.

## Tests

- `TestExtractAndStripMeta_MatchesSlowPath` — fast and slow paths produce
  byte-identical cleaned-cmd output and identical `c.session` side effects on
  a fixture covering all 8 stripped field names (`$db`, `lsid`,
  `$clusterTime`, `$readPreference`, `$readConcern`, `txnNumber`,
  `startTransaction`, `autocommit`).
- `TestExtractAndStripMeta_NoMetaFields_RoundTrips` — every element survives
  when no metadata is present.
- `TestExtractAndStripMeta_OnlyMetaFields_ProducesEmptyDoc` — strip-everything
  produces a valid 5-byte empty BSON doc.
- `TestExtractAndStripMeta_TooShort_ReturnsAdminAndPassthrough` — envelope
  guard.
- `TestExtractAndStripMeta_MalformedInterior_DoesNotProduceCorruption` —
  `ReadElement` failure mid-walk falls through with the original `cmd`
  unchanged (no silent length-prefix corruption).

## Pre-merge review

Code-reviewed by `code-reviewer` subagent. One Critical finding fixed
pre-commit: original benchmarks reused a single `*Connection` across all
`b.N` iterations, so the lazy `c.session` allocation was amortized to zero
from iteration 2 — understating per-request cost. Benchmarks now construct a
fresh `Connection` per iteration. Numbers above reflect the corrected
measurement.

## Out of scope

Further reductions are possible (e.g. avoiding the per-element `elem.Key()`
string allocation via raw-byte comparison) but the DoD target is comfortably
met and this PR keeps the diff narrowly scoped to the architectural change
that retires the `bson.Marshal` round-trip. Follow-up issue can be opened if
the v4 profile still shows extractAndStripMeta as a top allocator.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: ["#730"]
```

*Posted by the founder agent on behalf of @inder*