### PR TITLE
wire(hello): connectionId int32 to match MongoDB 7.0

### DIFF
--- a/internal/commands/hello.go
+++ b/internal/commands/hello.go
@@ -121,8 +121,11 @@ func handleHello(ctx *Context, cmd bson.Raw) (bson.Raw, error) {
 	// Middle: logicalSessionTimeoutMinutes.
 	buf = append(buf, helloMiddle...)
 
-	// Dynamic: connectionId.
-	buf = bsoncore.AppendInt64Element(buf, "connectionId", ctx.ConnID)
+	// Dynamic: connectionId. MongoDB 7.0's hello handler uses BSONObjBuilder
+	// appendNumber, which emits int32 when the value fits in [INT_MIN, INT_MAX]
+	// — connection IDs are monotonically incrementing per-mongod and will
+	// always fit in practice. Match that wire shape exactly.
+	buf = bsoncore.AppendInt32Element(buf, "connectionId", int32(ctx.ConnID))
 
 	// Suffix: minWireVersion .. readOnly.
 	buf = append(buf, helloSuffix...)

--- a/internal/commands/hello_bench_test.go
+++ b/internal/commands/hello_bench_test.go
@@ -29,12 +29,18 @@ var isMasterCmdRaw = func() bson.Raw {
 	return bson.Raw(raw)
 }()
 
-// helloResponseDocLegacy reproduces the bson.D the pre-PR handler built. Used
-// as the bench baseline so the ratio between the two is meaningful — and as
-// the canonical "expected wire" in the equivalence test.
+// helloResponseDocLegacy is the canonical MongoDB 7.0-equivalent wire form
+// expressed as a bson.D. It is both the bench baseline (mirrors the pre-PR
+// builder shape so the ratio between the two paths is meaningful) and the
+// expected output in the wire-equivalence test.
+//
+// connectionId is int32 because MongoDB Server's hello uses
+// BSONObjBuilder::appendNumber, which dispatches to int32 when the value fits
+// in [INT_MIN, INT_MAX] (verified in #744 against r7.0.0 source). Real
+// connection IDs always fit.
 //
 // connID and the localTime DateTime are supplied so the test can pin them.
-func helloResponseDocLegacy(connID int64, t time.Time) bson.D {
+func helloResponseDocLegacy(connID int32, t time.Time) bson.D {
 	return bson.D{
 		{Key: "isWritablePrimary", Value: true},
 		{Key: "topologyVersion", Value: bson.D{
@@ -62,7 +68,7 @@ func BenchmarkHandleHello_Legacy(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		d := helloResponseDocLegacy(ctx.ConnID, time.Now().UTC())
+		d := helloResponseDocLegacy(int32(ctx.ConnID), time.Now().UTC())
 		_ = marshalResponse(ctx, d)
 		ctx.runReleases()
 	}
@@ -135,7 +141,7 @@ func TestHandleHello_WireEquivalent(t *testing.T) {
 				t.Fatalf("unmarshal: %v", err)
 			}
 
-			want := helloResponseDocLegacy(ctx.ConnID, before)
+			want := helloResponseDocLegacy(int32(ctx.ConnID), before)
 			if tc.wantIsMa {
 				// Legacy flag is appended *after* readOnly and *before* ok.
 				okIdx := len(want) - 1

--- a/internal/commands/marshal_bench_test.go
+++ b/internal/commands/marshal_bench_test.go
@@ -23,7 +23,7 @@ func helloResponseDoc() bson.D {
 		{Key: "maxWriteBatchSize", Value: int32(100000)},
 		{Key: "localTime", Value: bson.DateTime(now.UnixMilli())},
 		{Key: "logicalSessionTimeoutMinutes", Value: int32(30)},
-		{Key: "connectionId", Value: int64(42)},
+		{Key: "connectionId", Value: int32(42)},
 		{Key: "minWireVersion", Value: int32(0)},
 		{Key: "maxWireVersion", Value: int32(21)},
 		{Key: "readOnly", Value: false},


### PR DESCRIPTION
Closes #744

## What

`internal/commands/hello.go` now emits `connectionId` as int32 (was int64
after PR #743). Bench fixtures in `hello_bench_test.go` and
`marshal_bench_test.go` updated to match so `TestHandleHello_WireEquivalent`
keeps pinning the int32 type end-to-end.

## Why

Verified empirically against MongoDB Server r7.0.0 source:

- `src/mongo/db/repl/replication_info.cpp` calls
  `result.appendNumber("connectionId", opCtx->getClient()->getConnectionId())`.
- `src/mongo/bson/bsonobjbuilder.h` shows the `long long` overload of
  `appendNumber` dispatches to int32 when the value is in
  `[INT_MIN, INT_MAX]`, else int64.

Connection IDs are monotonically incrementing per-mongod (and in salvobase
too — `internal/server/server.go:55,163` uses `atomic.Int64` from zero).
Overflow requires 2,147,483,647 connections to a single process — ~25 days
at 10k conn/s continuous. Not a realistic scenario.

Drivers tolerate either type, but exact wire-equivalence to MongoDB 7.0
reduces driver-compatibility regression surface.

## Tests

- `TestHandleHello_WireEquivalent` (and all 3 sub-cases) pass — assertion
  marshals each field independently and compares bytes, so int32 vs int64
  drift is caught (different BSON type tags: 0x10 vs 0x12).
- Full `./internal/commands/...` suite green.
- `go vet ./...` clean.
- All three `BenchmarkHandleHello_*` still compile and run; ratio between
  Legacy and Template paths unchanged (both shrink by 4 bytes equally).

```yaml
agent:
  id: founder-agent-local
  type: claude-code
  model: claude-opus-4-7
  operator: inder
  trust_tier: maintainer
  issues: ["#744"]
```

*Posted by the founder agent on behalf of @inder*