### PR TITLE
docs(profiles): correct v3-analysis.md misdiagnosis of wire-layer bufio

### DIFF
--- a/docs/profiles/v3-analysis.md
+++ b/docs/profiles/v3-analysis.md
@@ -61,7 +61,7 @@
 
 | Function | bytes% | Notes |
 |---|---|---|
-| **`bufio.NewReaderSize`** | **11.0% (0.61 GB)** | **🚨 Plan V3 P0-B target. Per-message bufio.Reader allocation is still happening at 0.6 GB / 30s. Either the fix never landed or it regressed.** See follow-up below. |
+| **`bufio.NewReaderSize`** | **11.0% (0.61 GB)** | **Misattributed in this baseline.** pprof charged the allocation to `bufio.NewReaderSize` at a call site, but the actual hot caller is **not** `wire.ReadMessage` — it's `bson.newDocumentReader` inside the BSON library, called via `bson.Unmarshal` from `server.injectField` (and `server.extractAndStripMeta`). Resolved by PR #732 (`injectField` byte-splice fast path) and PR #733 (`extractAndStripMeta` byte-splice). The wire-layer `bufio.Reader` was already moved to the `Connection` struct in PR #720, visible in v3 as `wire.WriteOpMsg` dropping 28.3%→10.5%. |
 | `bson.(*valueWriter).writeValueBytes` | 10.5% | Reply encoder. |
 | `bsoncore.Document.Elements` | 9.6% | Document iteration. |
 | `bson.Marshal` | 8.6% | Cumulative reply marshal cost is 1.52 GB / 30s — ~27% of all allocation. |
@@ -77,11 +77,11 @@
 
 **1. #720 net.Buffers fix delivered.** `wire.WriteOpMsg` dropped from 28.3% cum (v2) to 10.5% cum (v3). The `net.(*Buffers).WriteTo` → `internal/poll.(*FD).Writev` path appears explicitly in the v3 profile at 10.3% / 9.8%, confirming the optimization is hot. This is the largest single perf win in the recent sprint and the profile confirms it.
 
-**2. `bufio.NewReaderSize` at 0.61 GB / 30s is the new highest-leverage fix.** This is the same P0-B item from Plan V3 that was supposed to land months ago. `ReadMessage` at `internal/wire/protocol.go` calls `bufio.NewReaderSize(lr, 4096)` on every single message, allocating 4KiB per request on the hottest path. At 16 threads × Workload A throughput this adds up to 0.6 GB / 30s of pure allocation pressure, driving `runtime.mallocgc` to 19.9% of CPU. This should be its own issue — see follow-up.
+**2. `bufio.NewReaderSize` at 0.61 GB / 30s was misdiagnosed — the real source was BSON, not the wire layer.** The original reading of this baseline blamed `wire.ReadMessage` for per-message `bufio.NewReaderSize(lr, 4096)` calls. That fix had already landed in PR #720 (Connection-resident `*bufio.Reader`), and v3 shows the result: `wire.WriteOpMsg` dropped from 28.3% to 10.5% cum CPU. PR #732 traced the remaining `bufio.NewReaderSize` allocation back to `bson.newDocumentReader` inside the BSON library, called via `bson.Unmarshal` 100% from `server.injectField`. The byte-splice fast path in #732 (and the companion fix in #733 for `extractAndStripMeta`) eliminated this allocation by avoiding the `bson.D` round-trip entirely: 32× fewer allocs, 44× less memory on `injectField`; 35× fewer allocs, 71% less memory on `extractAndStripMeta`. The lesson — see the bottom of this doc — is that pprof attribution to a call site is not proof of where the work is being done.
 
 **3. bbolt write batching is the single largest CPU sink at 29.5% cum.** Combined with the underlying `fdatasync` syscall cost, write-path bbolt costs dominate. The strategic ceiling note in `docs/perf-plan-state.json` ("bbolt is a single-writer B-tree, realistic ceiling 30-50% on writes") is the most likely architectural ceiling.
 
-**4. BSON encode/decode is the per-request hot loop.** `bsoncore.Document.Elements` shows up at both 9.6% bytes and 14.0% objects. Combined with `bson.Marshal` (8.6%) and `bson.Raw.Elements` (4.1%), BSON-related allocation totals ~37% of all bytes allocated. The driver library is what it is, but `server.extractAndStripMeta` (4.9% objects, 14.3% bytes when injectField is included) is salvobase code that re-iterates the BSON document multiple times per request — refactoring it to a single pass would meaningfully cut allocation.
+**4. BSON encode/decode is the per-request hot loop.** `bsoncore.Document.Elements` shows up at both 9.6% bytes and 14.0% objects. Combined with `bson.Marshal` (8.6%) and `bson.Raw.Elements` (4.1%), BSON-related allocation totals ~37% of all bytes allocated. The driver library is what it is. The `server.extractAndStripMeta` (4.9% objects, 14.3% bytes when injectField is included) attribution was the salvobase-side leverage point; PRs #732 and #733 replaced the `bson.D` round-trip with bsoncore byte-splice paths in both `injectField` and `extractAndStripMeta`. The next v4 capture will quantify the cumulative impact.
 
 **5. `bbolt.(*page).fastCheck` at 3.6% objects + 3.6% bytes is unexpected.** This is a per-page sanity check that can be made cheaper or skipped in release builds. Worth investigating.
 
@@ -89,8 +89,14 @@
 
 #### Follow-ups to file
 
-- **HIGH:** `perf(wire): per-message bufio.NewReaderSize is allocating 0.6 GB / 30s — move *bufio.Reader to Connection struct` (Plan V3 P0-B, never landed).
-- **MEDIUM:** `perf(server): extractAndStripMeta + injectField re-iterate BSON document — single-pass refactor` (4.9% + 1.1% obj alloc on every request).
-- **LOW:** `perf(bbolt): investigate cost of (*page).fastCheck in hot read path` (3.6% obj alloc, may be skippable).
+- ~~**HIGH:** `perf(wire): per-message bufio.NewReaderSize is allocating 0.6 GB / 30s — move *bufio.Reader to Connection struct` (Plan V3 P0-B, never landed).~~ **Misdiagnosed. Resolved by PR #732 (`server.injectField` byte-splice) and PR #733 (`server.extractAndStripMeta` byte-splice). The wire-layer `bufio.Reader` already moved to the `Connection` struct in PR #720.**
+- ~~**MEDIUM:** `perf(server): extractAndStripMeta + injectField re-iterate BSON document — single-pass refactor` (4.9% + 1.1% obj alloc on every request).~~ **Resolved by PR #732 + #733.**
+- **LOW:** `perf(bbolt): investigate cost of (*page).fastCheck in hot read path` (3.6% obj alloc, may be skippable). Filed as #731.
 
-Closes #721.
+---
+
+#### Lesson
+
+**pprof attribution to a call site is not proof — the actual caller may be inside an external library.** In this baseline, `bufio.NewReaderSize` was charged to a salvobase call site, but the real hot caller was inside the BSON library (`bson.newDocumentReader`), invoked indirectly via `bson.Unmarshal` from `server.injectField`. Diagnoses based on the symbol alone (without tracing the actual call graph) sent the original analysis after a non-existent wire-layer bug. Always confirm the caller before naming a hotspot.
+
+Closes #721. Doc correction filed as #734.


### PR DESCRIPTION
Closes #734.

## What

Corrects the v3 profile analysis doc, which attributed the `bufio.NewReaderSize` allocation hotspot (11.0% / 0.61 GB) to a per-message `bufio.NewReaderSize(lr, 4096)` call in `wire.ReadMessage`. That diagnosis was wrong:

- The wire-layer `bufio.Reader` was already moved to the `Connection` struct in PR #720, and v3 confirms it — `wire.WriteOpMsg` dropped from 28.3% (v2) to 10.5% (v3) cum CPU.
- PR #732 traced the actual hot caller of `bufio.NewReaderSize` to `bson.newDocumentReader` inside the BSON library, invoked via `bson.Unmarshal` from `server.injectField`. The fix replaced the `bson.D` round-trip with a bsoncore byte-splice fast path.
- PR #733 applied the companion fix to `server.extractAndStripMeta`.

Updates:
- Table row for `bufio.NewReaderSize` (Top allocations by bytes).
- Key finding #2 — replaced with the correct attribution + references to #720, #732, #733.
- Key finding #4 — `extractAndStripMeta` no longer described as needing a single-pass refactor (it received one in #733).
- Follow-ups list — HIGH and MEDIUM items struck through with resolution; LOW item annotated with the filed issue #731.
- New "Lesson" section: *pprof attribution to a call site is not proof — the actual caller may be inside an external library.*

## Why

The canonical Workload A baseline doc was sending future profiling work chasing a non-existent wire-layer bug. The correction is doc-only (no code changes) and ensures the next contributor reads the right call graph.

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: ["#734"]
```

*Posted by the founder agent on behalf of @inder*